### PR TITLE
Fix the expectNotVisible assertion to properly handle 0 elements present

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.1"
+  version: "1.1.2"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
@@ -65,8 +65,11 @@ describe("renderStep", () => {
       { action: "expectNotVisible", target: "#modal" },
       1,
       [
+        'try {',
+        'await expect(page.getByTestId("#modal")).toHaveCount(0);',
+        '} catch {',
         'await expect(page.getByTestId("#modal")).toHaveCount(1);',
-        'await expect(page.getByTestId("#modal")).toBeHidden();',
+        'await expect(page.getByTestId("#modal")).not.toBeVisible();',
         'attachFailureArtifacts({ page, testInfo, stepIndex: 1, action: "expectNotVisible", testId: "#modal" })'
       ],
     ],

--- a/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
@@ -188,8 +188,12 @@ function renderStep(step: Step, stepIndex: number): string {
       const locator = `page.getByTestId(${JSON.stringify(step.target)})`;
       return [
         `    try {`,
-        `      await expect(${locator}).toHaveCount(1);`,
-        `      await expect(${locator}).toBeHidden();`,
+        `      try {`,
+        `        await expect(${locator}).toHaveCount(0);`,
+        `      } catch {`,
+        `        await expect(${locator}).toHaveCount(1);`,
+        `        await expect(${locator}).not.toBeVisible();`,
+        `      }`,
         `    } catch (error) {`,
         `      await attachFailureArtifacts({ page, testInfo, stepIndex: ${stepIndex}, action: "${step.action}", testId: ${JSON.stringify(step.target)} });`,
         `      throw error;`,


### PR DESCRIPTION
The `expectNotVisible` assertion was intended to pass (and documented as such) when:
- there is exactly 1 element, and it's not visible, or
- there are 0 elements with the target test id on the page

And it should fail if there is exactly 1 element and it's visible, or if there are 2+ elements of any visibility.

The bug is that the code currently only passes if there is exactly 1 invisible element, and the 0 elements case isn't covered.

This bugfix adds the second condition so it will properly pass if the element isn't there at all.