### PR TITLE
fix: improve handling of regex in url expectations

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/tests/fixtures/golden-file-test.expected.txt
+++ b/skills/accelint-ac-to-playwright/scripts/tests/fixtures/golden-file-test.expected.txt
@@ -43,7 +43,7 @@ test.describe("Golden file test", {
 
     tracker.setStep(4);
     try {
-      await expect(page).toHaveURL(/dashboard/);
+      await expect(page).toHaveURL(/\/dashboard(?:\/(?:[?#]|$)|[?#]|$)/);
     } catch (error) {
       await attachFailureArtifacts({ page, testInfo, stepIndex: 4, action: "expectUrl" });
       throw error;

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
@@ -135,7 +135,7 @@ describe("renderStep", () => {
       { action: "expectUrl", value: "dashboard" },
       1,
       [
-        "await expect(page).toHaveURL(/dashboard/);",
+        "await expect(page).toHaveURL(/\\/dashboard(?:\\/(?:[?#]|$)|[?#]|$)/);",
         'attachFailureArtifacts({ page, testInfo, stepIndex: 1, action: "expectUrl" })'
       ],
     ],

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.to-regex-literal.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.to-regex-literal.test.ts
@@ -2,39 +2,90 @@ import { describe, expect, it } from "vitest";
 import { _toRegexLiteral } from "../translate-plan-to-tests";
 
 describe("_toRegexLiteral", () => {
-  it("wraps the pattern in forward slashes", () => {
-    expect(_toRegexLiteral("dashboard")).toBe("/dashboard/");
+  it("adds leading slash and path terminator", () => {
+    expect(_toRegexLiteral("dashboard")).toBe("/\\/dashboard(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes forward slashes in the pattern", () => {
-    expect(_toRegexLiteral("foo/bar")).toBe("/foo\\/bar/");
+    expect(_toRegexLiteral("foo/bar")).toBe("/\\/foo\\/bar(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes multiple forward slashes", () => {
-    expect(_toRegexLiteral("a/b/c")).toBe("/a\\/b\\/c/");
+    expect(_toRegexLiteral("a/b/c")).toBe("/\\/a\\/b\\/c(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes regex metacharacters", () => {
-    expect(_toRegexLiteral("a.b?")).toBe("/a\\.b\\?/");
+    expect(_toRegexLiteral("a.b?")).toBe("/\\/a\\.b\\?(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes backslashes", () => {
-    expect(_toRegexLiteral("foo\\bar")).toBe("/foo\\\\bar/");
+    expect(_toRegexLiteral("foo\\bar")).toBe("/\\/foo\\\\bar(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes backslashes before forward slashes", () => {
-    expect(_toRegexLiteral("C:\\path\\to\\file")).toBe("/C:\\\\path\\\\to\\\\file/");
+    expect(_toRegexLiteral("C:\\path\\to\\file")).toBe("/\\/C:\\\\path\\\\to\\\\file(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes all special regex characters", () => {
-    expect(_toRegexLiteral("^$.*+?()[]{}|")).toBe("/\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|/");
+    expect(_toRegexLiteral("^$.*+?()[]{}|")).toBe("/\\/\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("escapes combination of metacharacters and slashes", () => {
-    expect(_toRegexLiteral("https://example.com/*")).toBe("/https:\\/\\/example\\.com\\/\\*/");
+    expect(_toRegexLiteral("https://example.com/*")).toBe("/\\/https:\\/\\/example\\.com\\/\\*(?:\\/(?:[?#]|$)|[?#]|$)/");
   });
 
   it("handles empty pattern", () => {
-    expect(_toRegexLiteral("")).toBe("//");
+    expect(_toRegexLiteral("")).toBe("/\\/(?:\\/(?:[?#]|$)|[?#]|$)/");
+  });
+
+  it("handles single slash to match only root path", () => {
+    expect(_toRegexLiteral("/")).toBe("/\\/(?:\\/(?:[?#]|$)|[?#]|$)/");
+  });
+
+  it("preserves leading slash when already present", () => {
+    expect(_toRegexLiteral("/dashboard")).toBe("/\\/dashboard(?:\\/(?:[?#]|$)|[?#]|$)/");
+  });
+});
+
+describe("_toRegexLiteral URL matching behavior", () => {
+  // Helper to convert the regex literal string (with wrapping slashes) to a RegExp
+  function toRegExp(pattern: string): RegExp {
+    const regexLiteral = _toRegexLiteral(pattern);
+    // Strip the wrapping /.../ from the literal to get the pattern
+    const regexPattern = regexLiteral.slice(1, -1);
+    return new RegExp(regexPattern);
+  }
+
+  it("matches dashboard path with various endings", () => {
+    const regex = toRegExp("dashboard");
+
+    // Should match
+    expect(regex.test("http://localhost:3000/dashboard")).toBe(true);
+    expect(regex.test("http://localhost:3000/dashboard/")).toBe(true);
+    expect(regex.test("http://localhost:3000/dashboard?tab=settings")).toBe(true);
+    expect(regex.test("http://localhost:3000/dashboard#section")).toBe(true);
+
+    // Should NOT match
+    expect(regex.test("http://localhost:3000/dashboard/edit")).toBe(false);
+    expect(regex.test("http://localhost:3000/home?prevloc=dashboard")).toBe(false);
+    expect(regex.test("http://localhost:3000/settings#dashboard")).toBe(false);
+  });
+
+  it("matches root path correctly", () => {
+    const regex = toRegExp("/");
+
+    expect(regex.test("http://localhost:3000/")).toBe(true);
+    expect(regex.test("http://localhost:3000/?x=1")).toBe(true);
+    expect(regex.test("http://localhost:3000/#top")).toBe(true);
+    expect(regex.test("http://localhost:3000/dashboard")).toBe(false);
+  });
+
+  it("matches nested paths without matching deeper paths", () => {
+    const regex = toRegExp("/settings/profile");
+
+    expect(regex.test("http://localhost:3000/settings/profile")).toBe(true);
+    expect(regex.test("http://localhost:3000/settings/profile/")).toBe(true);
+    expect(regex.test("http://localhost:3000/settings/profile?edit=true")).toBe(true);
+    expect(regex.test("http://localhost:3000/settings/profile/edit")).toBe(false);
   });
 });

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-single-plan.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-single-plan.test.ts
@@ -57,7 +57,7 @@ describe("_translateSingleTest", () => {
     const out = _translateSingleTest(testInput);
 
     const first = out.indexOf(`await page.goto("/one");`);
-    const second = out.indexOf(`toHaveURL(/one/);`);
+    const second = out.indexOf(`toHaveURL(/\\/one(?:\\/(?:[?#]|$)|[?#]|$)/);`);
 
     expect(first).toBeGreaterThan(-1);
     expect(second).toBeGreaterThan(-1);

--- a/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
@@ -224,12 +224,20 @@ function joinOutDir(outDir: string, filename: string): string {
   return `${trimmed}${separator}${filename}`;
 }
 
-// Converts a string to a regex literal, escaping all special regex characters
+// Converts a string to a regex literal that matches the path portion of a URL
   function toRegexLiteral(pattern: string): string {
-    const escaped = pattern
+    // Normalize: add leading slash if missing
+    const normalized = pattern.startsWith('/') ? pattern : `/${pattern}`;
+
+    // Escape special regex characters
+    const escaped = normalized
       .replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")  // Escape all regex metacharacters
       .replace(/\//g, "\\/");                  // Also escape forward slashes for the literal
-    return `/${escaped}/`;
+
+    // Match the path, optionally followed by trailing slash (but not more path segments), query params, or hash
+    // The pattern ensures /dashboard matches /dashboard, /dashboard/, /dashboard?x, /dashboard#x
+    // but NOT /dashboard/edit or URLs where dashboard appears in query/hash
+    return `/${escaped}(?:\\/(?:[?#]|$)|[?#]|$)/`;
   }
 
 // Outputs tags in the correct format for Playwright


### PR DESCRIPTION
Fixed a bug where `expectUrl('/')` would match every URL (since all URLs contain a slash). The regex now properly matches the path portion of URLs without false positives.

### What changed
Updated `toRegexLiteral()` to generate path-specific regex patterns.

Auto-adds leading `/` if missing (so `expectUrl("dashboard")` and `expectUrl("/dashboard")` behave the same). The pattern now matches the path segment followed by optional trailing slash, query params, or anchor.

### Matching behavior
Matches:
- http://localhost:3000/dashboard
- http://localhost:3000/dashboard/ (trailing slash OK)
- http://localhost:3000/dashboard?tab=settings (query params OK)
- http://localhost:3000/dashboard#section (anchor OK)

Doesn't match:
- http://localhost:3000/dashboard/edit (deeper paths)
- http://localhost:3000/home?prevloc=dashboard (in query param)
- http://localhost:3000/settings#dashboard (in anchor)