### PR TITLE
Add validation to enforce `@` prefix on tags

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.2"
+  version: "1.0.3"
 ---
 
 # AC To Playwright
@@ -191,6 +191,7 @@ Use `npx validate-plan path/to/plan.json` to validate a plan against `references
 |------------|---------------------|---------------|--------------|
 | **Schema validation fails** | What field does error message name? | Wrong field order, missing required field, extra field not in schema, incorrect field type | Check schema for exact field names and order; compare your JSON structure to schema requirements |
 | **Target naming invalid** | Does target match `area.component.intent`? | Wrong pattern structure, invalid keywords from controlled lists, missing dots | Review `test-hooks.md` for controlled vocabulary (area: nav/header/footer/etc, component: button/link/input/etc); use fallback keywords (last in each list) if AC term doesn't match |
+| **Tag validation fails** | Does error mention "Tags must start with '@'"? | Tags missing @ prefix in generated JSON | Review AC source: Gherkin tags should include @ (e.g., `@smoke` not `smoke`). If AC has @ but JSON doesn't, check JSON generation logic |
 | **Translation script errors** | Which action/assertion caused failure? | Unsupported action type, malformed target selector, missing required field in step | Verify action is in allowed list (click/fill/select); check target has all three parts; ensure step has target and any required fields (e.g., fill needs value) |
 | **Validation passes but tests fail** | Do test hooks match actual page elements? | Target selectors don't match DOM, wrong start URL, timing issues | Ask user to verify page structure matches expected targets; check if startUrl needs adjustment; consider if dynamic content needs wait conditions |
 | **Multiple validation failures after fixes** | Did first fix break something else? | Making multiple speculative changes, misunderstanding schema requirements | Stop after 2 attempts; report specific schema violations to user; ask if AC has ambiguities or if schema has changed |

--- a/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
+++ b/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { modifierKeyValidator, pressKeyValidator } from "./keyboard-key-validator";
 import { mouseButtonValidator, wheelDirectionValidator } from "./mouse-validator";
+import { tagValidator } from "./tag-validator";
 
 /**
  * Step schemas
@@ -146,7 +147,7 @@ export const stepSchema = z.discriminatedUnion("action", [
 export const testSchema = z.object({
   name: z.string(),
   startUrl: z.string(),
-  tags: z.array(z.string()).min(1).optional(),
+  tags: z.array(tagValidator).min(1).optional(),
   steps: z.array(stepSchema).min(1),
 }).superRefine((test, ctx) => {
   let unpairedMouseDown: { index: number; button: string } | null = null;
@@ -316,7 +317,7 @@ export const testSchema = z.object({
 
 export const testSuiteSchema = z.object({
   suiteName: z.string(),
-  tags: z.array(z.string()).min(1).optional(),
+  tags: z.array(tagValidator).min(1).optional(),
   source: z.object({
     repo: z.string(),
     path: z.string(),

--- a/skills/accelint-ac-to-playwright/scripts/tag-validator.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tag-validator.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+/**
+ * Zod validator for tag strings - ensures tags start with '@'
+ */
+export const tagValidator = z.string().refine(
+  (tag) => tag.startsWith('@'),
+  { message: "Tags must start with '@'" }
+);

--- a/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
@@ -1333,10 +1333,52 @@ describe("Suite-specific tags", () => {
         },
       ],
     };
-  
+
     const result = testSuiteSchema.safeParse(input);
     expect(result.success).toBe(false);
-  });  
+  });
+
+  it("rejects tags without @ prefix", () => {
+    const input = {
+      suiteName: "Basic suite",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tags: ["smoke"],
+      tests: [
+        {
+          name: "Basic test",
+          startUrl: "https://example.com",
+          steps: [{ action: "expectUrl", value: "https://example.com" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("Tags must start with '@'");
+    }
+  });
+
+  it("rejects tags with mixed @ prefix presence", () => {
+    const input = {
+      suiteName: "Basic suite",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tags: ["@smoke", "wip"],
+      tests: [
+        {
+          name: "Basic test",
+          startUrl: "https://example.com",
+          steps: [{ action: "expectUrl", value: "https://example.com" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("Tags must start with '@'");
+    }
+  });
 });
 
 
@@ -1408,10 +1450,52 @@ describe("Test-specific tags", () => {
         },
       ],
     };
-  
+
     const result = testSuiteSchema.safeParse(input);
     expect(result.success).toBe(false);
-  });  
+  });
+
+  it("rejects tags without @ prefix", () => {
+    const input = {
+      suiteName: "Basic suite",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Basic test",
+          startUrl: "https://example.com",
+          tags: ["smoke"],
+          steps: [{ action: "expectUrl", value: "https://example.com" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("Tags must start with '@'");
+    }
+  });
+
+  it("rejects tags with mixed @ prefix presence", () => {
+    const input = {
+      suiteName: "Basic suite",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Basic test",
+          startUrl: "https://example.com",
+          tags: ["@smoke", "wip"],
+          steps: [{ action: "expectUrl", value: "https://example.com" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("Tags must start with '@'");
+    }
+  });
 });
 
 // Helper functions


### PR DESCRIPTION
Tags in Gherkin files are supposed to start with `@`, but the schema wasn't enforcing it. Now it does.