### PR TITLE
Use z.infer to derive TypeScript types from Zod schemas

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
@@ -1733,3 +1733,109 @@ function formatIssues(error: ZodError): string {
     })
     .join("\n");
 }
+
+describe("Default values", () => {
+  it("applies default 'left' button when omitted for mouseDown and mouseUp", () => {
+    const input = {
+      suiteName: "Default button test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Mouse down/up with default button",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "mouseDown" },
+            { action: "mouseUp" },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.parse(input);
+    expect(result.tests[0].steps[0]).toEqual({ action: "mouseDown", button: "left" });
+    expect(result.tests[0].steps[1]).toEqual({ action: "mouseUp", button: "left" });
+  });
+
+  it("applies default 'left' button when omitted for doubleClick", () => {
+    const input = {
+      suiteName: "Default button test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Double click with default button",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "doubleClick", x: 100, y: 200 },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.parse(input);
+    expect(result.tests[0].steps[0]).toEqual({ action: "doubleClick", x: 100, y: 200, button: "left" });
+  });
+
+  it("preserves explicit button value when provided", () => {
+    const input = {
+      suiteName: "Explicit button test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Double click with explicit button",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "doubleClick", x: 150, y: 250, button: "right" },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.parse(input);
+    expect(result.tests[0].steps[0]).toEqual({ action: "doubleClick", x: 150, y: 250, button: "right" });
+  });
+
+  it("applies default 'left' button when omitted for drag", () => {
+    const input = {
+      suiteName: "Default button test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Drag with default button",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "drag", fromX: 100, fromY: 100, toX: 200, toY: 200 },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.parse(input);
+    expect(result.tests[0].steps[0]).toEqual({
+      action: "drag",
+      fromX: 100,
+      fromY: 100,
+      toX: 200,
+      toY: 200,
+      button: "left"
+    });
+  });
+
+  it("applies default 'left' button when omitted for mouseClick", () => {
+    const input = {
+      suiteName: "Default button test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Mouse click with default button",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "mouseClick", x: 100, y: 200 },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.parse(input);
+    expect(result.tests[0].steps[0]).toEqual({ action: "mouseClick", x: 100, y: 200, button: "left" });
+  });
+});

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
@@ -13,7 +13,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "doubleClick", x: 100, y: 200 },
+      { action: "doubleClick", x: 100, y: 200, button: "left" },
       4,
       [
         'await page.mouse.dblclick(100, 200);',
@@ -29,7 +29,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "drag", fromX: 100, fromY: 100, toX: 200, toY: 200 },
+      { action: "drag", fromX: 100, fromY: 100, toX: 200, toY: 200, button: "left" },
       6,
       [
         'await page.mouse.move(100, 100);',
@@ -140,7 +140,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseClick", x: 100, y: 200 },
+      { action: "mouseClick", x: 100, y: 200, button: "left" },
       1,
       [
         'await page.mouse.click(100, 200);',
@@ -156,7 +156,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseDown" },
+      { action: "mouseDown", button: "left" },
       3,
       [
         'await page.mouse.down();',
@@ -180,7 +180,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseUp" },
+      { action: "mouseUp", button: "left" },
       6,
       [
         'await page.mouse.up();',

--- a/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
@@ -1,5 +1,8 @@
 // This script converts a json test plan file to a Playwright test file.
 
+import type { z } from "zod";
+import type { stepSchema, testSchema, testSuiteSchema } from "./plan-schema";
+
 // Types
 
 type GeneratedFile = {
@@ -7,44 +10,9 @@ type GeneratedFile = {
   content: string;
 };
 
-export type PlanFile = {
-  suiteName: string;
-  tags?: string[];
-  source: {
-    repo: string;
-    path: string;
-  };
-  tests: Test[];
-};
-
-export type Step = {
-  action: "click"; target: string }
-  | { action: "doubleClick"; x: number; y: number; button?: "left" | "right" | "middle" }
-  | { action: "drag"; fromX: number; fromY: number; toX: number; toY: number; button?: "left" | "right" | "middle" }
-  | { action: "expectNotVisible"; target: string }
-  | { action: "expectText"; target: string; value: string }
-  | { action: "expectUrl"; value: string }
-  | { action: "expectVisible"; target: string }
-  | { action: "fill"; target: string; value: string }
-  | { action: "goto"; value: string }
-  | { action: "hover"; target: string }
-  | { action: "keyDown"; value: string }
-  | { action: "keyUp"; value: string }
-  | { action: "mouseClick"; x: number; y: number; button?: "left" | "right" | "middle" }
-  | { action: "mouseDown"; button?: "left" | "right" | "middle" }
-  | { action: "mouseMove"; x: number; y: number }
-  | { action: "mouseUp"; button?: "left" | "right" | "middle" }
-  | { action: "press"; value: string }
-  | { action: "reload" }
-  | { action: "scroll"; direction: "up" | "down" | "left" | "right"; amount: number }
-  | { action: "select"; target: string; value: string };
-  
-export type Test = {
-  name: string;
-  startUrl: string;
-  tags?: string[];
-  steps: Step[];
-};
+export type PlanFile = z.infer<typeof testSuiteSchema>;
+export type Step = z.infer<typeof stepSchema>;
+export type Test = z.infer<typeof testSchema>;
 
 // Main functionality
 


### PR DESCRIPTION
This PR replaces ~40 lines of manual TypeScript type definitions with `z.infer<typeof schema>` to derive types directly from Zod schemas. This eliminates the duplication between validation schemas and TypeScript types, ensuring they can never drift apart. I tweaked some existing tests and added some new ones to verify default button values are applied when omitted and explicit values are preserved.