### PR TITLE
feat: qrspi apply

### DIFF
--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## [1.0.0] - 2026-05-04
+
+### Added
+- Initial release of accelint-qrspi-apply skill
+- Automated parallelization detection from QRSPI-generated tasks.md "Parallelization Strategy" section
+- Dependency graph parsing to identify sequential vs parallel execution opportunities
+- Sub-agent orchestration for parallel slice execution using OpenSpec CLI (`/opsx:apply`)
+- Intelligent merge conflict detection when parallel slices modify overlapping files
+- Verification phase using `/opsx:verify` before declaring changes ready to archive
+- Human-in-the-loop checkpoints for validation failures, merge conflicts, and errors
+- Safe fallback to sequential execution when no parallelization strategy is present
+- Progress reporting showing slice-by-slice completion
+- Context management: pause points between dependency levels with clear/resume support
+- Resumption detection: automatically detects partial completion from task checkboxes and resumes from correct level
+- Final report with git status, validation results, and next steps
+- Scoped specifically to QRSPI-planned changes (requires `accelint-qrspi` skill output)
+
+### Design Decisions
+- **Why use OpenSpec CLI for each slice**: Sub-agents invoke `/opsx:apply` to preserve OpenSpec's context loading, state management, and progress tracking. Slice isolation is achieved through instructions rather than bypassing the CLI.
+- **Why QRSPI-only scope**: Standard OpenSpec changes don't include parallelization strategies. QRSPI's vertical slicing methodology is what makes parallel implementation safe and effective.
+- **Why sub-agents for parallelization**: Each QRSPI slice is a vertical feature increment that can be implemented independently. Sub-agents provide true parallelism and isolated contexts, preventing slices from interfering with each other.
+- **Why verification before archive**: Catches incomplete tasks, unimplemented requirements, and design divergences before archiving. OpenSpec's `/opsx:verify` command provides comprehensive verification across completeness, correctness, and coherence dimensions.
+- **Why safe defaults**: If no parallelization strategy is found, run tasks sequentially. This ensures correctness for changes that weren't planned with parallelization in mind.
+- **Why human-in-the-loop for conflicts**: Merge conflicts from parallel execution require domain knowledge to resolve correctly. The skill detects them and asks for guidance rather than attempting automatic resolution.
+- **Why pause points between levels**: Sub-agent results can accumulate significant context. Offering pause/clear/resume between dependency levels preserves the serial `opsx:apply` workflow flexibility while benefiting from parallelization within each level. Progress is tracked via task checkboxes, making it durable across context clears.
+
+### Known Limitations
+- Requires sub-agent support (not available in all environments like Claude.ai)
+- Assumes OpenSpec tasks.md follows the "Parallelization Strategy" section format
+- Does not support native OpenSpec slice targeting (works around with sub-agent instructions)
+- Merge conflicts from parallel execution require manual resolution
+
+### Version
+- Initial version: 1.0.0

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -7,15 +7,18 @@
 - Automated parallelization detection from QRSPI-generated tasks.md "Parallelization Strategy" section
 - Dependency graph parsing to identify sequential vs parallel execution opportunities
 - Sub-agent orchestration for parallel slice execution using OpenSpec CLI (`/opsx:apply`)
-- Intelligent merge conflict detection when parallel slices modify overlapping files
 - Verification phase using `/opsx:verify` before declaring changes ready to archive
-- Human-in-the-loop checkpoints for validation failures, merge conflicts, and errors
+- Human-in-the-loop checkpoints for validation failures and errors
 - Safe fallback to sequential execution when no parallelization strategy is present
 - Progress reporting showing slice-by-slice completion
 - Context management: pause points between dependency levels with clear/resume support
 - Resumption detection: automatically detects partial completion from task checkboxes and resumes from correct level
 - Final report with git status, validation results, and next steps
 - Scoped specifically to QRSPI-planned changes (requires `accelint-qrspi` skill output)
+- **Task format validation**: Mandatory checklist format (`- [ ] task`) validation in Phase 1 — exits early with error if tasks use numbered lists or plain bullets (required for progress tracking)
+- **Sub-agent delegation enforcement**: CRITICAL notes in sub-agent prompts requiring use of /opsx:apply command (prevents bypassing OpenSpec's context/state management)
+- **Verification enforcement**: CRITICAL note at Phase 3 emphasizing verification is mandatory before archive (catches incomplete/incorrect implementations)
+- **NEVER Do This section**: Anti-pattern list covering common failure modes (direct implementation, skipping verification, invalid formats, skipping dependencies)
 
 ### Design Decisions
 - **Why use OpenSpec CLI for each slice**: Sub-agents invoke `/opsx:apply` to preserve OpenSpec's context loading, state management, and progress tracking. Slice isolation is achieved through instructions rather than bypassing the CLI.
@@ -23,14 +26,13 @@
 - **Why sub-agents for parallelization**: Each QRSPI slice is a vertical feature increment that can be implemented independently. Sub-agents provide true parallelism and isolated contexts, preventing slices from interfering with each other.
 - **Why verification before archive**: Catches incomplete tasks, unimplemented requirements, and design divergences before archiving. OpenSpec's `/opsx:verify` command provides comprehensive verification across completeness, correctness, and coherence dimensions.
 - **Why safe defaults**: If no parallelization strategy is found, run tasks sequentially. This ensures correctness for changes that weren't planned with parallelization in mind.
-- **Why human-in-the-loop for conflicts**: Merge conflicts from parallel execution require domain knowledge to resolve correctly. The skill detects them and asks for guidance rather than attempting automatic resolution.
 - **Why pause points between levels**: Sub-agent results can accumulate significant context. Offering pause/clear/resume between dependency levels preserves the serial `opsx:apply` workflow flexibility while benefiting from parallelization within each level. Progress is tracked via task checkboxes, making it durable across context clears.
 
 ### Known Limitations
 - Requires sub-agent support (not available in all environments like Claude.ai)
 - Assumes OpenSpec tasks.md follows the "Parallelization Strategy" section format
 - Does not support native OpenSpec slice targeting (works around with sub-agent instructions)
-- Merge conflicts from parallel execution require manual resolution
+- Relies on proper vertical slicing to avoid file conflicts between parallel slices
 
 ### Version
 - Initial version: 1.0.0

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -70,14 +70,31 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 **Steps**:
 
 1. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
-2. **Check for partial completion** (resumption detection):
+
+2. **Validate checklist format** (CRITICAL for progress tracking):
+   - Check that tasks use markdown checklist format: `- [ ] task` or `- [x] task`
+   - If tasks use numbered lists (1. 2. 3.) or plain bullets (- without [ ]):
+     ```
+     ❌ Invalid tasks.md format
+     
+     This skill requires tasks in markdown checklist format (`- [ ] task`) for
+     progress tracking and resumption detection.
+     
+     Found format: [numbered lists / plain bullets / other]
+     
+     Please regenerate tasks.md using the accelint-qrspi-propose skill or convert
+     manually to checklist format before applying.
+     ```
+   - Exit if format is invalid — do not proceed with invalid task format
+
+3. **Check for partial completion** (resumption detection):
    - Count completed tasks (marked `- [x]`) vs total tasks
    - Parse which slices have all their tasks marked complete
    - If any slices are complete, announce: "Detected partial completion. Resuming from Slice N."
    - Adjust the execution plan to skip completed slices
 
-3. Look for the "Parallelization Strategy" section (usually at the end of the file)
-4. Parse the strategy to build a dependency graph:
+4. Look for the "Parallelization Strategy" section (usually at the end of the file)
+5. Parse the strategy to build a dependency graph:
 
    **Example strategy:**
    ```md
@@ -102,11 +119,11 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
      - Final integration
    ```
 
-4. If no "Parallelization Strategy" section exists:
+6. If no "Parallelization Strategy" section exists:
    - Assume all tasks must run sequentially (safe default)
    - Inform user: "No parallelization strategy found. Running tasks sequentially."
 
-5. Build an execution plan showing:
+7. Build an execution plan showing:
    - Which slices run in which order
    - Which slices can run in parallel (and which are already complete)
    - Total estimated parallelization speedup
@@ -126,6 +143,10 @@ For each level in the dependency graph (starting from level 0):
    - Spawn a single sub-agent with this prompt:
      ```
      /opsx:apply <change-name>
+
+     CRITICAL: You MUST use the /opsx:apply command to implement tasks.
+     DO NOT implement tasks directly yourself. The /opsx:apply workflow will
+     load context and guide implementation.
 
      IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
      
@@ -155,6 +176,10 @@ For each level with multiple independent slices:
    ```
    /opsx:apply <change-name>
 
+   CRITICAL: You MUST use the /opsx:apply command to implement tasks.
+   DO NOT implement tasks directly yourself. The /opsx:apply workflow will
+   load context and guide implementation.
+
    IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
    
    Context: This slice is independent and runs in parallel with Slices X, Y.
@@ -169,7 +194,6 @@ For each level with multiple independent slices:
        * Mark tasks complete as you go: `- [ ]` → `- [x]`
        * Test your changes if tests are specified in the tasks
    - Report completion with summary of changes made
-   - Expect potential merge conflicts when parallel work is integrated
 
    Focus exclusively on Slice N. Leave other slice tasks unchecked.
    Your work is independent and should not block or depend on other slices.
@@ -204,19 +228,6 @@ For each level with multiple independent slices:
    Progress is tracked in tasks.md checkboxes.
    ```
 
-**Handling merge conflicts**:
-
-When parallel slices complete, check for merge conflicts:
-
-```bash
-git status
-```
-
-If conflicts exist:
-- Report to user: "Parallel slices caused merge conflicts in: [list files]"
-- Ask user to resolve conflicts manually or provide guidance
-- Wait for confirmation before proceeding
-
 **Slice targeting approach**: OpenSpec's `/opsx:apply` command does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
 
 1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `/opsx:apply <change-name>`, which:
@@ -242,6 +253,9 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 ### Phase 3: Verify Implementation
 
 **Goal**: Verify that the implementation matches the change artifacts (specs, tasks, design).
+
+CRITICAL: Verification is MANDATORY before declaring a change ready to archive.
+Do NOT skip this phase or mark the change as complete without running verification.
 
 **Steps**:
 
@@ -367,7 +381,6 @@ The skill always runs `openspec validate` before declaring the change "ready to 
 ### Human-in-the-Loop
 
 The skill reports results and asks for guidance when:
-- Merge conflicts occur from parallel execution
 - Validation fails
 - Tasks are unclear or blocked
 - Any error occurs during implementation
@@ -403,13 +416,23 @@ If the environment doesn't support sub-agents (e.g., Claude.ai):
 - Fall back to sequential execution (implement all tasks yourself)
 - Inform user: "Sub-agents not available. Running tasks sequentially."
 
+## NEVER Do This
+
+**NEVER implement tasks directly** — Always delegate to `/opsx:apply` command via sub-agents. The /opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
+
+**NEVER skip verification** — Phase 3 verification using `/opsx:verify` is mandatory before declaring a change ready to archive. Verification catches incomplete tasks, unimplemented requirements, and design divergences. Skipping verification risks archiving incomplete or incorrect implementations.
+
+**NEVER proceed with invalid task format** — This skill depends on markdown checklist format (`- [ ] task`) for progress tracking and resumption detection. If tasks.md uses numbered lists or plain bullets, exit early with an error. Do not attempt to work around the format issue — the user must fix tasks.md first.
+
+**NEVER skip dependency levels** — If Slice A blocks Slice B, Slice B cannot start until Slice A completes successfully. Do not spawn dependent slices before their blockers finish, even if it would speed up implementation. The dependency graph in the Parallelization Strategy must be respected.
+
 ## Configuration Requirements
 
 This skill assumes:
 1. OpenSpec is installed and initialized
 2. The change exists and has a tasks.md file
 3. Sub-agent support is available (for parallel execution)
-4. Git is initialized (for checking file changes and merge conflicts)
+4. Git is initialized (for checking file changes)
 
 If any are missing, report the issue and guide the user to set them up.
 

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -1,0 +1,509 @@
+---
+name: accelint-qrspi-apply
+description: Implement QRSPI-planned OpenSpec changes with intelligent parallelization. Use when the user wants to apply a QRSPI change, implement tasks with parallelization, or says "apply this QRSPI change", "implement with parallelization", "run the parallel slices". This skill is specifically designed for changes created via accelint-qrspi that include "Parallelization Strategy" sections in tasks.md. It orchestrates parallel sub-agent execution for independent task slices using OpenSpec CLI workflows. Make sure to use this skill when the user mentions applying QRSPI changes, running parallel implementation, or working on changes with vertical slices.
+license: Apache-2.0
+compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
+metadata:
+  author: accelint
+  version: "1.0.0"
+---
+
+# Accelint QRSPI Apply
+
+Implement OpenSpec changes with intelligent parallelization. This skill orchestrates parallel sub-agent execution based on dependency analysis in the OpenSpec task file, validates implementation, and manages the complete apply workflow.
+
+## What This Skill Does
+
+**Automates**: The implementation phase of spec-driven development with parallel execution
+**Scope**: Task implementation → Validation → Archive readiness
+**Output**: Fully implemented change ready for archival
+
+**Does NOT**: Create plans, modify specs, or automatically archive (suggests archival when ready)
+
+## Prerequisites
+
+- OpenSpec CLI installed and initialized
+- OpenSpec change created via `accelint-qrspi` skill (includes "Parallelization Strategy" in tasks.md)
+- Sub-agent support (for parallel execution)
+- The expanded OpenSpec workflows (`explore`, `new`, `continue`) enabled
+
+**Important**: This skill is specifically designed for QRSPI-planned changes. Standard OpenSpec changes without parallelization strategies should use the regular `/opsx:apply` command directly.
+
+## Workflow Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Phase          Action                        Output            │
+├─────────────────────────────────────────────────────────────────┤
+│  Parse          Extract parallelization       Dependency graph  │
+│  Dependencies   Identify blocking tasks       Execution plan    │
+│  Execute        Run slices (parallel/serial)  Implemented code  │
+│  Verify         Run opsx:verify               Verification rpt  │
+│  Report         Show results + next steps     Archive or fix    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Phase Breakdown
+
+### Phase 0: Preflight and Change Selection
+
+**Steps**:
+
+1. If a change name is provided in the skill arguments, use it
+2. Otherwise, try to infer from conversation context (recent mentions of change names)
+3. If ambiguous or missing:
+   ```bash
+   openspec list --json
+   ```
+   Parse the JSON and use **AskUserQuestion** to let the user select the change
+4. Announce: "Applying change: `<name>`" and how to override (e.g., re-invoke with different name)
+5. Check that tasks.md exists:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `/opsx:continue` to generate tasks before applying."
+
+### Phase 1: Parse Tasks and Parallelization Strategy
+
+**Goal**: Extract task structure and identify parallel vs sequential execution opportunities. Detect if work has already started and resume from the correct level.
+
+**Steps**:
+
+1. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
+2. **Check for partial completion** (resumption detection):
+   - Count completed tasks (marked `- [x]`) vs total tasks
+   - Parse which slices have all their tasks marked complete
+   - If any slices are complete, announce: "Detected partial completion. Resuming from Slice N."
+   - Adjust the execution plan to skip completed slices
+
+3. Look for the "Parallelization Strategy" section (usually at the end of the file)
+4. Parse the strategy to build a dependency graph:
+
+   **Example strategy:**
+   ```md
+   ## Parallelization Strategy
+
+   - **Slice 1** must complete first (establishes infrastructure)
+   - **Slice 2** and **Slice 3** can run in parallel after Slice 1
+   - **Slice 2** (implementation cleanup) is independent of **Slice 3** (docs/verification)
+   - Final integration: merge both slices, run full pre-commit checklist
+   ```
+
+   **Parsed dependency graph:**
+   ```
+   Level 0 (must run first):
+     - Slice 1
+
+   Level 1 (can run in parallel after Level 0):
+     - Slice 2
+     - Slice 3
+
+   Level 2 (after all previous):
+     - Final integration
+   ```
+
+4. If no "Parallelization Strategy" section exists:
+   - Assume all tasks must run sequentially (safe default)
+   - Inform user: "No parallelization strategy found. Running tasks sequentially."
+
+5. Build an execution plan showing:
+   - Which slices run in which order
+   - Which slices can run in parallel (and which are already complete)
+   - Total estimated parallelization speedup
+   - Starting point (Level 0 or resuming from Level N)
+
+**Output**: Dependency graph, execution plan, and resumption point if applicable
+
+### Phase 2: Execute Tasks (Sequential + Parallel)
+
+**Goal**: Implement tasks following the dependency graph, spawning parallel sub-agents where possible.
+
+**Sequential execution** (when tasks have dependencies):
+
+For each level in the dependency graph (starting from level 0):
+
+1. If the level has only one slice:
+   - Spawn a single sub-agent with this prompt:
+     ```
+     /opsx:apply <change-name>
+
+     IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
+     
+     Context: This slice must complete before other slices can proceed.
+     Other slices will start after you finish.
+
+     Instructions:
+     - Work ONLY on tasks in Slice N: [list slice N tasks/sections]
+     - Do NOT implement tasks from other slices (Slices X, Y, Z will be handled separately)
+     - Follow the normal OpenSpec apply workflow:
+       * OpenSpec will load context files (proposal, design, specs, tasks)
+       * Implement the tasks assigned to Slice N
+       * Mark tasks complete as you go: `- [ ]` → `- [x]`
+       * Test your changes if tests are specified in the tasks
+     - Report completion with summary of changes made
+
+     Focus exclusively on Slice N. Leave other slice tasks unchecked.
+     ```
+
+2. Wait for completion before proceeding to the next level
+
+**Parallel execution** (when multiple slices are independent):
+
+For each level with multiple independent slices:
+
+1. Spawn all sub-agents in parallel in a single turn (one per slice):
+   ```
+   /opsx:apply <change-name>
+
+   IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
+   
+   Context: This slice is independent and runs in parallel with Slices X, Y.
+   Other agents are working on those slices simultaneously.
+
+   Instructions:
+   - Work ONLY on tasks in Slice N: [list slice N tasks/sections]
+   - Do NOT implement tasks from other slices - they are being handled in parallel
+   - Follow the normal OpenSpec apply workflow:
+       * OpenSpec will load context files (proposal, design, specs, tasks)
+       * Implement the tasks assigned to Slice N
+       * Mark tasks complete as you go: `- [ ]` → `- [x]`
+       * Test your changes if tests are specified in the tasks
+   - Report completion with summary of changes made
+   - Expect potential merge conflicts when parallel work is integrated
+
+   Focus exclusively on Slice N. Leave other slice tasks unchecked.
+   Your work is independent and should not block or depend on other slices.
+   ```
+
+2. Track completion as each sub-agent finishes
+3. When all slices in the level are done, **pause and offer context management**:
+   ```
+   ✅ Level N complete
+   
+   Completed slices:
+   - Slice X: [summary]
+   - Slice Y: [summary]
+   
+   Next: Level N+1 has M slice(s) to run [list slices]
+   
+   Options:
+   (a) Continue to next level
+   (b) Clear context and resume — I'll pick up from Level N+1
+   (c) Pause here — you can resume later with this skill
+   ```
+
+4. If user chooses (b), instruct them:
+   ```
+   Run `/clear` to reset context, then re-invoke this skill.
+   I'll detect that Level N is complete and resume from Level N+1.
+   ```
+
+5. If user chooses (c), exit and remind them how to resume:
+   ```
+   Paused at Level N+1. To resume, re-invoke this skill.
+   Progress is tracked in tasks.md checkboxes.
+   ```
+
+**Handling merge conflicts**:
+
+When parallel slices complete, check for merge conflicts:
+
+```bash
+git status
+```
+
+If conflicts exist:
+- Report to user: "Parallel slices caused merge conflicts in: [list files]"
+- Ask user to resolve conflicts manually or provide guidance
+- Wait for confirmation before proceeding
+
+**Slice targeting approach**: OpenSpec's `/opsx:apply` command does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
+
+1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `/opsx:apply <change-name>`, which:
+   - Runs `openspec instructions apply --change "<name>" --json` to get context
+   - Loads all context files (proposal, design, specs, tasks)
+   - Provides dynamic instructions based on current state
+   - Handles task progress tracking and status checks
+
+2. **Slice isolation via instructions**: The orchestrating skill:
+   - Parses the parallelization strategy to identify independent slices
+   - Spawns sub-agents with explicit instructions to work ONLY on their assigned slice
+   - Relies on QRSPI's vertical slicing to ensure slices are truly independent
+   - Each sub-agent marks only its slice's tasks as complete
+
+3. **Why this works**: QRSPI's vertical slicing methodology ensures each slice is:
+   - A complete end-to-end feature increment
+   - Independent with minimal file overlap
+   - Testable in isolation
+   - Safe to implement in parallel
+
+The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove CLI Surface", "## Slice 2: Remove Implementation"), making it straightforward for sub-agents to identify their scope.
+
+### Phase 3: Verify Implementation
+
+**Goal**: Verify that the implementation matches the change artifacts (specs, tasks, design).
+
+**Steps**:
+
+1. Call the verify command:
+   ```
+   /opsx:verify <change-name>
+   ```
+
+2. The verify command will:
+   - Check task completion (all checkboxes marked)
+   - Verify spec coverage (requirements implemented)
+   - Validate design adherence (decisions followed)
+   - Generate a verification report with CRITICAL/WARNING/SUGGESTION issues
+
+3. Present the verification report to the user as-is
+
+4. If CRITICAL issues exist:
+   ```
+   ⚠️ Critical issues found. Cannot archive until resolved.
+   
+   [verification report from opsx:verify]
+   
+   Options:
+   1. Fix issues manually and re-verify
+   2. I can attempt to fix issues automatically
+   ```
+
+5. If only warnings/suggestions:
+   ```
+   ✅ No critical issues found
+   
+   [verification report from opsx:verify]
+   
+   Ready to archive! (Note warnings above for future consideration)
+   ```
+
+**Output**: Verification report from `opsx:verify`
+
+### Phase 4: Report and Next Steps
+
+**Goal**: Summarize the implementation session and guide user on next steps.
+
+**Steps**:
+
+1. Read the final tasks.md to count completed vs total tasks
+2. Run `git status` to show changed files
+3. Present completion report:
+
+   **If verification passed (no CRITICAL issues):**
+   ```
+   ✅ Implementation complete
+
+   **Change:** <change-name>
+   **Tasks:** N/N complete
+   **Verification:** ✅ Passed (see report above for any warnings/suggestions)
+   **Files changed:** M
+
+   ### Summary
+   - Slice 1: [brief description of changes]
+   - Slice 2: [brief description of changes]
+   - Slice 3: [brief description of changes]
+
+   ### Changed files
+   [output from git status --short]
+
+   ### Next steps
+   1. Review the changes: `git diff`
+   2. Run tests: [project-specific test command]
+   3. Archive this change: `/opsx:archive <change-name>`
+
+   Ready to archive!
+   ```
+
+   **If verification failed (CRITICAL issues):**
+   ```
+   ⚠️ Implementation complete with critical issues
+
+   **Change:** <change-name>
+   **Tasks:** N/N complete
+   **Verification:** ❌ Failed (see report above)
+   **Files changed:** M
+
+   ### Critical Issues
+   [CRITICAL issues from verification report]
+
+   ### Next steps
+   1. Fix critical issues
+   2. Re-run verification: `/opsx:verify <change-name>`
+   3. Or re-invoke this skill to retry
+
+   Not ready to archive until critical issues are resolved.
+   ```
+
+4. Exit the skill — do NOT automatically archive
+
+**Output**: Completion report with status and next steps
+
+## Key Principles
+
+### Context Management and Resumption
+
+The skill supports pause/clear/resume workflow at dependency level boundaries:
+
+- **Pause points**: After each level completes, the skill offers to continue or let the user clear context
+- **Resumption detection**: When re-invoked, the skill reads tasks.md checkboxes to detect completed slices and resumes from the next incomplete level
+- **Progress tracking**: Task completion is tracked in tasks.md via checkboxes, making progress durable across context clears
+- **Rationale**: Sub-agents can accumulate significant context. Between dependency levels, the orchestrating agent can clear context while preserving work progress via task checkboxes.
+
+**Why this matters**: Long implementations with many slices can bloat context. By offering pause points between levels, users maintain the flexibility to clear context (like in serial `opsx:apply`) while still benefiting from parallelization within each level.
+
+### Intelligent Parallelization
+
+The skill automatically detects parallelization opportunities from the "Parallelization Strategy" section in tasks.md. When slices are independent, it spawns multiple sub-agents to work in parallel, significantly reducing implementation time.
+
+### Safe Defaults
+
+If no parallelization strategy is found, the skill runs tasks sequentially. This ensures correctness even for changes that weren't planned with parallelization in mind.
+
+### Validation Before Archive
+
+The skill always runs `openspec validate` before declaring the change "ready to archive". This catches incomplete tasks, broken references, or schema violations before the user archives.
+
+### Human-in-the-Loop
+
+The skill reports results and asks for guidance when:
+- Merge conflicts occur from parallel execution
+- Validation fails
+- Tasks are unclear or blocked
+- Any error occurs during implementation
+
+### Context Management
+
+Each sub-agent receives:
+- The full context files (proposal, design, specs, tasks)
+- Clear instructions to implement ONLY their assigned slice
+- Awareness that other slices may be running in parallel
+
+This prevents sub-agents from stepping on each other's work while allowing them to see the full picture.
+
+## Handling Edge Cases
+
+**Circular dependencies**:
+If the parallelization strategy contains circular dependencies (Slice A blocks B, B blocks A), detect this and report an error. Ask the user to fix the tasks.md file.
+
+**Missing slices**:
+If a slice is referenced in the parallelization strategy but doesn't exist in the task list, report an error and ask the user to fix tasks.md.
+
+**Partial completion**:
+If some tasks were already marked complete (from a previous session), resume from where it left off. Announce: "N/M tasks already complete. Resuming from Slice X."
+
+**Sub-agent failure**:
+If a sub-agent fails or times out:
+- Report which slice failed and why
+- Ask user if they want to retry that slice or handle it manually
+- Do not proceed to dependent slices until the blocking slice succeeds
+
+**No sub-agent support**:
+If the environment doesn't support sub-agents (e.g., Claude.ai):
+- Fall back to sequential execution (implement all tasks yourself)
+- Inform user: "Sub-agents not available. Running tasks sequentially."
+
+## Configuration Requirements
+
+This skill assumes:
+1. OpenSpec is installed and initialized
+2. The change exists and has a tasks.md file
+3. Sub-agent support is available (for parallel execution)
+4. Git is initialized (for checking file changes and merge conflicts)
+
+If any are missing, report the issue and guide the user to set them up.
+
+## Example Usage
+
+**Scenario 1: Change with parallelization strategy**
+
+```
+User: Apply the remove-security-ruleset change
+
+Skill: Applying change: remove-security-ruleset
+
+Parsing parallelization strategy...
+
+Execution plan:
+- Level 0 (sequential): Slice 1 (Remove CLI surface)
+- Level 1 (parallel): Slice 2 (Remove implementation), Slice 3 (Docs/verification)
+
+Starting Level 0: Slice 1
+[spawns sub-agent]
+✓ Slice 1 complete (4 tasks, ~8 minutes)
+
+Starting Level 1: Slices 2 and 3 in parallel
+[spawns 2 sub-agents simultaneously]
+✓ Slice 2 complete (4 tasks, ~6 minutes)
+✓ Slice 3 complete (4 tasks, ~7 minutes)
+
+Running validation...
+✅ Validation passed
+
+✅ Implementation complete
+
+**Change:** remove-security-ruleset
+**Tasks:** 12/12 complete
+**Validation:** ✅ Passed
+**Files changed:** 67
+
+Ready to archive! Run: `/opsx:archive remove-security-ruleset`
+```
+
+**Scenario 2: Validation failure**
+
+```
+User: Apply the auth-refactor change
+
+Skill: Applying change: auth-refactor
+
+[implementation proceeds...]
+
+Running validation...
+❌ Validation failed
+
+Errors:
+- Task 3.2 in tasks.md is incomplete (checkbox not marked)
+- Spec file specs/auth-service.md references non-existent file: src/old-auth.ts
+
+Options:
+1. Fix issues manually and re-validate
+2. I can attempt to fix issues automatically
+3. Skip validation and proceed (not recommended)
+
+User: Fix them automatically
+
+Skill: Attempting to fix validation errors...
+
+- Marking task 3.2 as complete in tasks.md
+- Updating spec reference from src/old-auth.ts → src/auth-service.ts
+
+Re-running validation...
+✅ Validation passed
+
+Ready to archive!
+```
+
+**Scenario 3: No parallelization (safe fallback)**
+
+```
+User: Apply the update-readme change
+
+Skill: Applying change: update-readme
+
+No parallelization strategy found. Running tasks sequentially.
+
+Working on task 1/3: Update installation section
+✓ Complete
+
+Working on task 2/3: Add examples section
+✓ Complete
+
+Working on task 3/3: Update changelog
+✓ Complete
+
+Running validation...
+✅ Validation passed
+
+All tasks complete. Ready to archive!
+```

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [1.2.0] - 2026-05-05
+
+### Fixed
+- **CRITICAL: Agents bypassing /opsx commands** — Added explicit CRITICAL/IMPORTANT notes to prevent agents from generating artifacts directly
+  - Issue: Sub-agents were sometimes writing tasks.md, proposal.md, or design.md content themselves instead of delegating to /opsx:continue commands
+  - Impact: When agents generate artifacts directly, they bypass OpenSpec's configured rules and create inconsistent outputs (e.g., tasks.md missing checklist format)
+  - Fix: Added CRITICAL blocks in Phase 3 and Phase 5 prompts stating "DO NOT generate content yourself. The /opsx:continue command handles artifact generation."
+  - Rationale: /opsx commands follow project-specific rules in config.yaml; direct generation ignores these rules
+
+- **CRITICAL: Markdown checklist format enforcement** — Added explicit validation for `- [ ] task` format in tasks.md
+  - Issue: When restructuring tasks.md from horizontal to vertical slicing, agents might lose the markdown checklist format and use numbered lists or plain bullets
+  - Impact: qrspi-apply skill depends on `- [ ] ...` format to track task completion; other formats break the workflow
+  - Fix: Added CRITICAL note in Step 10b requiring markdown checklist format preservation during restructuring
+  - Added anti-pattern: "NEVER use numbered lists or plain bullets in tasks.md"
+
+- **CRITICAL: Agents skipping mandatory checkpoints** — Strengthened enforcement of Phase 4 and Phase 5 checkpoints
+  - Issue: Agents were sometimes not pausing after design.md generation and proceeding directly to specs/tasks, bypassing the design review checkpoint
+  - Impact: Defeats the "brain surgery" moment where design corrections are cheap; skipping review means fixing issues after code is written (expensive)
+  - Fix: Added multiple CRITICAL blocks enforcing stops:
+    - Phase 3 sub-agent prompt: "STOP AFTER GENERATING DESIGN.MD. Your job ends here."
+    - Phase 3 Step 8: "DO NOT continue to Phase 5 yet. You MUST proceed to Phase 4 checkpoint."
+    - Phase 4 header: "You MUST pause here and wait for user input."
+    - Phase 4 end: "DO NOT PROCEED TO PHASE 5 WITHOUT EXPLICIT USER APPROVAL."
+    - Phase 5 Step 12: "DO NOT PROCEED TO PHASE 6 WITHOUT EXPLICIT USER APPROVAL."
+  - Updated workflow diagram with visual ⚠️ checkpoint markers
+  - Added anti-pattern: "NEVER skip the mandatory checkpoints"
+
+- **Parallelization Strategy overcomplicated** — Simplified guidance with concrete template and "DO NOT overcomplicate" warning
+  - Issue: Agents were sometimes generating overly detailed parallelization sections with excessive edge cases
+  - Fix: Added simple template format showing the right level of detail: dependencies, parallel opportunities, recommended order
+  - Added explicit checkpoint (Step 9) to verify Parallelization Strategy exists and follows the simple format
+  - Example template now matches the format from actual working changes
+
+### Added
+- **NEVER Do This section** — Added anti-pattern list reinforcing key principles
+  - NEVER generate artifacts yourself (always use /opsx commands)
+  - NEVER write tasks.md content directly (breaks checklist format)
+  - NEVER overcomplicate Parallelization Strategy (keep it simple)
+  - NEVER continue to specs/tasks without design approval (skips "brain surgery" checkpoint)
+  - NEVER let ticket leak into research/design context (causes solution-first thinking)
+  - Rationale: Explicit anti-patterns help agents avoid common failure modes
+
+### Changed
+- **Phase 5 vertical slicing guidance** — Moved detailed vertical slicing guidance from sub-agent prompt to validation step
+  - Issue: Long guidance in sub-agent prompt wasn't preventing agents from generating artifacts directly, and removing it entirely lost important context for validation
+  - Fix: Added brief CRITICAL notes in sub-agent prompt delegating to /opsx:continue; restored full vertical slicing guidance to Step 8 (validation phase)
+  - Rationale: Validation step needs detailed criteria to restructure horizontal slices; sub-agent prompt just needs to delegate to /opsx:continue
+  - Validation logic (Steps 8-10) now includes comprehensive examples and requirements for restructuring
+
+### Version
+- Bumped from 1.1.0 → 1.2.0
+
 ## [1.1.0] - 2026-05-01
 
 ### Fixed

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Automate the QRSPI + OpenSpec planning workflow (Questions → Rese
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Accelint QRSPI
@@ -48,10 +48,14 @@ openspec update
 │  Questions      Ticket only          Questions       —          │
 │  Research       Questions only       Research doc    —          │
 │  Design         Q+R (NO ticket)      proposal.md     —          │
-│                                      design.md       ✓ REVIEW   │
+│                                      design.md       —          │
 │                                      [STOP HERE]                │
+│  ⚠️  CHECKPOINT 1: Review design.md - MUST approve to continue  │
+│                                                                  │
 │  Specs/Tasks    Q+R+design           specs/*         —          │
-│                                      tasks.md        ✓ REVIEW   │
+│                                      tasks.md        —          │
+│  ⚠️  CHECKPOINT 2: Review tasks.md - MUST approve to continue   │
+│                                                                  │
 │  Done           —                    Exit            —          │
 └─────────────────────────────────────────────────────────────────┘
 
@@ -59,6 +63,9 @@ Note: Ticket is kept OUT of context after Phase 1 to prevent completion bleed.
 
 Critical: Phase 3 generates ONLY proposal.md and design.md, then STOPS for review.
 Phase 5 generates specs/* and tasks.md separately after design approval.
+
+⚠️  MANDATORY CHECKPOINTS: The agent MUST pause and wait for explicit user approval
+at both checkpoints. Proceeding without approval bypasses QRSPI's core value.
 ```
 
 ## Phase Breakdown
@@ -172,6 +179,10 @@ Before starting, verify OpenSpec has the required workflows enabled.
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
+   CRITICAL: You MUST use /opsx commands to create and generate artifacts.
+   DO NOT create files or write artifact content yourself. The /opsx commands
+   will handle artifact generation following OpenSpec's configured rules.
+
    Now create the OpenSpec change with proposal and design artifacts:
 
    1. Run /opsx:new to create the change (OpenSpec will prompt for a slug)
@@ -180,18 +191,9 @@ Before starting, verify OpenSpec has the required workflows enabled.
    4. Run /opsx:continue <change-name> ONCE to generate design.md ONLY
    5. STOP after design.md - do NOT generate specs or tasks yet
 
-   When creating design.md, follow the design rules from config.yaml but use your
-   judgment about structure and emphasis based on the specifics of this change.
-   The config.yaml provides guidelines - interpret them intelligently rather than
-   following them mechanically.
-
-   Key QRSPI principles for design.md:
-   - Target ~200 lines, focusing on decisions and trade-offs
-   - This is the "brain surgery" moment - decisions here are cheap to change,
-     decisions after code is written are expensive
-   - Emphasize WHY and WHAT (decisions, trade-offs) not HOW (implementation)
-   - Use numbered "Decision N" format with: Choice, Rationale, Alternatives, Trade-off
-   - Avoid detailed implementation plans, test strategies, or migration steps
+   IMPORTANT: Let /opsx:continue generate proposal.md and design.md using the
+   OpenSpec workflow. DO NOT write these files yourself. The /opsx:continue
+   command handles artifact generation based on config.yaml rules.
 
    After design.md is generated (and ONLY proposal.md and design.md exist),
    report completion, the CHANGE NAME, and the path to the design file. 
@@ -199,14 +201,17 @@ Before starting, verify OpenSpec has the required workflows enabled.
    IMPORTANT: You MUST report the change name explicitly at the end like:
    "Change name: <slug>"
    
-   Do NOT continue to generate specs or tasks - that happens in Phase 5 after human review.
+   CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
+   Your job ends here. The parent agent will handle the checkpoint and Phase 5.
+   If you generate specs/* or tasks.md, you will bypass the mandatory design review.
    ```
 
 4. Wait for the sub-agent to complete
 5. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
 6. Store the change name — it will be passed to Phase 5
 7. Verify the design.md file exists at the reported path
-8. Proceed to Phase 4 (mandatory checkpoint)
+8. CRITICAL: DO NOT continue to Phase 5 yet. You MUST proceed to Phase 4 checkpoint.
+9. Proceed to Phase 4 (mandatory checkpoint)
 
 **Output**: Generated `proposal.md` and `design.md` in `openspec/changes/<slug>/`
 
@@ -215,6 +220,10 @@ Before starting, verify OpenSpec has the required workflows enabled.
 **Goal**: Get human approval before proceeding to task breakdown.
 
 This is the "brain surgery" moment from the QRSPI talk — a correction here costs minutes; the same correction after implementation costs a code review cycle.
+
+CRITICAL: You MUST pause here and wait for user input. DO NOT proceed to Phase 5
+without explicit user approval. If you skip this checkpoint, you defeat the entire
+purpose of QRSPI's separation of design from implementation planning.
 
 **Steps**:
 
@@ -247,7 +256,11 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
      - Re-read design.md
      - Proceed to Phase 5
 
-**Do NOT proceed to Phase 5 without explicit user approval.**
+**CRITICAL: DO NOT PROCEED TO PHASE 5 WITHOUT EXPLICIT USER APPROVAL.**
+
+If the user does not explicitly approve (says "looks good", "approve", "continue", etc.),
+DO NOT move forward. This checkpoint is mandatory - skipping it bypasses the core value
+of QRSPI methodology.
 
 ### Phase 5: Specs & Tasks Generation
 
@@ -287,14 +300,30 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
+   CRITICAL: You MUST use /opsx:continue commands to generate artifacts.
+   DO NOT generate specs or tasks.md content yourself. The /opsx:continue command
+   will handle artifact generation following OpenSpec's configured rules.
+
    Now generate the remaining OpenSpec artifacts:
 
    1. Run /opsx:continue <change-name> to generate specs/* (delta specs)
    2. Run /opsx:continue <change-name> to generate tasks.md
 
-   Follow the tasks rules from config.yaml, emphasizing vertical slicing:
+   IMPORTANT: Let /opsx:continue generate tasks.md using the OpenSpec workflow.
+   DO NOT write tasks.md yourself. The /opsx:continue command handles this.
 
-   VERTICAL SLICING (core QRSPI principle):
+   After tasks.md is generated, you will need to validate it follows vertical
+   slicing principles (validation happens in the next step, not here).
+
+   After tasks.md is generated, report completion and the path to the tasks file.
+   ```
+
+5. Wait for the sub-agent to complete
+6. Verify specs/* and tasks.md exist at the reported paths
+7. Read the generated `tasks.md` file
+8. Validate vertical slicing structure:
+
+   **VERTICAL SLICING (required for qrspi-apply)**:
 
    Each slice must deliver an end-to-end testable feature path, NOT a horizontal
    layer. Structure the work so that after completing Slice 1, you have something
@@ -315,30 +344,6 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    Phase 4: All frontend components
    ```
 
-   Requirements for each slice:
-   - Deliverable: A working, testable increment (e.g., "CLI with security removed from public API")
-   - Test: Explicit verification steps showing the slice works end-to-end
-   - Parallelization: Slices should be independent enough to implement concurrently with minimal blocking
-   - Checkpoints: Each subtask has a "Test:" line describing verification
-   - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
-   - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
-
-   After all slices, include a "## Parallelization Strategy" section that:
-   - Identifies which slices must complete first (dependencies)
-   - States which slices can run in parallel
-   - Explains why parallel slices are independent
-   - Describes final integration steps
-
-   Use judgment about structure - the config.yaml provides guidelines.
-
-   After tasks.md is generated, report completion and the path to the tasks file.
-   ```
-
-5. Wait for the sub-agent to complete
-6. Verify specs/* and tasks.md exist at the reported paths
-7. Read the generated `tasks.md` file
-8. Analyze the slice structure for vertical vs horizontal organization:
-
    **Indicators of VERTICAL slicing (correct)**:
    - Each slice has a "Deliverable:" that describes a working, testable feature
    - Slices cross architectural boundaries (e.g., a slice touches both CLI and implementation)
@@ -351,17 +356,83 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    - Early slices cannot be tested end-to-end without later slices
    - Slices have sequential dependencies (must finish layer 1 before layer 2)
 
-9. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
+   Requirements for each slice:
+   - Deliverable: A working, testable increment (e.g., "CLI with security removed from public API")
+   - Test: Explicit verification steps showing the slice works end-to-end
+   - Parallelization: Slices should be independent enough to implement concurrently with minimal blocking
+   - Checkpoints: Each subtask has a "Test:" line describing verification
+   - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
+   - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
 
-   - Identify the smallest testable feature path that crosses all layers
-   - Restructure tasks so each slice delivers that end-to-end path
-   - Each slice should have a clear "Deliverable:" describing what works after completion
-   - Ensure each subtask has explicit "Test:" verification steps
-   - Structure for parallelization where possible (independent slices)
-   - Write the converted structure directly to `tasks.md`
-   - Show a diff of the changes to the user with explanation of what was restructured
+9. Check for "## Parallelization Strategy" section:
 
-10. Present tasks.md to the user for final approval:
+   **If missing or incomplete**, add a simple parallelization strategy section following this format:
+
+   ```markdown
+   ## Parallelization Strategy
+
+   ### Dependencies (Must Complete First)
+
+   - **Slice X** must wait until Slices Y-Z complete (reason)
+
+   **Independent tasks (can run in parallel):**
+   - Slice A and Slice B are independent → can implement simultaneously
+   - Slice A and Slice C are independent → can implement simultaneously
+
+   **Sequential dependencies:**
+   - Slice D must complete before Slice E because (reason)
+
+   **Critical path:**
+   Slice X → Slice Y (reason for dependency)
+
+   **Recommended implementation order:**
+   1. Implement Slices A, B, C in parallel (description)
+   2. Implement Slice D (description)
+   3. Implement Slice E (description)
+   ```
+
+   Keep it simple and focused on:
+   - Which slices can run in parallel (and why they're independent)
+   - Which slices must be sequential (and the dependency reason)
+   - Recommended order for implementation
+
+   DO NOT overcomplicate with excessive detail or edge cases.
+
+10. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
+
+   CRITICAL: The qrspi-apply skill requires vertical slicing. If /opsx:continue
+   generated horizontal slices, you MUST restructure them before presenting to the user.
+
+   **Conversion process**:
+   
+   a) **Identify end-to-end feature paths**: Look for the smallest complete user-facing
+      feature that touches all relevant architectural layers. For example:
+      - Instead of: "Slice 1: All API changes" + "Slice 2: All CLI changes"
+      - Convert to: "Slice 1: CLI help command (CLI + API)" + "Slice 2: CLI list command (CLI + API)"
+   
+   b) **Restructure each slice** with these required elements:
+      - **Deliverable:** - A working, demonstrable feature (not just "API endpoint exists")
+      - **Test:** - Explicit verification showing the end-to-end path works
+      - **Subtasks in markdown checklist format**: Each subtask MUST use `- [ ] instruction` format
+      - Subtasks that cross layers (e.g., "- [ ] Update API handler" + "- [ ] Wire CLI command" + "- [ ] Add help text")
+      
+      CRITICAL: Preserve the markdown checklist format (`- [ ] ...`) for all subtasks.
+      Do NOT use numbered lists (1. 2. 3.) or plain bullets (- without [ ]).
+      The qrspi-apply skill depends on this format to track task completion.
+   
+   c) **Preserve parallelization opportunities**: Structure slices to be independent
+      - Good: "Slice 1: auth flow" and "Slice 2: data export flow" are independent
+      - Bad: "Slice 1: database schema" must complete before "Slice 2: service layer"
+   
+   d) **Update Parallelization Strategy**: Revise the strategy section to reflect the
+      new slice structure (which slices can run in parallel, which have dependencies)
+   
+   e) **Write changes to tasks.md**: Edit the file in place using the Edit tool
+   
+   f) **Show diff to user**: Display what changed and explain why (e.g., "Converted
+      from layer-based to feature-based slices for better parallelization")
+
+11. Present tasks.md to the user for final approval:
 
    ```
    Specs and tasks generated.
@@ -379,7 +450,12 @@ This is the "brain surgery" moment from the QRSPI talk — a correction here cos
    (c) Manual edit — edit tasks.md yourself, then confirm
    ```
 
-11. Handle user input (same flow as Phase 4: approve, request edits, or manual edit)
+12. Handle user input (same flow as Phase 4: approve, request edits, or manual edit)
+
+**CRITICAL: DO NOT PROCEED TO PHASE 6 WITHOUT EXPLICIT USER APPROVAL.**
+
+Wait for the user to explicitly approve the tasks.md structure. If they don't respond
+or the conversation ends, stop here - do not auto-proceed to completion.
 
 **Output**: Generated `specs/*` and `tasks.md` in `openspec/changes/<slug>/`
 
@@ -470,6 +546,22 @@ This skill assumes the project has:
 4. `AGENTS.md` or `CLAUDE.md` defining agent behavior (ideally via `accelint-onboard-agent` skill)
 
 If any of these are missing, guide the user to set them up before running this skill.
+
+## NEVER Do This
+
+**NEVER generate artifacts yourself** — Always use /opsx commands (new, continue) to create proposal.md, design.md, specs/*, and tasks.md. The /opsx workflow handles artifact generation following OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design/spec/task rules and create inconsistent outputs.
+
+**NEVER generate tasks.md from scratch** — Always use /opsx:continue to create the initial tasks.md. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If /opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) following the validation guidance in Phase 5 Step 10. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert to numbered lists or plain bullets.
+
+**NEVER use numbered lists or plain bullets in tasks.md** — All subtasks must use markdown checklist format: `- [ ] instruction`. The qrspi-apply skill tracks completion by checking/unchecking these boxes. If you see numbered lists (1. 2. 3.) or plain bullets (- without [ ]), convert them to `- [ ] ...` format.
+
+**NEVER overcomplicate Parallelization Strategy** — Keep it simple: list which slices can run in parallel, which have sequential dependencies, and recommended implementation order. Don't add excessive detail about every possible edge case or coordination mechanism. The example in this skill shows the right level of detail.
+
+**NEVER continue to specs/tasks without design approval** — Phase 4 checkpoint is mandatory. If you skip the design review and generate tasks immediately, you miss the "brain surgery" moment where corrections are cheap. Fixing design issues after code is written costs review cycles and rework.
+
+**NEVER let the ticket leak into research/design context** — Questions are generated WITH ticket context, but research and design must see ONLY questions + research answers. If the ticket stays in context during research, the agent will propose solutions instead of gathering objective facts about the current codebase.
+
+**NEVER skip the mandatory checkpoints** — Phase 4 (after design.md) and Phase 5 Step 12 (after tasks.md) require explicit user approval before continuing. If you proceed without waiting for user confirmation ("looks good", "approve", "continue"), you bypass the core value of QRSPI: cheap corrections at the design stage. The "brain surgery" moment is when design is reviewed BEFORE specs/tasks are generated. Skipping checkpoints defeats the entire methodology.
 
 ## Example Usage
 

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Automate the QRSPI + OpenSpec planning workflow (Questions → Rese
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.0"
+  version: "1.2.1"
 ---
 
 # Accelint QRSPI
@@ -51,11 +51,11 @@ openspec update
 │                                      design.md       —          │
 │                                      [STOP HERE]                │
 │  ⚠️  CHECKPOINT 1: Review design.md - MUST approve to continue  │
-│                                                                  │
+│                                                                 │
 │  Specs/Tasks    Q+R+design           specs/*         —          │
 │                                      tasks.md        —          │
 │  ⚠️  CHECKPOINT 2: Review tasks.md - MUST approve to continue   │
-│                                                                  │
+│                                                                 │
 │  Done           —                    Exit            —          │
 └─────────────────────────────────────────────────────────────────┘
 
@@ -196,11 +196,11 @@ Before starting, verify OpenSpec has the required workflows enabled.
    command handles artifact generation based on config.yaml rules.
 
    After design.md is generated (and ONLY proposal.md and design.md exist),
-   report completion, the CHANGE NAME, and the path to the design file. 
-   
+   report completion, the CHANGE NAME, and the path to the design file.
+
    IMPORTANT: You MUST report the change name explicitly at the end like:
    "Change name: <slug>"
-   
+
    CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
    Your job ends here. The parent agent will handle the checkpoint and Phase 5.
    If you generate specs/* or tasks.md, you will bypass the mandatory design review.
@@ -312,8 +312,8 @@ of QRSPI methodology.
    IMPORTANT: Let /opsx:continue generate tasks.md using the OpenSpec workflow.
    DO NOT write tasks.md yourself. The /opsx:continue command handles this.
 
-   After tasks.md is generated, you will need to validate it follows vertical
-   slicing principles (validation happens in the next step, not here).
+   After tasks.md is generated, the parent agent will validate vertical slicing
+   and add a "## Parallelization Strategy" section if needed.
 
    After tasks.md is generated, report completion and the path to the tasks file.
    ```
@@ -364,9 +364,49 @@ of QRSPI methodology.
    - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
    - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
 
-9. Check for "## Parallelization Strategy" section:
+9. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
 
-   **If missing or incomplete**, add a simple parallelization strategy section following this format:
+   CRITICAL: The qrspi-apply skill requires vertical slicing. If /opsx:continue
+   generated horizontal slices, you MUST restructure them before presenting to the user.
+
+   **Conversion process**:
+
+   a) **Identify end-to-end feature paths**: Look for the smallest complete user-facing
+      feature that touches all relevant architectural layers. For example:
+      - Instead of: "Slice 1: All API changes" + "Slice 2: All CLI changes"
+      - Convert to: "Slice 1: CLI help command (CLI + API)" + "Slice 2: CLI list command (CLI + API)"
+
+   b) **Restructure each slice** with these required elements:
+      - **Deliverable:** - A working, demonstrable feature (not just "API endpoint exists")
+      - **Test:** - Explicit verification showing the end-to-end path works
+      - **Subtasks in markdown checklist format**: Each subtask MUST use `- [ ] instruction` format
+      - Subtasks that cross layers (e.g., "- [ ] Update API handler" + "- [ ] Wire CLI command" + "- [ ] Add help text")
+
+      CRITICAL: Preserve the markdown checklist format (`- [ ] ...`) for all subtasks.
+      Do NOT use numbered lists (1. 2. 3.) or plain bullets (- without [ ]).
+      The qrspi-apply skill depends on this format to track task completion.
+
+   c) **Preserve parallelization opportunities**: Structure slices to be independent
+      - Good: "Slice 1: auth flow" and "Slice 2: data export flow" are independent
+      - Bad: "Slice 1: database schema" must complete before "Slice 2: service layer"
+
+   d) **Update Parallelization Strategy (if it exists)**: If the tasks.md already has
+      a "## Parallelization Strategy" section, revise it to reflect the new slice
+      structure (which slices can run in parallel, which have dependencies).
+      Note: If the section doesn't exist, the parent agent will add it in step 10.
+
+   e) **Write changes to tasks.md**: Edit the file in place using the Edit tool
+
+   f) **Show diff to user**: Display what changed and explain why (e.g., "Converted
+      from layer-based to feature-based slices for better parallelization")
+
+10. **CRITICAL: Check for and add Parallelization Strategy section**:
+
+   After vertical slicing is validated/corrected, check if tasks.md contains a
+   "## Parallelization Strategy" section.
+
+   **If the section is missing or incomplete**, add it NOW using the Edit tool
+   to append to the end of tasks.md (after all slices):
 
    ```markdown
    ## Parallelization Strategy
@@ -398,39 +438,9 @@ of QRSPI methodology.
 
    DO NOT overcomplicate with excessive detail or edge cases.
 
-10. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
-
-   CRITICAL: The qrspi-apply skill requires vertical slicing. If /opsx:continue
-   generated horizontal slices, you MUST restructure them before presenting to the user.
-
-   **Conversion process**:
-   
-   a) **Identify end-to-end feature paths**: Look for the smallest complete user-facing
-      feature that touches all relevant architectural layers. For example:
-      - Instead of: "Slice 1: All API changes" + "Slice 2: All CLI changes"
-      - Convert to: "Slice 1: CLI help command (CLI + API)" + "Slice 2: CLI list command (CLI + API)"
-   
-   b) **Restructure each slice** with these required elements:
-      - **Deliverable:** - A working, demonstrable feature (not just "API endpoint exists")
-      - **Test:** - Explicit verification showing the end-to-end path works
-      - **Subtasks in markdown checklist format**: Each subtask MUST use `- [ ] instruction` format
-      - Subtasks that cross layers (e.g., "- [ ] Update API handler" + "- [ ] Wire CLI command" + "- [ ] Add help text")
-      
-      CRITICAL: Preserve the markdown checklist format (`- [ ] ...`) for all subtasks.
-      Do NOT use numbered lists (1. 2. 3.) or plain bullets (- without [ ]).
-      The qrspi-apply skill depends on this format to track task completion.
-   
-   c) **Preserve parallelization opportunities**: Structure slices to be independent
-      - Good: "Slice 1: auth flow" and "Slice 2: data export flow" are independent
-      - Bad: "Slice 1: database schema" must complete before "Slice 2: service layer"
-   
-   d) **Update Parallelization Strategy**: Revise the strategy section to reflect the
-      new slice structure (which slices can run in parallel, which have dependencies)
-   
-   e) **Write changes to tasks.md**: Edit the file in place using the Edit tool
-   
-   f) **Show diff to user**: Display what changed and explain why (e.g., "Converted
-      from layer-based to feature-based slices for better parallelization")
+   **If the section exists but was part of a horizontal-to-vertical conversion**
+   (step 9d), verify it accurately reflects the new vertical slice structure and
+   update if needed.
 
 11. Present tasks.md to the user for final approval:
 


### PR DESCRIPTION
Create an "apply" skill for the QRSPI methodology. This is a wrapper around `opsx:apply` that reads the "Parallelization Strategy" that is generated from the `qrspi-propose` skill and spins up parallel sub-agents where possible. This reduces time to completion for a given spec. Also, once steps are completed, runs the `opsx:verify` command.`

Also, a few tweaks to the `qrspi-propose` skill in order to critical/anti-patterns more visible.