### PR TITLE
refactor: update a few skills to use parallel discovery

### DIFF
--- a/skills/accelint-onboard-agent/CHANGELOG.md
+++ b/skills/accelint-onboard-agent/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## [1.3.0] - 2026-05-11
+
+### Changed
+- **Replaced serial codebase discovery with parallel subagents in Phase 3**
+  - Rationale: Serial scanning wastes time on codebases with many config files spread across directories. Parallel discovery pattern from `accelint-architecture-doc` significantly improves performance.
+  - Now spawns 5 subagents simultaneously:
+    - Agent A: Version control & commit conventions
+    - Agent B: CI/CD & pre-commit workflows  
+    - Agent C: Testing & code quality
+    - Agent D: Security & migrations
+    - Agent E: OpenSpec & development workflow
+  - Each agent focuses on one behavioral domain and returns structured findings
+  - Results are merged after all agents complete before Phase 4
+
+### Added
+- **NEVER Do section** with anti-patterns including:
+  - Never run codebase discovery serially
+  - Never skip discovery before asking questions
+  - Never omit sections from generated AGENTS.md
+  - Never duplicate root-level instructions in package files
+  - Never write final file without showing preview
+- **Parallel discovery** principle added to Interaction Principles section
+
+### Version
+- Bumped from 1.2 → 1.3

--- a/skills/accelint-onboard-agent/README.md
+++ b/skills/accelint-onboard-agent/README.md
@@ -1,0 +1,193 @@
+# accelint-onboard-agent
+
+Generates `AGENTS.md` or `CLAUDE.md` files through an interactive interview. These files tell AI coding agents how to behave in your project — workflow conventions, communication style, decision-making rules.
+
+## What it does
+
+The skill runs a conversational interview covering agent role, communication preferences, workflow procedures, and guardrails. It tries to infer answers from your codebase (commit conventions from commitlint.config.ts, pre-commit checks from Husky hooks) before asking questions.
+
+Three modes:
+- Create — New file from scratch
+- Import — Restructure existing content that doesn't match the template
+- Refresh — Update a file that matches the expected structure
+
+The output is *behavior* only. Stack details, architecture patterns, and coding standards belong in `openspec/config.yaml`, not here.
+
+## When to use it
+
+Run this skill to set up agent instructions for a new project, update rules after workflow changes, or create package-specific overrides in a monorepo.
+
+Trigger phrases: "create AGENTS.md", "set up agent rules", "configure claude code", "onboard agent"
+
+## How it works
+
+**Phase 0: File state detection**
+
+Checks if AGENTS.md exists and picks a mode. In monorepos, also looks for a root-level AGENTS.md to avoid duplicating global instructions.
+
+**Phase 1: Discovery interview**
+
+Asks about agent role, communication style, workflow procedures (feature dev, bug fixes, commit format), decision heuristics (when to ask vs. proceed), tool preferences, and guardrails.
+
+**Phase 2: Smart defaults**
+
+After you answer a question, the skill suggests related conventions based on what it found. If you mentioned Turborepo + PNPM, it confirms whether to use `pnpm -w` for root deps and `pnpm --filter` for packages. If it sees commitlint.config.ts, it asks which commit types you use beyond the standard set.
+
+**Phase 3: Parallel codebase discovery**
+
+For gaps the interview didn't fill, the skill spawns five agents in parallel to scan config files:
+
+- Version control & commit conventions (commitlint, git log, branch protection)
+- CI/CD & pre-commit workflows (GitHub Actions, Husky, lefthook)
+- Testing & code quality (vitest/jest/pytest, package manager lockfiles)
+- Security & migrations (migration directories, .env.example, .gitignore patterns)
+- OpenSpec integration (openspec/ directory, config.yaml)
+
+Running these in parallel instead of serially cuts discovery time on repos with scattered config files.
+
+**Phase 4: Preview and write**
+
+Shows you the complete file with source comments on inferred values:
+
+```markdown
+- Always run `pnpm check` before committing   # inferred from .husky/pre-commit
+- Use Conventional Commits (`feat:`, `fix:`)  # inferred from commitlint.config.ts
+```
+
+After you confirm, it writes the file without the source comments.
+
+## AGENTS.md structure
+
+The generated file has these sections:
+
+```markdown
+# Agent Behavior
+
+## Role & Identity
+[one-sentence role definition and scope]
+
+## Communication
+[response style, code change format, uncertainty handling]
+
+## Workflow Procedures
+[feature development, bug fixes, pre-commit checklist, commit conventions, PR rules, versioning]
+
+## Decision Heuristics
+[table of situations and default actions]
+
+## Tool Preferences
+[package manager, test runner, linter, task runner]
+
+## Guardrails
+[never rules, always-ask-first rules, security-sensitive areas]
+```
+
+Each section gets filled from interview answers, codebase inference, or marked `<!-- TODO: fill in -->` if neither source has the answer.
+
+## Separation of concerns
+
+Behavior goes in AGENTS.md. Project facts go in openspec/config.yaml:
+
+| AGENTS.md (behavior) | openspec/config.yaml (project DNA) |
+|----------------------|-----------------------------------|
+| "Always run `pnpm check` before committing" | "Package manager: pnpm" |
+| "Use Conventional Commits" | "TypeScript 5.x, strict mode" |
+| "Ask before deleting files" | "Monorepo: Turborepo + PNPM" |
+| "You are a senior TS engineer" | "`type` over `interface`" |
+
+If you document both what the agent does and what the project is in the same file, you waste tokens loading project facts during every agent invocation.
+
+## Monorepo behavior
+
+When you run this inside a monorepo package, the skill checks for a root-level AGENTS.md. If found, it reads that file and only asks about package-specific differences. The generated file references the root instead of repeating global rules:
+
+```markdown
+<!-- Inherits from: ../../AGENTS.md -->
+<!-- Only package-specific overrides and additions are defined here. -->
+```
+
+This keeps package files short and avoids loading duplicate instructions.
+
+## What it avoids
+
+Common mistakes this skill doesn't make:
+
+- Running codebase discovery one file at a time (uses parallel agents instead)
+- Asking questions before checking config files (infers first, asks second)
+- Silently omitting sections (marks gaps with `<!-- TODO: fill in -->`)
+- Repeating root-level instructions in package files (references instead)
+- Writing without showing you the output first (always previews)
+
+## Installation
+
+```bash
+npx skills add https://github.com/accelint/agent-skills --skill accelint-onboard-agent
+```
+
+## Usage
+
+```
+/accelint-onboard-agent
+```
+
+Or just say "Help me set up AGENTS.md for this project".
+
+## Example Output
+
+For a TypeScript monorepo with Turborepo, PNPM, Conventional Commits, and Husky pre-commit hooks, the skill generates:
+
+```markdown
+# Agent Behavior
+
+## Role & Identity
+You are a senior TypeScript engineer working across the @accelint/* monorepo.
+
+## Communication
+- **Response style**: Concise for simple tasks, detailed for complex work
+- **Code changes**: Show diffs separately from explanations
+- **Uncertainty**: Always ask before proceeding
+- **Reasoning**: Explain reasoning before taking action
+
+## Workflow Procedures
+
+### Pre-Commit Checklist
+- [ ] `pnpm typecheck`                    # inferred from .husky/pre-commit
+- [ ] `pnpm lint`                         # inferred from package.json scripts
+- [ ] `pnpm test`                         # inferred from package.json scripts
+
+### Commit Messages
+Convention: Conventional Commits          # inferred from commitlint.config.ts
+Format: `[type]([scope]): [description]`
+Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`
+Example: `feat(layer): add WebGPU fallback for Safari`
+
+## Tool Preferences
+- **Package manager**: always use `pnpm`  # inferred from pnpm-lock.yaml
+- **Test runner**: `vitest`               # inferred from vitest.config.ts
+- **Task runner**: `pnpm turbo run <task> --filter=<pkg>`
+
+## Guardrails
+### Never
+- [ ] Never force-push to any branch       # inferred from branch protection
+- [ ] Never commit secrets or credentials
+- [ ] Never use `any` in TypeScript
+```
+
+## Version history
+
+See [CHANGELOG.md](CHANGELOG.md) for details.
+
+Current version: 1.3.0
+
+Changes in 1.3.0:
+- Parallel codebase discovery (spawns 5 agents instead of scanning files one at a time)
+- Anti-pattern section
+- Monorepo inheritance detection
+
+## Related skills
+
+- `accelint-onboard-openspec` — Generates openspec/config.yaml for architecture and coding standards
+- `accelint-architecture-doc` — Creates architecture documentation
+- `init` — Quick CLAUDE.md setup without the interview
+
+Use this skill when you want the full structured interview. Use `/init` when you just need something basic.

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -4,7 +4,7 @@ description: Interactively onboard a project to agent-driven development by runn
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # Onboard Agents
@@ -62,6 +62,16 @@ should the agent behave?", it belongs in `config.yaml`, not here.
 | "Prefer small, focused PRs"       | "`type` over `interface`"         |
 | "You are a senior TS engineer"    | "Domain: geospatial visualization"|
 | "Never force-push to main"        | "Testing: Vitest + @testing-library"|
+
+---
+
+## NEVER Do When Onboarding Agents
+
+- **NEVER run codebase discovery serially** — Phase 3 spawns parallel subagents for different behavioral domains. Serial scanning wastes time on codebases with many config files spread across directories.
+- **NEVER skip discovery before asking questions** — attempt to infer behavioral conventions from the codebase before adding questions to the interview. A question about commit format when `commitlint.config.ts` exists wastes the user's time.
+- **NEVER omit sections from the generated AGENTS.md** — if a section cannot be inferred or answered, mark it with `<!-- TODO: fill in -->` rather than leaving it out. Missing sections silently shape agent behavior in unpredictable ways.
+- **NEVER duplicate root-level instructions in package-level files** — if a monorepo root AGENTS.md exists, package files should reference it and add only what is package-specific. Repeated instructions inflate context on every agent invocation.
+- **NEVER write the final file without showing a preview** — the user must see inferred values with source annotations and confirm before any filesystem write.
 
 ---
 
@@ -321,35 +331,56 @@ appropriate.
 
 ---
 
-### Phase 3 — Codebase Inference (fill gaps before generating)
+### Phase 3 — Parallel Codebase Discovery (fill gaps before generating)
 
 After the interview, audit every AGENTS.md section that still has no answer.
 For each gap, attempt to derive the behavioral intent directly from the
-codebase before asking or leaving a `# TODO`. A behavioral file with explicit
-TODOs is actionable; a file with missing sections silently shapes agent
-behavior in unpredictable ways.
+codebase using parallel subagents before asking or leaving a `# TODO`. A
+behavioral file with explicit TODOs is actionable; a file with missing sections
+silently shapes agent behavior in unpredictable ways.
 
-**Inference targets and where to look:**
+Spawn discovery subagents in parallel — don't scan serially. Each agent focuses
+on one behavioral domain and returns structured findings. Wait for all agents
+to complete, then merge results before Phase 4.
 
-| Gap | Files / signals to inspect |
-|-----|---------------------------|
-| Commit convention | `commitlint.config.*`, recent `git log --oneline`, `.gitmessage`, `.releaserc*` |
-| PR workflow | `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/` (CI gate names) |
-| Pre-commit checks | `.husky/`, `.lefthook.yml`, `package.json#scripts` (lint, typecheck, test) |
-| Test runner preference | `vitest.config.*`, `jest.config.*` — whichever is present |
-| Package manager | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb` |
-| Forced-push protection | `.github/branch-protection*`, README mentions of branch policy |
-| Migration guardrails | Presence of `migrations/`, `prisma/migrations/`, `alembic/` |
-| Secret handling | `.env.example`, `.gitignore` patterns, presence of `dotenv` / vault tooling |
-| OpenSpec usage | `openspec/` directory, `openspec/config.yaml`, any `/opsx:*` references in docs |
-| Versioning workflow | `.changeset/`, `CHANGELOG.md`, `standard-version`, `conventional-changelog` |
-| Path aliases (for tool commands) | `tsconfig.json#paths`, `vite.config` — infer preferred import style |
-| TypeScript project detection | `tsconfig.json` presence — enables TS-specific baseline guardrails |
-| Vitest global mock cleanup | `vitest.config.ts` — check for `clearMocks`, `mockReset`, `restoreMocks` flags |
-| Test file type checking | CI workflows, package.json scripts — check if `tsc --noEmit` runs on test files |
+**Spawn these agents simultaneously:**
 
-**After inference, for each field resolved this way**, note the source in the
-preview with a trailing comment, e.g.:
+**Agent A — Version Control & Commit Conventions**
+- Commit convention: `commitlint.config.*`, recent `git log --oneline`, `.gitmessage`, `.releaserc*`
+- Versioning workflow: `.changeset/`, `CHANGELOG.md`, `standard-version`, `conventional-changelog`
+- Forced-push protection: `.github/branch-protection*`, README mentions of branch policy
+- Return: commit message format with types and examples, versioning commands, branch protection rules
+
+**Agent B — CI/CD & Pre-commit Workflows**
+- PR workflow: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/` (CI gate names, required checks)
+- Pre-commit checks: `.husky/`, `.lefthook.yml`, `package.json#scripts` (lint, typecheck, test)
+- Return: PR conventions (size, labels, templates), pre-commit checklist with commands, CI required checks
+
+**Agent C — Testing & Code Quality**
+- Test runner: `vitest.config.*`, `jest.config.*`, `pytest.ini`, `pyproject.toml [tool.pytest]`, Playwright, Cypress
+- Package manager: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`
+- TypeScript project: `tsconfig.json` presence, path aliases in `tsconfig.json#paths` or `vite.config`
+- Vitest config: `vitest.config.ts` — check for `clearMocks`, `mockReset`, `restoreMocks` flags
+- Test file type checking: CI workflows, `package.json` scripts — check if `tsc --noEmit` runs on test files
+- Return: test framework, package manager, TS-specific guardrails if applicable, vitest cleanup config
+
+**Agent D — Security & Migrations**
+- Migration files: presence of `migrations/`, `prisma/migrations/`, `alembic/`
+- Secret handling: `.env.example`, `.gitignore` patterns, presence of `dotenv` / vault tooling
+- Return: migration guardrails if migrations exist, secret handling practices
+
+**Agent E — OpenSpec & Development Workflow**
+- OpenSpec: `openspec/` directory, `openspec/config.yaml`, any `/opsx:*` references in docs or CLAUDE.md
+- Return: OpenSpec usage status, when to invoke spec workflow
+
+**After all agents complete:** merge their findings into a unified discovery map.
+Tag each field as `# inferred from [source]` or leave empty if unknown. Fields
+that remain empty after discovery become explicit `<!-- TODO: fill in -->` markers
+in the generated file.
+
+**Preview with source annotations:**
+
+After merging discovery results, show a preview with trailing comments on inferred values:
 
 ```markdown
 - Always run `pnpm check` before committing   # inferred from .husky/pre-commit
@@ -566,6 +597,7 @@ with placeholder text.
 
 ## Interaction Principles
 
+- **Parallel discovery.** Spawn subagents for Phase 3 simultaneously — don't scan config files one-by-one.
 - **Conversational, not interrogative.** Bundle related questions into a
   single turn. Use natural language, not bullet-dump forms.
 - **Infer and confirm.** "You mentioned Husky — I'll assume the pre-commit

--- a/skills/accelint-onboard-openspec/CHANGELOG.md
+++ b/skills/accelint-onboard-openspec/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [1.3.0] - 2026-05-11
+
+### Changed
+- **CRITICAL PERFORMANCE FIX:** Replaced serial codebase inference with parallel sub-agent discovery
+  - Rationale: Phase 3 now spawns 4 discovery agents simultaneously (Stack & Build, Testing & Quality, Architecture & Patterns, CI/CD & Versioning) instead of scanning config files one-by-one. Dramatically reduces discovery time on large codebases with many config files spread across directories.
+  - Pattern borrowed from `accelint-architecture-doc` skill's proven parallel discovery architecture
+
+### Added
+- Added "NEVER Do" anti-pattern warning about serial scanning when subagents are available
+- Created Phase 3 parallel discovery agent specifications:
+  - Agent A: Stack & Build Tooling
+  - Agent B: Testing & Code Quality
+  - Agent C: Architecture & Code Patterns
+  - Agent D: CI/CD & Versioning
+
+### Version
+- Bumped from 1.2.0 → 1.3.0

--- a/skills/accelint-onboard-openspec/README.md
+++ b/skills/accelint-onboard-openspec/README.md
@@ -1,0 +1,314 @@
+# OpenSpec Onboarding Skill
+
+Generates `openspec/config.yaml` files through a conversational interview. The skill asks questions about your tech stack, architecture, and domain concepts, then runs parallel codebase inference to fill gaps. The output is a complete configuration file for the QRSPI (Question, Research, Spec, Plan, Implement) methodology.
+
+## Overview
+
+OpenSpec needs an `openspec/config.yaml` file that defines project context and per-artifact rules. This skill creates it by:
+
+- Asking targeted questions about tech stack, architecture, domain concepts, and team conventions
+- Spawning four discovery agents simultaneously to infer missing details from your codebase
+- Detecting whether to create, import, or refresh based on existing file state
+- Enforcing YAML quoting rules and validating syntax
+
+The configuration gets injected into every AI-generated proposal, design document, task list, and specification.
+
+## When to use
+
+Use this skill when starting a new project with OpenSpec, migrating an existing project to the OpenSpec workflow, updating configuration after tech stack changes, onboarding team members, or refreshing stale configuration.
+
+The skill detects the current state and adapts.
+
+## Quick start
+
+### Prerequisites
+
+You need Claude Code with agent spawning for parallel inference. A git repository is recommended but not required.
+
+### Basic usage
+
+1. Invoke the skill:
+   ```
+   /accelint-onboard-openspec
+   ```
+
+2. Answer interview questions grouped by topic (project identity, tech stack, architecture, domain concepts, code patterns)
+
+3. Review the generated preview with inferred values and TODO markers
+
+4. Confirm to write `openspec/config.yaml` to disk
+
+The entire process takes 5-10 minutes depending on project complexity and interview depth.
+
+## Configuration modes
+
+The skill has three modes based on file state:
+
+### Mode 1: Create
+
+**Triggers when:** `openspec/config.yaml` doesn't exist or is empty
+
+Runs a complete interview covering all configuration sections. Questions are grouped into natural conversation turns rather than dumped as a questionnaire.
+
+Outputs a fresh configuration file with all context sections populated.
+
+### Mode 2: Import
+
+**Triggers when:** `openspec/config.yaml` exists with unrecognized structure
+
+Presents three options:
+
+- **(a) Restructure** - Map existing content onto QRSPI schema, flag behavioral content for `AGENTS.md`, run targeted interview to fill gaps
+- **(b) Append** - Run full interview and add new sections alongside existing content
+- **(c) Dry run** - Generate output without writing to filesystem
+
+This protects existing custom configuration while letting you adopt the QRSPI structure.
+
+### Mode 3: Refresh
+
+**Triggers when:** `openspec/config.yaml` exists with recognized QRSPI schema
+
+Runs an abbreviated interview:
+
+- Drift detection: scans for tech stack changes (new dependencies, updated TypeScript config, new CI workflows)
+- Unresolved TODOs: finds `# TODO: fill in` markers left from previous runs
+
+Only asks about changed areas. Unchanged sections stay untouched.
+
+## Interview structure
+
+The interview covers 10 topics:
+
+| Turn | Focus Area | Example Questions |
+|------|------------|------------------|
+| 1 | Project Identity | Name, purpose, monorepo structure, package manager |
+| 2 | Tech Stack | Runtime, language, framework, data layer, testing, build tools |
+| 3 | Architecture | Organization style, path aliases, design patterns |
+| 4 | Domain Concepts | Key entities, terminology, specialized concepts |
+| 5 | Performance | Concrete targets (p95 latency, fps, memory), hot paths |
+| 6 | Code Patterns | Export style, naming conventions, error handling, testing structure |
+| 7 | Anti-Patterns | Banned patterns, deprecated approaches, performance traps |
+| 8 | Proposal Rules | Database impact, breaking changes, security checklists |
+| 9 | Design Rules | Docker/K8s changes, performance implications, diagram styles |
+| 10 | Task Rules | Tagging conventions, rollback requirements, test gates |
+
+Questions within each topic are bundled. The skill infers related tooling from stack answers (mention Vitest and it assumes testing-library for React components).
+
+## Parallel codebase inference
+
+After the interview, four discovery agents run simultaneously:
+
+### Agent A: Stack & Build Tooling
+
+Analyzes:
+- Runtime version (`.nvmrc`, `.node-version`, `package.json#engines`)
+- TypeScript configuration (`tsconfig.json` — compiler options, path aliases)
+- Package manager (lockfile detection)
+- Monorepo workspaces (`pnpm-workspace.yaml`, `turbo.json`)
+- Build tools (`vite.config.*`, `webpack.config.*`)
+
+### Agent B: Testing & Code Quality
+
+Analyzes:
+- Test framework (`vitest.config.*`, `jest.config.*`, `pytest.ini`)
+- Linting and formatting (`.eslintrc*`, `biome.json`, `.prettierrc*`)
+- Test structure patterns (describe/it nesting, file location)
+- Type checking configuration for test files
+- Mock cleanup settings (Vitest)
+
+### Agent C: Architecture & Code Patterns
+
+Analyzes:
+- Architecture organization (directory tree structure)
+- Path aliases (`tsconfig.json#paths`, `vite.config#resolve.alias`)
+- Design patterns (factory, repository, observer — inferred from source)
+- Export style (named vs default — tallied from samples)
+- Naming conventions (file names, identifiers)
+- Error handling approach (throw, Result, Either, boundaries)
+
+### Agent D: CI/CD & Versioning
+
+Analyzes:
+- CI/CD platform (`.github/workflows/`, `.circleci/`)
+- Versioning strategy (`.changeset/`, `commitlint.config.*`)
+- Anti-patterns (ESLint rule overrides, `@deprecated` annotations)
+
+All agents run concurrently. The skill merges their findings before showing you the preview.
+
+## Configuration schema
+
+The generated `openspec/config.yaml` has this structure:
+
+```yaml
+schema: spec-driven
+
+context: |
+  # Project DNA — injected into every AI artifact
+  
+  ## Stack Facts
+  - Project identity, tech stack, architecture patterns
+  - Domain concepts with one-line definitions
+  - Performance targets and constraints
+  
+  ## Patterns to Follow
+  - Code patterns (exports, naming, error handling)
+  - Architecture patterns
+  - Testing patterns with AAA structure
+  
+  ## Patterns to Avoid
+  - Code anti-patterns with rationale
+  - Performance anti-patterns
+  - Testing anti-patterns
+
+rules:
+  proposal:
+    - Scope definition checkpoints
+    - Out-of-scope boundaries
+  
+  design:
+    - Required sections (Current State, Desired End State, etc.)
+    - Technical depth requirements
+    - Line limits
+  
+  tasks:
+    - Vertical slicing preference
+    - Granularity limits (max 2 hours per task)
+    - Test verification requirements
+  
+  spec:
+    - Given/When/Then format
+    - Concrete example data
+    - Edge case documentation
+```
+
+Every section matters. Missing fields degrade the AI artifacts that use this config. Unresolved fields get marked `# TODO: fill in` rather than omitted.
+
+## YAML safety features
+
+The skill enforces YAML generation rules:
+
+### Automatic quoting
+
+Values starting with special characters get quoted:
+
+```yaml
+tag: "[PKG:auth]"           # Square brackets protected
+description: "(internal)"    # Parentheses protected
+pattern: "some|other"        # Pipe character protected
+note: "Time: 5pm"            # Colon in value protected
+```
+
+### Block scalar indicators
+
+Multi-line content uses literal block scalars:
+
+```yaml
+context: |
+  Line 1
+  Line 2
+  Line 3
+```
+
+### Validation checklist
+
+Before writing, the skill checks:
+- No tab characters (YAML needs spaces)
+- Quote matching
+- Consistent 2-space indentation
+- List items aligned at same level
+- Special characters quoted where needed
+
+After writing, it reads the file back to verify it's valid YAML.
+
+## Smart defaults
+
+The skill suggests stack-specific conventions. Next.js + TypeScript + Tailwind gets questions about App Router vs Pages Router, Server Component boundaries, and `"use client"` directive placement. React + Vitest assumes `userEvent` over `fireEvent` and role-based queries. Python + FastAPI asks about Pydantic v1 vs v2 and dependency injection. Node.js + Prisma asks about transaction patterns and soft-delete conventions.
+
+This reduces open-ended questions.
+
+## Companion skill: `accelint-onboard-agent`
+
+This skill produces the project DNA layer (structural facts). Its companion `accelint-onboard-agent` produces the behavior layer (`AGENTS.md` / `CLAUDE.md`) covering how the agent acts, communicates, and makes decisions.
+
+If you volunteer behavioral content during the OpenSpec interview (commit conventions, workflow steps, tool preferences), the skill will redirect you:
+
+> "That's behavioral - it belongs in AGENTS.md. I'll note it here for reference, but the `accelint-onboard-agent` skill is where to capture it."
+
+The two skills don't overlap.
+
+## Best practices
+
+### Answer honestly about unknowns
+
+If you don't know an answer, say so. The skill will try codebase inference. Fields that can't be resolved get marked `# TODO: fill in` for later.
+
+### Review inferred values
+
+The preview labels all inferred values with their source:
+
+```yaml
+- Runtime: Node.js 20 LTS   # inferred from .nvmrc
+```
+
+Check these before confirming. Inference can misread unconventional project structures.
+
+### Complete TODOs after generation
+
+If the final config has `# TODO: fill in` markers, edit the file directly. These usually represent performance targets, team-specific rules, or domain concept definitions that can't be inferred from code.
+
+### Use refresh mode for updates
+
+When the tech stack changes, re-run the skill. It detects drift automatically and only asks about changed sections.
+
+### Keep context factual
+
+The `context:` block gets injected into every AI artifact. Put objective facts there, not opinions or procedures. Guidelines like "use semantic tokens" belong in the patterns section, not as prose.
+
+## Validation and quality
+
+After generation, the skill:
+
+1. Shows a labeled preview with inference sources and TODO markers
+2. Asks for confirmation before writing to disk
+3. Writes the file without inference comment clutter
+4. Validates the YAML by reading it back
+5. Reports what was configured, what was inferred vs answered, and which TODOs remain
+
+This catches syntax errors before they hit disk.
+
+## Troubleshooting
+
+### "Config file has unrecognized structure"
+
+The skill found content that doesn't match the expected schema. Choose (a) Restructure to migrate to QRSPI format, (b) Append to keep existing structure and add new sections, or (c) Dry run to preview without modifying the file.
+
+### "YAML syntax error after generation"
+
+The validation caught a parse error. It's automatically fixed before the final write. If you see this, the safety checks worked.
+
+### "Agent spawning failed"
+
+Parallel inference needs Claude Code agent support. Without it, the skill falls back to serial discovery (slower, same output).
+
+### "Inference marked too many fields as TODO"
+
+This happens when the project has unconventional structure or the skill can't find expected config files. Edit the file directly to fill TODOs, or re-run with more detailed interview answers.
+
+## Version history
+
+See [CHANGELOG.md](CHANGELOG.md) for details.
+
+Current version: 1.3.0
+- Parallel sub-agent discovery (4x faster inference)
+- Anti-pattern warning for serial scanning
+- Performance improvements for large codebases
+
+## License
+
+Apache-2.0
+
+## Related skills
+
+- `accelint-onboard-agent` - Generate behavioral configuration (`AGENTS.md` / `CLAUDE.md`)
+- `accelint-readme-writer` - Generate README documentation
+- `accelint-architecture-doc` - Create architecture.md with parallel discovery (pattern reference for this skill)

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -4,13 +4,17 @@ description: Interactively onboard a project to OpenSpec by running a structured
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # Onboard OpenSpec
 
 Guide the user through a conversational interview to produce a complete,
 project-specific `openspec/config.yaml` configured for the QRSPI methodology.
+
+## NEVER Do When Onboarding OpenSpec
+
+- **NEVER run codebase inference serially when subagents are available** — Phase 3 spawns parallel subagents for different discovery domains. Serial scanning wastes time on codebases with many config files spread across directories. Spawn all 4 discovery agents simultaneously.
 
 ## Companion Skill
 
@@ -280,42 +284,57 @@ examples as a pattern; extend to other stacks as appropriate.
 
 ---
 
-### Phase 3 — Codebase Inference (fill gaps before generating)
+### Phase 3 — Parallel Codebase Inference
 
-After the interview, audit every config field that still has no answer. For each
-gap, attempt to derive the answer directly from the codebase before asking the
-user or leaving the field empty. All config sections are load-bearing — a
-missing field degrades every downstream AI artifact, so inference is always
-preferable to omission.
+After the interview, spawn parallel discovery subagents to fill remaining config
+gaps. All config sections are load-bearing — a missing field degrades every
+downstream AI artifact, so inference is always preferable to omission.
 
-**Inference targets and where to look:**
+Spawn discovery subagents in parallel — don't scan serially. Each agent focuses
+on one inference domain and returns structured findings. Wait for all agents to
+complete, then merge results before Phase 4.
 
-| Gap | Files / signals to inspect |
-|-----|---------------------------|
-| Runtime / Node version | `.nvmrc`, `.node-version`, `package.json#engines`, `Dockerfile` |
-| TypeScript config | `tsconfig.json` (compilerOptions flags, paths aliases) |
-| Package manager | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb` |
-| Monorepo workspaces | `package.json#workspaces`, `pnpm-workspace.yaml`, `turbo.json`, `nx.json` |
-| Build tools | `vite.config.*`, `webpack.config.*`, `tsup.config.*`, `esbuild` scripts in `package.json` |
-| Test framework | `vitest.config.*`, `jest.config.*`, `pytest.ini`, `pyproject.toml#tool.pytest` |
-| Linting / formatting | `.eslintrc*`, `biome.json`, `.prettierrc*`, `ruff.toml` |
-| CI/CD | `.github/workflows/`, `.circleci/`, `Jenkinsfile` |
-| Versioning | `.changeset/`, `CHANGELOG.md`, `commitlint.config.*`, `.releaserc*` |
-| Path aliases | `tsconfig.json#compilerOptions.paths`, `vite.config#resolve.alias` |
-| Architecture organisation | Directory tree of `src/` or workspace roots — infer feature-based vs layer-based |
-| Design patterns | Sample source files — look for factory functions, repository objects, observer hooks |
-| Export style | Sample 3–5 source files; tally named vs default exports |
-| Naming conventions | Sample file names, exported identifiers; describe what you observe |
-| Error handling | Grep for `throw`, `Result`, `Either`, `tryCatch`, error boundary components |
-| Test structure | Sample test files — describe/it nesting depth, file location relative to source |
-| Anti-patterns | `eslint` rule overrides marked `off` or `warn`, comments like `// TODO: replace`, `@deprecated` |
-| TypeScript baseline patterns | If `tsconfig.json` exists, automatically include TS/JS baseline patterns (classes, return values, type safety, testing, anti-patterns) |
-| Vitest global mock cleanup | `vitest.config.ts` — check for `clearMocks`, `mockReset`, `restoreMocks` in config |
-| Test file type checking | CI scripts, package.json — check if `tsc --noEmit` runs on `*.test.ts` files |
-| Property-based testing | Check for `fast-check` in dependencies — indicates PBT usage |
+**Spawn these agents simultaneously:**
 
-**After inference, for each field resolved this way**, note the source in the
-preview with a trailing comment, e.g.:
+**Agent A — Stack & Build Tooling**
+- Runtime / Node version: `.nvmrc`, `.node-version`, `package.json#engines`, `Dockerfile`
+- TypeScript config: `tsconfig.json` (compilerOptions flags, paths aliases)
+- Package manager: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`
+- Monorepo workspaces: `package.json#workspaces`, `pnpm-workspace.yaml`, `turbo.json`, `nx.json`
+- Build tools: `vite.config.*`, `webpack.config.*`, `tsup.config.*`, `esbuild` scripts
+- Return: runtime version, TS config flags, package manager, workspace list, build tools
+
+**Agent B — Testing & Code Quality**
+- Test framework: `vitest.config.*`, `jest.config.*`, `pytest.ini`, `pyproject.toml#tool.pytest`
+- Linting / formatting: `.eslintrc*`, `biome.json`, `.prettierrc*`, `ruff.toml`
+- Test structure: Sample test files — describe/it nesting depth, file location relative to source
+- Test file type checking: CI scripts, package.json — check if `tsc --noEmit` runs on `*.test.ts` files
+- Property-based testing: Check for `fast-check` in dependencies
+- Vitest mock cleanup: `vitest.config.ts` — check for `clearMocks`, `mockReset`, `restoreMocks`
+- Return: test framework, code quality tools, test structure patterns, type checking config
+
+**Agent C — Architecture & Code Patterns**
+- Architecture organisation: Directory tree of `src/` or workspace roots — infer feature-based vs layer-based
+- Path aliases: `tsconfig.json#compilerOptions.paths`, `vite.config#resolve.alias`
+- Design patterns: Sample source files — look for factory functions, repository objects, observer hooks
+- Export style: Sample 3–5 source files; tally named vs default exports
+- Naming conventions: Sample file names, exported identifiers; describe what you observe
+- Error handling: Grep for `throw`, `Result`, `Either`, `tryCatch`, error boundary components
+- TypeScript baseline patterns: If `tsconfig.json` exists, flag that TS/JS baseline patterns should be included
+- Return: architecture style, path aliases, design patterns, export conventions, naming patterns, error handling approach
+
+**Agent D — CI/CD & Versioning**
+- CI/CD: `.github/workflows/`, `.circleci/`, `Jenkinsfile`
+- Versioning: `.changeset/`, `CHANGELOG.md`, `commitlint.config.*`, `.releaserc*`
+- Anti-patterns: `eslint` rule overrides marked `off` or `warn`, comments like `// TODO: replace`, `@deprecated`
+- Return: CI/CD platform, versioning approach, documented anti-patterns
+
+**After all agents complete:** merge their findings into a unified inference map.
+Tag each field as `INFERRED [source]` or `UNKNOWN`. Fields tagged `UNKNOWN`
+should be marked as `# TODO: fill in` in the config preview.
+
+**For each field resolved via inference**, note the source in the preview with a
+trailing comment, e.g.:
 
 ```yaml
 - Runtime: Node.js 20 LTS   # inferred from .nvmrc

--- a/skills/accelint-readme-writer/CHANGELOG.md
+++ b/skills/accelint-readme-writer/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [1.1.0] - 2026-05-11
+
+### Changed
+- **Step 2: Parallel Codebase Discovery** — restructured to use parallel sub-agents for different discovery domains (entry points, dependencies, examples, docs context)
+  - Rationale: Following the pattern from `accelint-architecture-doc`, parallel discovery significantly reduces analysis time on codebases with files spread across directories. When sub-agents are available, spawn them simultaneously rather than scanning serially.
+  - Agents spawn in parallel: Agent A (Entry Points & Public API), Agent B (Dependencies & Configuration), Agent C (Examples & Usage Patterns), Agent D (Documentation Context)
+  - Falls back to inline serial discovery when sub-agents are unavailable
+
+### Added
+- **NEVER Do When Writing READMEs** section with 6 anti-patterns:
+  - Never run discovery serially when sub-agents are available
+  - Never document non-exported internal functions
+  - Never fabricate usage examples
+  - Never use the wrong package manager commands
+  - Never skip comparing code to existing README
+  - Never write robotic, AI-sounding text
+  - Rationale: These are expert-level knowledge based on common failure modes. Each includes the WHY behind the rule.
+
+### Version
+- Bumped from 1.0.0 → 1.1.0

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -4,12 +4,21 @@ description: Use when creating or editing a README.md file in any project or pac
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # README Writer
 
 This skill guides the creation and maintenance of comprehensive, human-friendly README documentation by analyzing the codebase and ensuring documentation stays in sync with actual functionality.
+
+## NEVER Do When Writing READMEs
+
+- **NEVER run discovery serially when sub-agents are available** — spawn parallel discovery agents for different aspects (entry points, dependencies, examples, existing docs) to analyze the codebase efficiently. Serial file-by-file scanning wastes time.
+- **NEVER document non-exported internal functions** — only document the public API that's accessible through package entry points. Internal helper functions that aren't re-exported from `index.ts` don't belong in the README.
+- **NEVER fabricate usage examples** — extract real examples from test files, JSDoc blocks, or `examples/` directories. Made-up examples often contain subtle errors that confuse users.
+- **NEVER use the wrong package manager commands** — check for lockfiles (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`) and use the matching package manager in all commands. Wrong commands break the user's first experience.
+- **NEVER skip comparing code to existing README** — when updating documentation, identify what's missing, what's stale, and what signature changes occurred. Silent drift between code and docs causes user frustration.
+- **NEVER write robotic, AI-sounding text** — use the humanizer skill to remove inflated language, promotional tone, and AI writing patterns. Documentation should sound like a helpful human wrote it.
 
 ## When to Activate This Skill
 
@@ -45,15 +54,39 @@ project-root/           # README here documents entire monorepo
 └── README.md
 ```
 
-### Step 2: Analyze the Codebase
+### Step 2: Parallel Codebase Discovery
 
-Recursively parse code starting from the README's directory:
+**Use parallel sub-agents when available** to discover different aspects of the codebase simultaneously. If sub-agents are not available, perform these discovery tasks inline but in the same systematic order.
 
-1. **Identify entry points**: Look for `index.ts`, `main.ts`, package.json `main`/`exports`
-2. **Map public API**: Find all exported functions, classes, types, constants
-3. **Trace dependencies**: Understand what the package depends on
-4. **Find examples**: Look for `examples/`, test files, or inline usage comments
-5. **Check package.json**: Extract scripts, dependencies, peer dependencies
+Spawn these discovery agents in parallel (if sub-agents available):
+
+**Agent A — Entry Points & Public API**
+- Check `package.json` for `main`, `module`, `types`, `exports` fields
+- Read the main entry point file (e.g., `src/index.ts`)
+- Trace all re-exports to map the complete public API
+- List all exported functions, classes, types, constants with signatures
+- Return: entry point paths, complete export list with types
+
+**Agent B — Dependencies & Configuration**
+- Read `package.json` for dependencies, devDependencies, peerDependencies, scripts
+- Check lockfile type (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`)
+- Look for configuration files: `tsconfig.json`, `.eslintrc*`, `vitest.config.*`, etc.
+- Return: dependency list (separate runtime vs peer), available scripts, package manager, configs found
+
+**Agent C — Examples & Usage Patterns**
+- Search for `examples/` or `__examples__/` directory
+- Read test files (`*.test.ts`, `*.spec.ts`) for usage patterns
+- Extract JSDoc `@example` blocks from source files
+- Look for inline comments showing usage
+- Return: example file paths, extracted usage patterns from tests, JSDoc examples
+
+**Agent D — Documentation Context** *(optional, runs concurrently)*
+- Check for existing README.md
+- Look for CHANGELOG.md, CONTRIBUTING.md, LICENSE
+- Check for TypeDoc/JSDoc configuration
+- Return: existing doc files and their key sections
+
+**After all agents complete:** merge findings and identify documentation gaps (what exists in code but not in README, what's documented but doesn't exist, signature mismatches)
 
 ### Step 3: Compare Against Existing README
 


### PR DESCRIPTION
Update the two onboard-* skills and the readme writer to utilize parallel sub-agents while performing discovery. And add readme's to the ones missing them.