### PR TITLE
Support case-insensitive keyboard key names

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.5"
+  version: "1.0.6"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/keyboard-key-validator.ts
+++ b/skills/accelint-ac-to-playwright/scripts/keyboard-key-validator.ts
@@ -60,21 +60,35 @@ const unmodifiedCharacters = "abcdefghijklmnopqrstuvwxyz0123456789`-=[]\\;',./";
  * Zod validator for keyboard keys for presses
  * Accepts either:
  * - A single unmodified character (no Shift required on US keyboard)
- * - A valid Playwright key name from the list above
+ * - A valid Playwright key name from the list above (case-insensitive)
  */
-export const pressKeyValidator = z.string().refine(
-  (val): val is string => {
-    // Allow single unmodified characters only
-    if (val.length === 1) {
-      return unmodifiedCharacters.includes(val);
+export const pressKeyValidator = z.string().transform((val, ctx) => {
+  // Single characters must match exactly (case-sensitive)
+  if (val.length === 1) {
+    if (unmodifiedCharacters.includes(val)) {
+      return val;
     }
-    // Allow named Playwright keys
-    return (validPlaywrightKeys as readonly string[]).includes(val);
-  },
-  {
-    message: "Key must be a single unmodified character (a-z, 0-9, or symbols that don't require Shift) or a valid Playwright key name (e.g., Enter, Tab, Escape, Space, ArrowLeft, F1, etc.).",
+    ctx.addIssue({
+      code: "custom",
+      message: "Key must be a single unmodified character (a-z, 0-9, or symbols that don't require Shift) or a valid Playwright key name (e.g., Enter, Tab, Escape, Space, ArrowLeft, F1, etc.).",
+    });
+    return z.NEVER;
   }
-);
+
+  // Named keys: case-insensitive lookup, return canonical casing
+  const lowerInput = val.toLowerCase();
+  const matchedKey = validPlaywrightKeys.find(k => k.toLowerCase() === lowerInput);
+
+  if (matchedKey) {
+    return matchedKey;
+  }
+
+  ctx.addIssue({
+    code: "custom",
+    message: "Key must be a single unmodified character (a-z, 0-9, or symbols that don't require Shift) or a valid Playwright key name (e.g., Enter, Tab, Escape, Space, ArrowLeft, F1, etc.).",
+  });
+  return z.NEVER;
+});
 
 /**
  * Valid modifier keys for the application under test
@@ -84,13 +98,20 @@ export const validModifierKeys = ["Shift", "Control", "a"] as const;
 
 /**
  * Zod validator for modifier keys (keyDown/keyUp actions)
- * Only accepts the specific modifier keys used by the application under test
+ * Only accepts the specific modifier keys used by the application under test (case-insensitive)
  */
-export const modifierKeyValidator = z.string().refine(
-  (val): val is string => {
-    return (validModifierKeys as readonly string[]).includes(val);
-  },
-  {
-    message: 'Key must be one of the valid modifier keys for this application: "Shift", "Control", or "a".',
+export const modifierKeyValidator = z.string().transform((val, ctx) => {
+  // Case-insensitive lookup, return canonical casing
+  const lowerInput = val.toLowerCase();
+  const matchedKey = validModifierKeys.find(k => k.toLowerCase() === lowerInput);
+
+  if (matchedKey) {
+    return matchedKey;
   }
-);
+
+  ctx.addIssue({
+    code: "custom",
+    message: 'Key must be one of the valid modifier keys for this application: "Shift", "Control", or "a".',
+  });
+  return z.NEVER;
+});

--- a/skills/accelint-ac-to-playwright/scripts/tests/keyboard-key-validator.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/keyboard-key-validator.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { modifierKeyValidator, pressKeyValidator } from "../keyboard-key-validator";
+
+describe("pressKeyValidator", () => {
+  describe("single characters", () => {
+    it("accepts lowercase letters", () => {
+      const result = pressKeyValidator.safeParse("a");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("a");
+      }
+    });
+
+    it("accepts digits", () => {
+      const result = pressKeyValidator.safeParse("5");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("5");
+      }
+    });
+
+    it("accepts unmodified symbols", () => {
+      const result = pressKeyValidator.safeParse("-");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("-");
+      }
+    });
+
+    it("rejects uppercase letters (require Shift)", () => {
+      const result = pressKeyValidator.safeParse("A");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects symbols that require Shift", () => {
+      const result = pressKeyValidator.safeParse("+");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("named keys - case sensitivity", () => {
+    it("accepts properly-cased key names", () => {
+      const result = pressKeyValidator.safeParse("Enter");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("Enter");
+      }
+    });
+
+    it("accepts lowercase key names and normalizes to proper case", () => {
+      const result = pressKeyValidator.safeParse("enter");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("Enter");
+      }
+    });
+  });
+
+  describe("named keys - various key types", () => {
+    it("accepts arrow keys with case normalization", () => {
+      const result = pressKeyValidator.safeParse("arrowleft");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("ArrowLeft");
+      }
+    });
+
+    it("accepts function keys with case normalization", () => {
+      const result = pressKeyValidator.safeParse("f12");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("F12");
+      }
+    });
+
+    it("accepts tab key with case normalization", () => {
+      const result = pressKeyValidator.safeParse("TAB");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("Tab");
+      }
+    });
+  });
+
+  describe("invalid keys", () => {
+    it("rejects invalid key names", () => {
+      const result = pressKeyValidator.safeParse("InvalidKey");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty strings", () => {
+      const result = pressKeyValidator.safeParse("");
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("modifierKeyValidator", () => {
+  describe("case sensitivity", () => {
+    it("accepts properly-cased modifier keys", () => {
+      const result = modifierKeyValidator.safeParse("Shift");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("Shift");
+      }
+    });
+
+    it("accepts lowercase modifier keys and normalizes to proper case", () => {
+      const result = modifierKeyValidator.safeParse("control");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("Control");
+      }
+    });
+  });
+
+  describe("app-specific modifier 'a'", () => {
+    it("accepts lowercase 'a'", () => {
+      const result = modifierKeyValidator.safeParse("a");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("a");
+      }
+    });
+
+    it("accepts uppercase 'A' and normalizes to lowercase", () => {
+      const result = modifierKeyValidator.safeParse("A");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe("a");
+      }
+    });
+  });
+
+  describe("invalid modifiers", () => {
+    it("rejects non-modifier keys", () => {
+      const result = modifierKeyValidator.safeParse("Enter");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects invalid modifier names", () => {
+      const result = modifierKeyValidator.safeParse("Alt");
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty strings", () => {
+      const result = modifierKeyValidator.safeParse("");
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
The skill will now accept case-insensitive keyboard key names and normalize them to proper Playwright casing.

For example, AC writers can use "enter", "ENTER", or "Enter" and all will be converted to the correct "Enter" format in generated tests. Applies to both press actions and modifier keys (keyDown/keyUp).
