### PR TITLE
Extract shared test fixtures to eliminate duplication

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.6"
+  version: "1.1.0"
 ---
 
 # AC To Playwright
@@ -84,7 +84,9 @@ Assessment mode analyzes AC text only (no artifact generation). Full conversion 
   -  Append a summary entry to the batch JSON file in the user-specified summary directory (one batch file per run).
 5. **Next steps**: 
   - Work on the next input file, if any remain.
-  - After all files are processed, ask the user if they would like a Playwright config template. If yes, copy `skills/accelint-ac-to-playwright/assets/templates/playwright.config.ts` into the user‑specified summaries location.
+  - After all files are processed:
+    - Copy `skills/accelint-ac-to-playwright/assets/fixtures/` directory to `<tests-output-dir>/fixtures/`. This directory contains shared test utilities (`error-handling.ts` and `console-tracking.ts`) that generated tests import from.
+    - Ask the user if they would like a Playwright config template. If yes, copy `skills/accelint-ac-to-playwright/assets/templates/playwright.config.ts` into the user‑specified summaries location.
 
 ## Recognition Patterns
 Before processing AC, identify these quality signals:
@@ -108,6 +110,14 @@ The above table directs you to ask for clarifications because guessing creates t
 **Input to output mapping**: One AC file → one suite → one plan file (`<plans-dir>/<suite-slug>.json`) → one test file
 - `.md` bullet-style: each `- ` bullet = one test
 - `.feature` Gherkin: each Scenario = one test; each Examples row in Scenario Outline = one test
+
+**Output structure**: After conversion completes, the test output directory will contain:
+- `<suite-slug>.spec.ts` files (one per AC file)
+- `fixtures/` directory with shared utilities:
+  - `fixtures/error-handling.ts` - failure artifact attachment helper
+  - `fixtures/console-tracking.ts` - console message tracking helper
+
+**Important for users**: When copying generated tests to your Playwright project, copy both the `.spec.ts` files AND the `fixtures/` directory. Tests import from these fixtures and will fail to compile without them.
 
 | Input | Suite Name | Test Name | Output Slug |
 |-------|------------|-----------|-------------|

--- a/skills/accelint-ac-to-playwright/assets/fixtures/console-tracking.ts
+++ b/skills/accelint-ac-to-playwright/assets/fixtures/console-tracking.ts
@@ -1,0 +1,32 @@
+import type { ConsoleMessage, Page, TestInfo } from "@playwright/test";
+
+export async function setupConsoleTracking(args: {
+  page: Page;
+  testInfo: TestInfo;
+}) {
+  const { page, testInfo } = args;
+  const consoleMessages: Array<{ type: string; text: string; stepIndex: number; timestamp: string; location: { url: string; lineNumber?: number; columnNumber?: number } }> = [];
+  let currentStep = 0;
+
+  page.on('console', (msg: ConsoleMessage) => {
+    consoleMessages.push({
+      type: msg.type(),
+      text: msg.text(),
+      stepIndex: currentStep,
+      timestamp: new Date().toISOString(),
+      location: msg.location()
+    });
+  });
+
+  return {
+    setStep: (step: number) => { currentStep = step; },
+    attachMessages: async () => {
+      if (consoleMessages.length > 0) {
+        await testInfo.attach('console-messages', {
+          contentType: 'application/json',
+          body: Buffer.from(JSON.stringify(consoleMessages, null, 2), 'utf8')
+        });
+      }
+    }
+  };
+}

--- a/skills/accelint-ac-to-playwright/assets/fixtures/error-handling.ts
+++ b/skills/accelint-ac-to-playwright/assets/fixtures/error-handling.ts
@@ -1,0 +1,43 @@
+import type { Page, TestInfo } from "@playwright/test";
+
+export async function attachFailureArtifacts(args: {
+  page: Page;
+  testInfo: TestInfo;
+  stepIndex: number;
+  action: string;
+  testId?: string;
+}) {
+  const { page, testInfo, stepIndex, action, testId } = args;
+  if (!testInfo) return;
+  const payload = {
+    url: page.url(),
+    stepIndex,
+    action,
+    testId,
+  };
+  await testInfo.attach("step failure", {
+    contentType: "application/json",
+    body: Buffer.from(JSON.stringify(payload, null, 2), "utf8"),
+  });
+  try {
+    const screenshot = await page.screenshot({ fullPage: true });
+    await testInfo.attach("step screenshot", {
+      contentType: "image/png",
+      body: screenshot,
+    });
+  } catch {
+    // ignore screenshot issues
+  }
+  try {
+    const video = page.video?.();
+    if (video) {
+      const path = await video.path();
+      await testInfo.attach("step video", {
+        contentType: "video/webm",
+        path,
+      });
+    }
+  } catch {
+    // ignore video issues
+  }
+}

--- a/skills/accelint-ac-to-playwright/scripts/cli/create-markdown-summary.ts
+++ b/skills/accelint-ac-to-playwright/scripts/cli/create-markdown-summary.ts
@@ -253,7 +253,7 @@ function renderMarkdown(data: {
   lines.push("");
   lines.push("## Next steps");
   lines.push(
-    "- Copy the generated Playwright spec files into your project repo.",
+    "- Copy the generated Playwright spec files AND the fixtures/ directory into your project repo. The spec files import test utilities from fixtures/ and will fail to compile without it.",
   );
   lines.push(
     "- Ensure the codebase includes the required test hooks (data-testid attributes on the appropriate elements). If there's any ambiguity, review the input AC file alongside the JSON plan to most easily see the intended test flow and targets.",

--- a/skills/accelint-ac-to-playwright/scripts/tests/fixtures/golden-file-test.expected.txt
+++ b/skills/accelint-ac-to-playwright/scripts/tests/fixtures/golden-file-test.expected.txt
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test";
+import { setupConsoleTracking } from "./fixtures/console-tracking";
+import { attachFailureArtifacts } from "./fixtures/error-handling";
 
 test.describe("Golden file test", {
   tag: ["@smoke", "@fast"],
@@ -53,76 +55,3 @@ test.describe("Golden file test", {
   });
 
 });
-
-async function attachFailureArtifacts(args: {
-  page: import("@playwright/test").Page;
-  testInfo: import("@playwright/test").TestInfo;
-  stepIndex: number;
-  action: string;
-  testId?: string;
-}) {
-  const { page, testInfo, stepIndex, action, testId } = args;
-  if (!testInfo) return;
-  const payload = {
-    url: page.url(),
-    stepIndex,
-    action,
-    testId,
-  };
-  await testInfo.attach("step failure", {
-    contentType: "application/json",
-    body: Buffer.from(JSON.stringify(payload, null, 2), "utf8"),
-  });
-  try {
-    const screenshot = await page.screenshot({ fullPage: true });
-    await testInfo.attach("step screenshot", {
-      contentType: "image/png",
-      body: screenshot,
-    });
-  } catch {
-    // ignore screenshot issues
-  }
-  try {
-    const video = page.video?.();
-    if (video) {
-      const path = await video.path();
-      await testInfo.attach("step video", {
-        contentType: "video/webm",
-        path,
-      });
-    }
-  } catch {
-    // ignore video issues
-  }
-}
-
-async function setupConsoleTracking(args: {
-  page: import("@playwright/test").Page;
-  testInfo: import("@playwright/test").TestInfo;
-}) {
-  const { page, testInfo } = args;
-  const consoleMessages: Array<{ type: string; text: string; stepIndex: number; timestamp: string; location: { url: string; lineNumber?: number; columnNumber?: number } }> = [];
-  let currentStep = 0;
-
-  page.on('console', msg => {
-    consoleMessages.push({
-      type: msg.type(),
-      text: msg.text(),
-      stepIndex: currentStep,
-      timestamp: new Date().toISOString(),
-      location: msg.location()
-    });
-  });
-
-  return {
-    setStep: (step: number) => { currentStep = step; },
-    attachMessages: async () => {
-      if (consoleMessages.length > 0) {
-        await testInfo.attach('console-messages', {
-          contentType: 'application/json',
-          body: Buffer.from(JSON.stringify(consoleMessages, null, 2), 'utf8')
-        });
-      }
-    }
-  };
-}

--- a/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
@@ -60,6 +60,8 @@ export function translatePlan(
   const lines: string[] = [];
 
   lines.push(`import { expect, test } from "@playwright/test";`);
+  lines.push(`import { setupConsoleTracking } from "./fixtures/console-tracking";`);
+  lines.push(`import { attachFailureArtifacts } from "./fixtures/error-handling";`);
   lines.push(``);
 
   // Set up group
@@ -85,83 +87,7 @@ export function translatePlan(
     lines.push(translateSingleTest(test));
   }
 
-  // Helper to attach diagnostics on failure
   lines.push(`});`);
-  lines.push(``);
-  lines.push(`async function attachFailureArtifacts(args: {`);
-  lines.push(`  page: import("@playwright/test").Page;`);
-  lines.push(`  testInfo: import("@playwright/test").TestInfo;`);
-  lines.push(`  stepIndex: number;`);
-  lines.push(`  action: string;`);
-  lines.push(`  testId?: string;`);
-  lines.push(`}) {`);
-  lines.push(`  const { page, testInfo, stepIndex, action, testId } = args;`);
-  lines.push(`  if (!testInfo) return;`);
-  lines.push(`  const payload = {`);
-  lines.push(`    url: page.url(),`);
-  lines.push(`    stepIndex,`);
-  lines.push(`    action,`);
-  lines.push(`    testId,`);
-  lines.push(`  };`);
-  lines.push(`  await testInfo.attach("step failure", {`);
-  lines.push(`    contentType: "application/json",`);
-  lines.push(`    body: Buffer.from(JSON.stringify(payload, null, 2), "utf8"),`);
-  lines.push(`  });`);
-  lines.push(`  try {`);
-  lines.push(`    const screenshot = await page.screenshot({ fullPage: true });`);
-  lines.push(`    await testInfo.attach("step screenshot", {`);
-  lines.push(`      contentType: "image/png",`);
-  lines.push(`      body: screenshot,`);
-  lines.push(`    });`);
-  lines.push(`  } catch {`);
-  lines.push(`    // ignore screenshot issues`);
-  lines.push(`  }`);
-  lines.push(`  try {`);
-  lines.push(`    const video = page.video?.();`);
-  lines.push(`    if (video) {`);
-  lines.push(`      const path = await video.path();`);
-  lines.push(`      await testInfo.attach("step video", {`);
-  lines.push(`        contentType: "video/webm",`);
-  lines.push(`        path,`);
-  lines.push(`      });`);
-  lines.push(`    }`);
-  lines.push(`  } catch {`);
-  lines.push(`    // ignore video issues`);
-  lines.push(`  }`);
-  lines.push(`}`);
-
-  // Helper to attach console logs (if present)
-  lines.push(``);
-  lines.push(`async function setupConsoleTracking(args: {`);
-  lines.push(`  page: import("@playwright/test").Page;`);
-  lines.push(`  testInfo: import("@playwright/test").TestInfo;`);
-  lines.push(`}) {`);
-  lines.push(`  const { page, testInfo } = args;`);
-  lines.push(`  const consoleMessages: Array<{ type: string; text: string; stepIndex: number; timestamp: string; location: { url: string; lineNumber?: number; columnNumber?: number } }> = [];`);
-  lines.push(`  let currentStep = 0;`);
-  lines.push(``);
-  lines.push(`  page.on('console', msg => {`);
-  lines.push(`    consoleMessages.push({`);
-  lines.push(`      type: msg.type(),`);
-  lines.push(`      text: msg.text(),`);
-  lines.push(`      stepIndex: currentStep,`);
-  lines.push(`      timestamp: new Date().toISOString(),`);
-  lines.push(`      location: msg.location()`);
-  lines.push(`    });`);
-  lines.push(`  });`);
-  lines.push(``);
-  lines.push(`  return {`);
-  lines.push(`    setStep: (step: number) => { currentStep = step; },`);
-  lines.push(`    attachMessages: async () => {`);
-  lines.push(`      if (consoleMessages.length > 0) {`);
-  lines.push(`        await testInfo.attach('console-messages', {`);
-  lines.push(`          contentType: 'application/json',`);
-  lines.push(`          body: Buffer.from(JSON.stringify(consoleMessages, null, 2), 'utf8')`);
-  lines.push(`        });`);
-  lines.push(`      }`);
-  lines.push(`    }`);
-  lines.push(`  };`);
-  lines.push(`}`);
 
   const suiteSlug = slug(planFile.suiteName);
   if (!suiteSlug) {


### PR DESCRIPTION
- Extracted `attachFailureArtifacts()` and `setupConsoleTracking()` from inline generation into shared fixture files
- All generated tests now import these from a fixtures/ directory instead of duplicating ~80 lines per test
- The fixture files are stored as assets and copied into the target directory where tests are generated (user-specified)
- The summary file created after test generation tells the user to copy the fixture files over too

I verified things worked by generating a sample test from AC and verifying it compiles and runs successfully with Playwright. I think I put the imports in the correct order for our biome implementation to not freak out, but if we find this not to be the case I can make a fix here later.