### PR TITLE
Expand accepted keyboard keys to include some numpad ones

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/keyboard-key-validator.ts
+++ b/skills/accelint-ac-to-playwright/scripts/keyboard-key-validator.ts
@@ -35,6 +35,20 @@ export const validPlaywrightKeys = [
   "Shift",
   "Control",
   "Alt",
+  "Numpad0",
+  "Numpad1",
+  "Numpad2",
+  "Numpad3",
+  "Numpad4",
+  "Numpad5",
+  "Numpad6",
+  "Numpad7",
+  "Numpad8",
+  "Numpad9",
+  "NumpadAdd",
+  "NumpadSubtract",
+  "NumpadDecimal",
+  "NumpadEnter",
 ] as const;
 
 /**


### PR DESCRIPTION
Adds support for numpad keyboard keys with 14 new key names.

In talking with PMs, operators use these numpad keys:
- Numbers (Numpad0-9)
- Plus and minus (NumpadAdd, NumpadSubtract)
- Period and enter (NumpadDecimal, NumpadEnter)

It sounded like they don't use the multiply or divide signs so I didn't include those, but they can be added later if there's a usecase. I also did not add numlock at this time.