### PR TITLE
refactor: correctness and parallel tweaks for qrspi skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,39 @@ Comprehensive security audit and vulnerability detection following OWASP Top 10:
 
 **Activates when:** Auditing security, checking for vulnerabilities, implementing authentication, adding API endpoints, handling user input, working with secrets or sensitive data, implementing payment features, or conducting pre-deployment security checks.
 
+### accelint-qrspi-propose
+
+QRSPI + OpenSpec planning workflow automation:
+
+- Question generation → Research → Design → Structure phases
+- Pauses for review after design before generating implementation tasks
+- Creates OpenSpec artifacts (proposal.md, design.md, tasks.md)
+- Stops at planning; implementation continues with `/opsx:apply`
+
+**Activates when:** Planning tickets, starting QRSPI workflow, creating spec-driven changes, "plan this with QRSPI", "use QRSPI to plan".
+
+### accelint-onboard-agent
+
+Interactive agent onboarding and AGENTS.md/CLAUDE.md generation:
+
+- Runs structured interview to capture agent behavior preferences
+- Generates project-specific AGENTS.md or CLAUDE.md
+- Covers agent identity, workflow, communication style
+- Defines the behavioral layer of agent instruction stack
+
+**Activates when:** Setting up agent rules, configuring Claude Code, writing AGENTS.md/CLAUDE.md, defining agent behavior, onboarding agents to project.
+
+### accelint-onboard-openspec
+
+Interactive OpenSpec onboarding and config.yaml generation:
+
+- Runs structured interview to capture project structure
+- Generates openspec/config.yaml configured for QRSPI methodology
+- Documents what the project is (structure, components, architecture)
+- Works alongside accelint-onboard-agent for complete setup
+
+**Activates when:** Setting up OpenSpec, generating openspec config, configuring QRSPI, onboarding to OpenSpec.
+
 ### accelint-skill-manager
 
 A meta-skill for creating and managing other skills:
@@ -227,17 +260,6 @@ A meta-skill for creating and managing other skills:
 - SKILL.md and AGENTS.md formatting
 
 **Activates when:** Creating new skills or updating existing ones.
-
-### accelint-command-creator
-
-Guide for creating Claude Code commands:
-
-- Command specification format (YAML front matter + Markdown)
-- Skill discovery and integration
-- Argument definition patterns
-- Workflow and statistics reporting
-
-**Activates when:** Creating new Claude Code commands.
 
 ### accelint-readme-writer
 
@@ -262,14 +284,6 @@ Converts acceptance criteria into JSON test plans and then Playwright `*.spec.ts
 - Test hook naming/structure conventions
 
 **Activates when:** Turning acceptance criteria into Playwright `*.spec.ts` tests.
-
-### Feature Planning Commands
-
-| Command | Description |
-|---------|-------------|
-| `/feature-planning:acceptance` | Define acceptance criteria for a feature. |
-| `/feature-planning:implementation` | Research codebase patterns and create implementation tasks. |
-| `/feature-planning:testing` | Generate test plans based on implementation. |
 
 ## Ecosystem
 

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -509,6 +509,7 @@ context: |
   - Type safety:    Avoid `any` (use `unknown` or generics); avoid `enum` (use `as const` objects); use `type` over `interface`
   - Immutability:   Prefer `const`, immutable data structures, pure functions
   - Documentation:  Comprehensive JSDoc for all exported code (@param, @returns, @template, @example)
+  - Order:          Internal functions, variables and types should be defined before they are used (internal/export types -> internal/export constants -> internal/export functions)
 
   ## Architecture Patterns
   - [pattern name]: [brief description of how it's used here]

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## [1.1.0] - 2026-05-01
+
+### Fixed
+- **CRITICAL: Change name tracking across phases** — sub-agents now explicitly pass change name to all `/opsx:continue` calls
+  - Issue: When multiple specs exist in openspec/ folder, `/opsx:continue` without a change name parameter would incorrectly target the wrong spec
+  - Fix: Phase 3 now instructs sub-agent to capture and report the change name after `/opsx:new`; Phase 5 sub-agent receives this name and uses `/opsx:continue <change-name>` for all artifact generation
+  - Impact: Prevents cross-contamination when working on multiple specs; ensures all artifacts are generated for the correct change
+  - Completion message now includes the change name for user reference when running `/opsx:apply <change-name>`
+
+### Fixed
+- **CRITICAL: Phase 3 flow control** — explicitly prevent generating specs/tasks during design phase
+  - Issue: Sub-agent was instructed to run `/opsx:continue` multiple times in sequence, generating proposal.md, design.md, specs/*, and tasks.md all at once
+  - Fix: Added explicit STOP instruction after design.md generation; specs and tasks now generated only in Phase 5 after human design review
+  - Rationale: Design checkpoint is the "brain surgery" moment — must review design before generating implementation artifacts
+
+- **Vertical slicing guidance clarity** — strengthened instructions with concrete examples and explicit anti-patterns
+  - Issue: Generated tasks.md still used horizontal (layer-by-layer) slicing despite guidance
+  - Fix: Added side-by-side ✓/✗ examples, explicit "Deliverable:" requirement, and detailed indicators for detecting horizontal vs vertical structure
+  - Reference: Real vertical example at `/Users/bryankizer/Documents/auditkit-cli/openspec/changes/remove-security-ruleset/tasks.md`
+  - Improvement: Each slice now explicitly requires a testable end-to-end deliverable with verification steps
+
+### Changed
+- **Workflow overview diagram** — clarified that design phase outputs proposal.md + design.md only, with explicit [STOP HERE] marker
+  - Rationale: Visual reinforcement of the two-phase artifact generation (design artifacts → review → task artifacts)
+
+### Added
+- **Parallelization Strategy section** — tasks.md now includes explicit section mapping dependencies and parallel opportunities
+  - Content: Which slices must complete first, which can run in parallel, why they're independent, final integration steps
+  - Rationale: Makes execution strategy explicit for developers/agents implementing the change
+
+### Changed
+- **Removed manual checkpoint for vertical slice conversion** — skill now ALWAYS automatically converts horizontal slicing to vertical slicing
+  - Rationale: Vertical slicing is always the correct approach per QRSPI methodology; asking users to choose adds friction without value
+  - Improvement: User experience is now smoother — one less decision point in the workflow
+
+- **Added parallelization consideration to vertical slicing logic** — slices structured to be independent enough for concurrent implementation
+  - Rationale: Properly structured vertical slices can be implemented by parallel agents/sub-agents, improving development velocity
+  - Improvement: Tasks are now explicitly designed with parallelization in mind
+
+### Version
+- Bumped from 1.0.0 → 1.1.0

--- a/skills/accelint-qrspi-propose/README.md
+++ b/skills/accelint-qrspi-propose/README.md
@@ -1,4 +1,4 @@
-# Accelint QRSPI
+# Accelint QRSPI Propose
 
 Automate the planning phase of spec-driven development. This skill walks you through Questions → Research → Design → Structure (QRSPI), with mandatory review checkpoints before code gets written.
 
@@ -154,7 +154,7 @@ Run `/clear` and `/opsx:apply` when you're ready to start building.
 ## Example Usage
 
 ```
-/accelint-qrspi
+/accelint-qrspi-propose
 
 ## Issue #42: Expand array chaining detection
 

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: accelint-qrspi
+name: accelint-qrspi-propose
 description: Automate the QRSPI + OpenSpec planning workflow (Questions → Research → Design → Structure) for spec-driven development. Use this skill when the user wants to plan a ticket, start a QRSPI workflow, create a change with QRSPI, or says "plan this with QRSPI", "use QRSPI to plan", "start QRSPI workflow", "create spec-driven change", or asks about planning a feature/change before implementation. This skill handles ONLY the planning phase — it does NOT implement code. After completion, the user continues with /opsx:apply for implementation.
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Accelint QRSPI
@@ -47,12 +47,18 @@ openspec update
 ├─────────────────────────────────────────────────────────────────┤
 │  Questions      Ticket only          Questions       —          │
 │  Research       Questions only       Research doc    —          │
-│  Design         Q+R (NO ticket)      design.md       ✓ REVIEW   │
-│  Specs/Tasks    Q+R+design           specs/*, tasks  ✓ REVIEW   │
+│  Design         Q+R (NO ticket)      proposal.md     —          │
+│                                      design.md       ✓ REVIEW   │
+│                                      [STOP HERE]                │
+│  Specs/Tasks    Q+R+design           specs/*         —          │
+│                                      tasks.md        ✓ REVIEW   │
 │  Done           —                    Exit            —          │
 └─────────────────────────────────────────────────────────────────┘
 
 Note: Ticket is kept OUT of context after Phase 1 to prevent completion bleed.
+
+Critical: Phase 3 generates ONLY proposal.md and design.md, then STOPS for review.
+Phase 5 generates specs/* and tasks.md separately after design approval.
 ```
 
 ## Phase Breakdown
@@ -71,16 +77,16 @@ Before starting, verify OpenSpec has the required workflows enabled.
 4. If any are missing:
    ```
    This skill requires the expanded OpenSpec workflows (explore, new, continue).
-   
+
    Your current workflows: [list what's enabled]
    Missing: [list what's missing]
-   
+
    To enable the expanded workflows, run:
-   
+
    openspec config profile
    # Select "expanded" from the list
    openspec update
-   
+
    Then re-run this skill.
    ```
 5. Exit the skill if required workflows are not enabled
@@ -166,11 +172,13 @@ Before starting, verify OpenSpec has the required workflows enabled.
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   Now create the OpenSpec change and design artifact:
+   Now create the OpenSpec change with proposal and design artifacts:
 
    1. Run /opsx:new to create the change (OpenSpec will prompt for a slug)
-   2. Run /opsx:continue to generate proposal.md
-   3. Run /opsx:continue to generate design.md
+   2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
+   3. Run /opsx:continue <change-name> ONCE to generate proposal.md ONLY
+   4. Run /opsx:continue <change-name> ONCE to generate design.md ONLY
+   5. STOP after design.md - do NOT generate specs or tasks yet
 
    When creating design.md, follow the design rules from config.yaml but use your
    judgment about structure and emphasis based on the specifics of this change.
@@ -185,12 +193,20 @@ Before starting, verify OpenSpec has the required workflows enabled.
    - Use numbered "Decision N" format with: Choice, Rationale, Alternatives, Trade-off
    - Avoid detailed implementation plans, test strategies, or migration steps
 
-   After design.md is generated, report completion and the path to the design file.
+   After design.md is generated (and ONLY proposal.md and design.md exist),
+   report completion, the CHANGE NAME, and the path to the design file. 
+   
+   IMPORTANT: You MUST report the change name explicitly at the end like:
+   "Change name: <slug>"
+   
+   Do NOT continue to generate specs or tasks - that happens in Phase 5 after human review.
    ```
 
 4. Wait for the sub-agent to complete
-5. Verify the design.md file exists at the reported path
-6. Proceed to Phase 4 (mandatory checkpoint)
+5. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
+6. Store the change name — it will be passed to Phase 5
+7. Verify the design.md file exists at the reported path
+8. Proceed to Phase 4 (mandatory checkpoint)
 
 **Output**: Generated `proposal.md` and `design.md` in `openspec/changes/<slug>/`
 
@@ -251,6 +267,8 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    approved design. You have access to research and design, but NOT the original
    ticket text.
 
+   CHANGE NAME: <change-name-from-phase-3>
+
    Research Questions and Answers:
    [paste questions from Phase 1]
 
@@ -271,36 +289,25 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
 
    Now generate the remaining OpenSpec artifacts:
 
-   1. Run /opsx:continue to generate specs/* (delta specs)
-   2. Run /opsx:continue to generate tasks.md
+   1. Run /opsx:continue <change-name> to generate specs/* (delta specs)
+   2. Run /opsx:continue <change-name> to generate tasks.md
 
    Follow the tasks rules from config.yaml, emphasizing vertical slicing:
-   
+
    VERTICAL SLICING (core QRSPI principle):
-   - Order as vertical slices - each task delivers a testable end-to-end path
-   - Avoid grouping by architectural layer (database/service/API/frontend)
-   - Each task should include an explicit "Test:" line describing verification
-   - Prefer 3-5 major slices; more than 5 suggests scope is too large
-   - Max 2 hours per task; break larger work into subtasks
-   
-   Use judgment about structure - the config.yaml provides guidelines.
 
-   After tasks.md is generated, report completion and the path to the tasks file.
+   Each slice must deliver an end-to-end testable feature path, NOT a horizontal
+   layer. Structure the work so that after completing Slice 1, you have something
+   demonstrable and testable.
+
+   ✓ CORRECT - Vertical (end-to-end feature slices):
+   ```
+   Slice 1: Mock API + working frontend (user can see and click, no real data)
+   Slice 2: Wire real service layer (now pulls actual data)
+   Slice 3: Add database integration (data persists)
    ```
 
-5. Wait for the sub-agent to complete
-6. Verify specs/* and tasks.md exist at the reported paths
-5. Read the generated `tasks.md` file
-6. Analyze the phase structure — check for vertical vs horizontal slicing:
-
-   **Vertical (good)**:
-   ```
-   Phase 1: Mock API + working frontend (end-to-end, no real data)
-   Phase 2: Wire real service layer
-   Phase 3: Add database integration
-   ```
-
-   **Horizontal (problematic)**:
+   ✗ WRONG - Horizontal (architectural layers):
    ```
    Phase 1: All database migrations
    Phase 2: All service layer changes
@@ -308,18 +315,63 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    Phase 4: All frontend components
    ```
 
-7. Present tasks.md to the user:
+   Requirements for each slice:
+   - Deliverable: A working, testable increment (e.g., "CLI with security removed from public API")
+   - Test: Explicit verification steps showing the slice works end-to-end
+   - Parallelization: Slices should be independent enough to implement concurrently with minimal blocking
+   - Checkpoints: Each subtask has a "Test:" line describing verification
+   - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
+   - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
+
+   After all slices, include a "## Parallelization Strategy" section that:
+   - Identifies which slices must complete first (dependencies)
+   - States which slices can run in parallel
+   - Explains why parallel slices are independent
+   - Describes final integration steps
+
+   Use judgment about structure - the config.yaml provides guidelines.
+
+   After tasks.md is generated, report completion and the path to the tasks file.
+   ```
+
+5. Wait for the sub-agent to complete
+6. Verify specs/* and tasks.md exist at the reported paths
+7. Read the generated `tasks.md` file
+8. Analyze the slice structure for vertical vs horizontal organization:
+
+   **Indicators of VERTICAL slicing (correct)**:
+   - Each slice has a "Deliverable:" that describes a working, testable feature
+   - Slices cross architectural boundaries (e.g., a slice touches both CLI and implementation)
+   - Each slice ends with something demonstrable to a user or stakeholder
+   - Parallelization is possible with minimal dependencies between slices
+
+   **Indicators of HORIZONTAL slicing (incorrect)**:
+   - Slices are organized by layer: "Database changes", "Service layer", "API routes", "Frontend"
+   - Deliverables are architectural components, not user-facing features
+   - Early slices cannot be tested end-to-end without later slices
+   - Slices have sequential dependencies (must finish layer 1 before layer 2)
+
+9. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
+
+   - Identify the smallest testable feature path that crosses all layers
+   - Restructure tasks so each slice delivers that end-to-end path
+   - Each slice should have a clear "Deliverable:" describing what works after completion
+   - Ensure each subtask has explicit "Test:" verification steps
+   - Structure for parallelization where possible (independent slices)
+   - Write the converted structure directly to `tasks.md`
+   - Show a diff of the changes to the user with explanation of what was restructured
+
+10. Present tasks.md to the user for final approval:
 
    ```
-   Specs and tasks generated. Phase structure: [vertical/horizontal/mixed]
+   Specs and tasks generated.
 
-   [If horizontal detected:]
-   ⚠️  I detected horizontal slicing (grouped by layer). The QRSPI methodology
-   recommends vertical slices where each phase delivers a testable end-to-end
-   feature increment. Would you like me to restructure this, or proceed as-is?
+   [If auto-converted:]
+   ✓ Converted task structure to vertical slices for better parallelization
+   and incremental delivery. Each phase now delivers an end-to-end testable feature.
 
-   [If vertical:]
-   Task phases follow vertical slicing ✓
+   [If already vertical:]
+   ✓ Task structure follows vertical slicing
 
    Options:
    (a) Approve — planning complete, ready for implementation
@@ -327,7 +379,7 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    (c) Manual edit — edit tasks.md yourself, then confirm
    ```
 
-8. Handle user input (same flow as Phase 4: approve, request edits, or manual edit)
+11. Handle user input (same flow as Phase 4: approve, request edits, or manual edit)
 
 **Output**: Generated `specs/*` and `tasks.md` in `openspec/changes/<slug>/`
 
@@ -340,6 +392,8 @@ After tasks.md is approved:
    ```
    ✅ QRSPI planning phase complete.
 
+   Change name: <change-name-from-phase-3>
+
    Generated artifacts:
    - openspec/changes/<change-slug>/proposal.md
    - openspec/changes/<change-slug>/design.md
@@ -349,7 +403,7 @@ After tasks.md is approved:
    Next steps:
    1. Review the artifacts one more time if needed
    2. Run `/clear` to start fresh context for implementation
-   3. Run `/opsx:apply` to begin implementation
+   3. Run `/opsx:apply <change-name>` to begin implementation
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.


### PR DESCRIPTION
- Rename skill slightly to clarify intent and to open for future additions.
- Change the task list step to always convert to vertical (end-to-end changes) slices for the task list. Also considering parallelization needs when doing so. (Future skill reasons).
- Clarify some step wording
- Clean up README