### PR TITLE
Add schema validation for target field structure

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/references/target-vocabulary.ts
+++ b/skills/accelint-ac-to-playwright/references/target-vocabulary.ts
@@ -1,0 +1,33 @@
+/**
+ * Controlled vocabulary for target area keywords.
+ * Last item in array is the fallback when no specific area matches.
+ */
+export const areaKeywords = [
+  "nav",
+  "header",
+  "footer",
+  "form",
+  "drawer",
+  "card",
+  "toast",
+  "modal",
+  "table",
+  "page",
+  "area",
+] as const;
+
+/**
+ * Controlled vocabulary for target component keywords.
+ * Last item in array is the fallback when no specific component matches.
+ */
+export const componentKeywords = [
+  "button",
+  "link",
+  "input",
+  "dropdown",
+  "checkbox",
+  "radio",
+  "text",
+  "div",
+  "component",
+] as const;

--- a/skills/accelint-ac-to-playwright/references/test-hooks.md
+++ b/skills/accelint-ac-to-playwright/references/test-hooks.md
@@ -1,8 +1,8 @@
 # Target conventions
 The pattern `<area>.<component>.<intent>` is used for `target` values. 
 
-- area (controlled list): `nav`, `header`, `footer`, `form`, `drawer`, `card`, `toast`, `modal`, `table`, `page`, `area`
-- component (controlled list): `button`, `link`, `input`, `dropdown`, `checkbox`, `radio`, `text`, `div`, `component`
+- area (controlled list): see `target-vocabulary.ts` for the canonical list
+- component (controlled list): see `target-vocabulary.ts` for the canonical list
 - intent: noun, lowercase, multi‑word joined with dashes (no verbs)
 
 Area and component selection rules:

--- a/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
+++ b/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
@@ -2,13 +2,14 @@ import { z } from "zod";
 import { modifierKeyValidator, pressKeyValidator } from "./keyboard-key-validator";
 import { mouseButtonValidator, wheelDirectionValidator } from "./mouse-validator";
 import { tagValidator } from "./tag-validator";
+import { targetValidator } from "./target-validator";
 
 /**
  * Step schemas
  */
 const clickStep = z.object({
   action: z.literal("click"),
-  target: z.string(),
+  target: targetValidator,
 }).strict();
 
 const doubleClickStep = z.object({
@@ -29,12 +30,12 @@ const dragStep = z.object({
 
 const expectNotVisibleStep = z.object({
   action: z.literal("expectNotVisible"),
-  target: z.string(),
+  target: targetValidator,
 }).strict();
 
 const expectTextStep = z.object({
   action: z.literal("expectText"),
-  target: z.string(),
+  target: targetValidator,
   value: z.string(),
 }).strict();
 
@@ -45,12 +46,12 @@ const expectUrlStep = z.object({
 
 const expectVisibleStep = z.object({
   action: z.literal("expectVisible"),
-  target: z.string(),
+  target: targetValidator,
 }).strict();
 
 const fillStep = z.object({
   action: z.literal("fill"),
-  target: z.string(),
+  target: targetValidator,
   value: z.string(),
 }).strict();
 
@@ -61,7 +62,7 @@ const gotoStep = z.object({
 
 const hoverStep = z.object({
   action: z.literal("hover"),
-  target: z.string(),
+  target: targetValidator,
 }).strict();
 
 const keyDownStep = z.object({
@@ -114,7 +115,7 @@ const scrollStep = z.object({
 
 const selectStep = z.object({
   action: z.literal("select"),
-  target: z.string(),
+  target: targetValidator,
   value: z.string(),
 }).strict();
 

--- a/skills/accelint-ac-to-playwright/scripts/target-validator.ts
+++ b/skills/accelint-ac-to-playwright/scripts/target-validator.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { areaKeywords, componentKeywords } from "../references/target-vocabulary";
+
+/**
+ * Zod validator for target strings - enforces area.component.intent pattern
+ */
+export const targetValidator = z.string().superRefine((target, ctx) => {
+  const parts = target.split(".");
+
+  // Check structure first
+  if (parts.length !== 3) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Target must follow area.component.intent pattern with exactly two dots"
+    });
+    return;
+  }
+
+  const [area, component, intent] = parts;
+
+  // Check area vocabulary
+  if (!areaKeywords.includes(area as typeof areaKeywords[number])) {
+    ctx.addIssue({
+      code: "custom",
+      message: `Invalid area keyword. Must be one of: ${areaKeywords.join(", ")}`
+    });
+    return;
+  }
+
+  // Check component vocabulary
+  if (!componentKeywords.includes(component as typeof componentKeywords[number])) {
+    ctx.addIssue({
+      code: "custom",
+      message: `Invalid component keyword. Must be one of: ${componentKeywords.join(", ")}`
+    });
+    return;
+  }
+
+  // Check intent format
+  if (!intent) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Target intent cannot be empty"
+    });
+    return;
+  }
+
+  if (!/^[a-z]+(-[a-z]+)*$/.test(intent)) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Intent must be lowercase letters only, multi-word joined with dashes (no spaces, underscores, or uppercase)"
+    });
+    return;
+  }
+});

--- a/skills/accelint-ac-to-playwright/scripts/tests/append-json-summary-entry.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/append-json-summary-entry.test.ts
@@ -201,7 +201,7 @@ describe("run()", () => {
     const validPlan = JSON.stringify({
       suiteName: "Suite",
       source: { repo: "some-repo", path: "path/to/ac.feature" },
-      tests: [{ name: "Test A", startUrl: "/", steps: [{ action: "click", target: "a" }] }],
+      tests: [{ name: "Test A", startUrl: "/", steps: [{ action: "click", target: "page.button.submit" }] }],
     });
 
     const { runtime, errors } = makeAppendRuntime({
@@ -250,9 +250,9 @@ describe("run()", () => {
           name: "Test A",
           startUrl: "/",
           steps: [
-            { action: "click", target: "login-button" },
+            { action: "click", target: "form.button.login" },
             { action: "expectUrl", value: "/home" },
-            { action: "fill", target: "email-input", value: "a@b.com" },
+            { action: "fill", target: "form.input.email", value: "a@b.com" },
           ],
         },
       ],
@@ -306,8 +306,8 @@ describe("run()", () => {
     expect(parsed.entries[0].outputs.plan).toBe(planPath);
     expect(parsed.entries[0].outputs.test).toBe(testPath);
     expect(parsed.entries[0].tests[0].requiredTestHooks).toEqual([
-      "login-button",
-      "email-input",
+      "form.button.login",
+      "form.input.email",
     ]);
   });
 
@@ -335,7 +335,7 @@ describe("run()", () => {
         {
           name: "Test A",
           startUrl: "/",
-          steps: [{ action: "click", target: "login-button" }],
+          steps: [{ action: "click", target: "form.button.login" }],
         },
       ],
     });

--- a/skills/accelint-ac-to-playwright/scripts/tests/fixtures/all-actions.json
+++ b/skills/accelint-ac-to-playwright/scripts/tests/fixtures/all-actions.json
@@ -12,17 +12,17 @@
         },
         {
           "action": "fill",
-          "target": "username",
+          "target": "form.input.username",
           "value": "someone"
         },
         {
           "action": "fill",
-          "target": "password",
+          "target": "form.input.password",
           "value": "password123"
         },
         {
           "action": "select",
-          "target": "dropdown.role",
+          "target": "form.dropdown.role",
           "value": "admin"
         },
         {
@@ -39,7 +39,7 @@
         },
         {
           "action": "click",
-          "target": "button.login"
+          "target": "form.button.login"
         },
         {
           "action": "doubleClick",
@@ -79,31 +79,31 @@
         },
         {
           "action": "expectNotVisible",
-          "target": "banner.welcome"
+          "target": "page.div.welcome"
         },
         {
           "action": "click",
-          "target": "button.show-welcome"
+          "target": "page.button.show-welcome"
         },
         {
           "action": "expectVisible",
-          "target": "banner.welcome"
+          "target": "page.div.welcome"
         },
         {
           "action": "expectVisible",
-          "target": "banner.error"
+          "target": "page.div.error"
         },
         {
           "action": "click",
-          "target": "button.hide-error"
+          "target": "page.button.hide-error"
         },
         {
           "action": "expectNotVisible",
-          "target": "banner.error"
+          "target": "page.div.error"
         },
         {
           "action": "expectText",
-          "target": "banner.welcome",
+          "target": "page.div.welcome",
           "value": "Welcome!"
         }
       ]

--- a/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
@@ -963,9 +963,9 @@ describe("visibility pairing validation", () => {
           name: "Show element",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "modal.dialog" },
-            { action: "click", target: "button.open" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "expectNotVisible", target: "modal.div.dialog" },
+            { action: "click", target: "modal.button.open" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
       ],
@@ -984,9 +984,9 @@ describe("visibility pairing validation", () => {
           name: "Hide element",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectVisible", target: "panel.settings" },
+            { action: "expectVisible", target: "page.div.settings" },
             { action: "press", value: "Escape" },
-            { action: "expectNotVisible", target: "panel.settings" },
+            { action: "expectNotVisible", target: "page.div.settings" },
           ],
         },
       ],
@@ -1005,12 +1005,12 @@ describe("visibility pairing validation", () => {
           name: "Multiple pairs",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "panel.layers" },
-            { action: "click", target: "button.layers" },
-            { action: "expectVisible", target: "panel.layers" },
-            { action: "expectVisible", target: "panel.properties" },
-            { action: "click", target: "button.properties" },
-            { action: "expectNotVisible", target: "panel.properties" },
+            { action: "expectNotVisible", target: "page.div.layers" },
+            { action: "click", target: "page.button.layers" },
+            { action: "expectVisible", target: "page.div.layers" },
+            { action: "expectVisible", target: "page.div.properties" },
+            { action: "click", target: "page.button.properties" },
+            { action: "expectNotVisible", target: "page.div.properties" },
           ],
         },
       ],
@@ -1029,8 +1029,8 @@ describe("visibility pairing validation", () => {
           name: "Unpaired visible",
           startUrl: "https://example.com",
           steps: [
-            { action: "click", target: "button.show" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "click", target: "page.button.show" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
       ],
@@ -1056,8 +1056,8 @@ describe("visibility pairing validation", () => {
           name: "Unpaired not visible",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "panel.info" },
-            { action: "click", target: "button.hide" },
+            { action: "expectNotVisible", target: "page.div.info" },
+            { action: "click", target: "page.button.hide" },
           ],
         },
       ],
@@ -1083,8 +1083,8 @@ describe("visibility pairing validation", () => {
           name: "No action between",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "modal.dialog" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "expectNotVisible", target: "modal.div.dialog" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
       ],
@@ -1109,10 +1109,10 @@ describe("visibility pairing validation", () => {
           name: "Multiple actions between",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "modal.dialog" },
-            { action: "click", target: "button.open" },
-            { action: "fill", target: "input.name", value: "test" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "expectNotVisible", target: "modal.div.dialog" },
+            { action: "click", target: "modal.button.open" },
+            { action: "fill", target: "form.input.name", value: "test" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
       ],
@@ -1138,9 +1138,9 @@ describe("visibility pairing validation", () => {
           name: "Mismatched targets",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "panel.layers" },
-            { action: "click", target: "button.show" },
-            { action: "expectVisible", target: "panel.properties" },
+            { action: "expectNotVisible", target: "page.div.layers" },
+            { action: "click", target: "page.button.show" },
+            { action: "expectVisible", target: "page.div.properties" },
           ],
         },
       ],
@@ -1165,9 +1165,9 @@ describe("visibility pairing validation", () => {
           name: "Assertion between",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "modal.dialog" },
+            { action: "expectNotVisible", target: "modal.div.dialog" },
             { action: "expectText", target: "header.title", value: "Welcome" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
       ],
@@ -1194,16 +1194,16 @@ describe("visibility pairing validation", () => {
           name: "Test 1 - valid",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectNotVisible", target: "modal.dialog" },
-            { action: "click", target: "button.open" },
-            { action: "expectVisible", target: "modal.dialog" },
+            { action: "expectNotVisible", target: "modal.div.dialog" },
+            { action: "click", target: "modal.button.open" },
+            { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
         {
           name: "Test 2 - invalid",
           startUrl: "https://example.com",
           steps: [
-            { action: "expectVisible", target: "panel.info" },
+            { action: "expectVisible", target: "page.div.info" },
           ],
         },
       ],
@@ -1495,6 +1495,222 @@ describe("Test-specific tags", () => {
     if (!result.success) {
       expect(result.error.issues[0].message).toContain("Tags must start with '@'");
     }
+  });
+});
+
+describe("Target field validation", () => {
+  it("rejects target with no dots", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "navbuttonsubmit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("area.component.intent");
+    }
+  });
+
+  it("rejects target with only one dot", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.buttonsubmit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("area.component.intent");
+    }
+  });
+
+  it("rejects target with three or more dots", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.header.button.submit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("area.component.intent");
+    }
+  });
+
+  it("rejects target with invalid area keyword", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "invalidarea.button.submit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("area");
+    }
+  });
+
+  it("rejects target with invalid component keyword", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.invalidcomponent.settings" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("component");
+    }
+  });
+
+  it("rejects target with empty intent", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.button." }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("intent");
+    }
+  });
+
+  it("rejects target with uppercase in intent", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.button.Submit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("lowercase");
+    }
+  });
+
+  it("rejects target with spaces in intent", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.button.log in" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("dash");
+    }
+  });
+
+  it("rejects target with underscores in intent", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with invalid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.button.log_in" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("dash");
+    }
+  });
+
+  it("accepts valid single-word intent", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with valid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "click", target: "nav.button.submit" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid multi-word intent with dashes", () => {
+    const input = {
+      suiteName: "Target test",
+      source: { "repo": "some-repo", "path": "path/to/file.md" },
+      tests: [
+        {
+          name: "Test with valid target",
+          startUrl: "https://example.com",
+          steps: [{ action: "fill", target: "form.input.email-address", value: "test@example.com" }],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
Enforces the area.component.intent pattern with controlled vocabulary validation at the schema level. I created single source of truth for area/component keywords in `target-vocabulary.ts`.