### PR TITLE
Improve visibility pairing validation 

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.2"
+  version: "1.1.3"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
+++ b/skills/accelint-ac-to-playwright/scripts/plan-schema.ts
@@ -8,11 +8,13 @@ import { targetValidator } from "./target-validator";
  * Step schemas
  */
 const clickStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("click"),
   target: targetValidator,
 }).strict();
 
 const doubleClickStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("doubleClick"),
   x: z.number().int().min(0),
   y: z.number().int().min(0),
@@ -20,6 +22,7 @@ const doubleClickStep = z.object({
 }).strict();
 
 const dragStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("drag"),
   fromX: z.number().int().min(0),
   fromY: z.number().int().min(0),
@@ -29,53 +32,63 @@ const dragStep = z.object({
 }).strict();
 
 const expectNotVisibleStep = z.object({
+  type: z.literal("assertion").default("assertion"),
   action: z.literal("expectNotVisible"),
   target: targetValidator,
 }).strict();
 
 const expectTextStep = z.object({
+  type: z.literal("assertion").default("assertion"),
   action: z.literal("expectText"),
   target: targetValidator,
   value: z.string(),
 }).strict();
 
 const expectUrlStep = z.object({
+  type: z.literal("assertion").default("assertion"),
   action: z.literal("expectUrl"),
   value: z.string(),
 }).strict();
 
 const expectVisibleStep = z.object({
+  type: z.literal("assertion").default("assertion"),
   action: z.literal("expectVisible"),
   target: targetValidator,
 }).strict();
 
 const fillStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("fill"),
   target: targetValidator,
   value: z.string(),
 }).strict();
 
 const gotoStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("goto"),
   value: z.string(),
 }).strict();
 
 const hoverStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("hover"),
   target: targetValidator,
 }).strict();
 
 const keyDownStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("keyDown"),
   value: modifierKeyValidator,
 }).strict();
 
 const keyUpStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("keyUp"),
   value: modifierKeyValidator,
 }).strict();
 
 const mouseClickStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("mouseClick"),
   x: z.number().int().min(0),
   y: z.number().int().min(0),
@@ -83,37 +96,44 @@ const mouseClickStep = z.object({
 }).strict();
 
 const mouseDownStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("mouseDown"),
   button: mouseButtonValidator.optional().default("left"),
 }).strict();
 
 const mouseMoveStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("mouseMove"),
   x: z.number().int().min(0),
   y: z.number().int().min(0),
 }).strict();
 
 const mouseUpStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("mouseUp"),
   button: mouseButtonValidator.optional().default("left"),
 }).strict();
 
 const pressStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("press"),
   value: pressKeyValidator,
 }).strict();
 
 const reloadStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("reload"),
 }).strict();
 
 const scrollStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("scroll"),
   direction: wheelDirectionValidator,
   amount: z.number().int().positive(),
 }).strict();
 
 const selectStep = z.object({
+  type: z.literal("action").default("action"),
   action: z.literal("select"),
   target: targetValidator,
   value: z.string(),
@@ -254,60 +274,78 @@ export const testSchema = z.object({
 
   // Validate visibility assertion pairing
   if (!hasError) {
-    const visibilityAssertions: Array<{
+    // Helper to check if a step is an action (not an assertion)
+    const isAction = (step: z.infer<typeof stepSchema>): boolean => {
+      return step.type === "action";
+    };
+
+    // Helper to count actions between two indices
+    const countActionsBetween = (startIndex: number, endIndex: number): number => {
+      let count = 0;
+      for (let i = startIndex + 1; i < endIndex; i++) {
+        if (isAction(test.steps[i])) {
+          count++;
+        }
+      }
+      return count;
+    };
+
+    // Group visibility assertions by target
+    const assertionsByTarget = new Map<string, Array<{
       index: number;
       action: "expectVisible" | "expectNotVisible";
-      target: string;
-    }> = [];
+    }>>();
 
-    // Collect all visibility assertions
     test.steps.forEach((step, index) => {
       if (step.action === "expectVisible" || step.action === "expectNotVisible") {
-        visibilityAssertions.push({
-          index,
-          action: step.action,
-          target: step.target,
-        });
+        const targetAssertions = assertionsByTarget.get(step.target);
+        if (targetAssertions) {
+          targetAssertions.push({
+            index,
+            action: step.action,
+          });
+        } else {
+          assertionsByTarget.set(step.target, [{
+            index,
+            action: step.action,
+          }]);
+        }
       }
     });
 
-    // Validate each visibility assertion has a proper pair
-    for (const assertion of visibilityAssertions) {
-      const oppositeAction = assertion.action === "expectVisible"
-        ? "expectNotVisible"
-        : "expectVisible";
-
-      // Check for pair immediately before (at index - 2, with one action at index - 1)
-      const hasPairBefore =
-        assertion.index >= 2 &&
-        visibilityAssertions.some(other =>
-          other.index === assertion.index - 2 &&
-          other.action === oppositeAction &&
-          other.target === assertion.target
-        ) &&
-        // Ensure step at index - 1 is an action (not an assertion)
-        !["expectVisible", "expectNotVisible", "expectText", "expectUrl"].includes(
-          test.steps[assertion.index - 1].action
-        );
-
-      // Check for pair immediately after (at index + 2, with one action at index + 1)
-      const hasPairAfter =
-        assertion.index + 2 < test.steps.length &&
-        visibilityAssertions.some(other =>
-          other.index === assertion.index + 2 &&
-          other.action === oppositeAction &&
-          other.target === assertion.target
-        ) &&
-        // Ensure step at index + 1 is an action (not an assertion)
-        !["expectVisible", "expectNotVisible", "expectText", "expectUrl"].includes(
-          test.steps[assertion.index + 1].action
-        );
-
-      if (!hasPairBefore && !hasPairAfter) {
+    // Validate each target
+    for (const [target, assertions] of assertionsByTarget.entries()) {
+      // Must have exactly 2 assertions
+      if (assertions.length !== 2) {
         ctx.addIssue({
           code: "custom",
-          message: `${assertion.action} at step ${assertion.index} for target "${assertion.target}" must be paired with ${oppositeAction} for the same target, with exactly one action between them. Pattern: ${oppositeAction} → action → ${assertion.action} OR ${assertion.action} → action → ${oppositeAction}.`,
-          path: ["steps", assertion.index, "action"],
+          message: `Target "${target}" has ${assertions.length} visibility assertion(s), but must have exactly 2 (one expectVisible and one expectNotVisible with exactly one action between them).`,
+          path: ["steps"],
+        });
+        hasError = true;
+        break;
+      }
+
+      const [first, second] = assertions;
+
+      // Must be opposite types
+      if (first.action === second.action) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Target "${target}" has two ${first.action} assertions. Visibility assertions must be opposite types (one expectVisible and one expectNotVisible).`,
+          path: ["steps", second.index, "action"],
+        });
+        hasError = true;
+        break;
+      }
+
+      // Must have exactly 1 action between them
+      const actionCount = countActionsBetween(first.index, second.index);
+      if (actionCount !== 1) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Target "${target}" has ${actionCount} action(s) between visibility assertions at steps ${first.index} and ${second.index}, but must have exactly 1 action.`,
+          path: ["steps", second.index, "action"],
         });
         hasError = true;
         break;
@@ -316,6 +354,9 @@ export const testSchema = z.object({
   }
 }).strict();
 
+/**
+ * Exports
+*/
 export const testSuiteSchema = z.object({
   suiteName: z.string(),
   tags: z.array(tagValidator).min(1).optional(),

--- a/skills/accelint-ac-to-playwright/scripts/tests/append-json-summary-entry.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/append-json-summary-entry.test.ts
@@ -69,10 +69,10 @@ describe("parseArgs", () => {
 describe("extractHooks", () => {
   it("dedupes targets in first-seen order", () => {
     const hooks = _extractHooks([
-      { action: "click", target: "alpha" },
-      { action: "expectUrl", value: "/settings" },
-      { action: "fill", target: "beta", value: "x" },
-      { action: "click", target: "alpha" },
+      { type: "action", action: "click", target: "alpha" },
+      { type: "assertion", action: "expectUrl", value: "/settings" },
+      { type: "action", action: "fill", target: "beta", value: "x" },
+      { type: "action", action: "click", target: "alpha" },
     ]);
     expect(hooks).toEqual(["alpha", "beta"]);
   });

--- a/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
@@ -52,7 +52,7 @@ describe("Plan schema", () => {
         {
           name: "A",
           startUrl: "https://x.com",
-          steps: [{ action: "scroll", value: "down" }],
+          steps: [{ type: "action", action: "scroll", value: "down" }],
         },
       ],
     };
@@ -176,7 +176,7 @@ describe("Plan schema", () => {
         {
           name: "Click test",
           startUrl: "https://example.com",
-          steps: [{ action: "mouseClick", x, y, ...(button && { button }) }],
+          steps: [{ type: "action", action: "mouseClick", x, y, ...(button && { button }) }],
         },
       ],
     };
@@ -198,7 +198,7 @@ describe("Plan schema", () => {
         {
           name: "Invalid click",
           startUrl: "https://example.com",
-          steps: [{ action: "mouseClick", x, y, ...(button && { button }) }],
+          steps: [{ type: "action", action: "mouseClick", x, y, ...(button && { button }) }],
         },
       ],
     };
@@ -215,7 +215,7 @@ describe("Plan schema", () => {
         {
           name: "Move mouse",
           startUrl: "https://example.com",
-          steps: [{ action: "mouseMove", x: 150, y: 250 }],
+          steps: [{ type: "action", action: "mouseMove", x: 150, y: 250 }],
         },
       ],
     };
@@ -236,7 +236,7 @@ describe("Plan schema", () => {
         {
           name: "Invalid move",
           startUrl: "https://example.com",
-          steps: [{ action: "mouseMove", x, y }],
+          steps: [{ type: "action", action: "mouseMove", x, y }],
         },
       ],
     };
@@ -254,8 +254,8 @@ describe("Plan schema", () => {
           name: "Invalid button",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown", button: "invalid" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown", button: "invalid" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -274,8 +274,8 @@ describe("Plan schema", () => {
           name: "Invalid button",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseUp", button: "invalid" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp", button: "invalid" },
           ],
         },
       ],
@@ -298,7 +298,7 @@ describe("Plan schema", () => {
         {
           name: "Scroll test",
           startUrl: "https://example.com",
-          steps: [{ action: "scroll", direction, amount }],
+          steps: [{ type: "action", action: "scroll", direction, amount }],
         },
       ],
     };
@@ -320,7 +320,7 @@ describe("Plan schema", () => {
         {
           name: "Invalid scroll",
           startUrl: "https://example.com",
-          steps: [{ action: "scroll", direction, amount }],
+          steps: [{ type: "action", action: "scroll", direction, amount }],
         },
       ],
     };
@@ -340,10 +340,10 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Valid drag sequence",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseMove", x: 100, y: 100 },
-            { action: "mouseDown" },
-            { action: "mouseMove", x: 200, y: 200 },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseMove", x: 100, y: 100 },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseMove", x: 200, y: 200 },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -362,10 +362,10 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Multiple complete pairs",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseUp" },
-            { action: "mouseDown" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -384,8 +384,8 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Invalid sequence",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseMove", x: 100, y: 100 },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseMove", x: 100, y: 100 },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -410,8 +410,8 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Unpaired mouseDown",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseMove", x: 100, y: 100 },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseMove", x: 100, y: 100 },
           ],
         },
       ],
@@ -436,9 +436,9 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Nested mouseDown",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseDown" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -463,9 +463,9 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Double mouseUp",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseUp" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -490,8 +490,8 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Mismatched buttons",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown", button: "left" },
-            { action: "mouseUp", button: "right" },
+            { type: "action", action: "mouseDown", button: "left" },
+            { type: "action", action: "mouseUp", button: "right" },
           ],
         },
       ],
@@ -517,8 +517,8 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Right button pair",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown", button: "right" },
-            { action: "mouseUp", button: "right" },
+            { type: "action", action: "mouseDown", button: "right" },
+            { type: "action", action: "mouseUp", button: "right" },
           ],
         },
       ],
@@ -537,10 +537,10 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Overlapping different buttons",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown", button: "left" },
-            { action: "mouseDown", button: "right" },
-            { action: "mouseUp", button: "right" },
-            { action: "mouseUp", button: "left" },
+            { type: "action", action: "mouseDown", button: "left" },
+            { type: "action", action: "mouseDown", button: "right" },
+            { type: "action", action: "mouseUp", button: "right" },
+            { type: "action", action: "mouseUp", button: "left" },
           ],
         },
       ],
@@ -565,15 +565,15 @@ describe("mouseDown/mouseUp pairing validation", () => {
           name: "Test 1 - valid",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
           ],
         },
         {
           name: "Test 2 - invalid",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseUp" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -599,7 +599,7 @@ it.each([
       {
         name: "Test press",
         startUrl: "https://example.com",
-        steps: [{ action: "press", value }],
+        steps: [{ type: "action", action: "press", value }],
       },
     ],
   };
@@ -619,7 +619,7 @@ it.each([
       {
         name: "Test press",
         startUrl: "https://example.com",
-        steps: [{ action: "press", value }],
+        steps: [{ type: "action", action: "press", value }],
       },
     ],
   };
@@ -638,9 +638,9 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Valid keyboard shortcut",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Shift" },
-            { action: "press", value: "g" },
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "press", value: "g" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -659,10 +659,10 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Multiple complete pairs",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "keyUp", value: "Control" },
-            { action: "keyDown", value: "Shift" },
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -681,8 +681,8 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Invalid sequence",
           startUrl: "https://example.com",
           steps: [
-            { action: "press", value: "g" },
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "press", value: "g" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -707,8 +707,8 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Unpaired keyDown",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "press", value: "g" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "press", value: "g" },
           ],
         },
       ],
@@ -733,9 +733,9 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Nested keyDown with different modifiers",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "keyDown", value: "Shift" },
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -760,9 +760,9 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Nested keyDown with same modifier",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "keyDown", value: "Control" },
-            { action: "keyUp", value: "Control" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
           ],
         },
       ],
@@ -787,9 +787,9 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Double keyUp",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "keyUp", value: "Control" },
-            { action: "keyUp", value: "Control" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
           ],
         },
       ],
@@ -814,8 +814,8 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Mismatched keys",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Shift" },
-            { action: "keyUp", value: "Control" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "keyUp", value: "Control" },
           ],
         },
       ],
@@ -841,9 +841,9 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "App modifier pair",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "a" },
-            { action: "press", value: "g" },
-            { action: "keyUp", value: "a" },
+            { type: "action", action: "keyDown", value: "a" },
+            { type: "action", action: "press", value: "g" },
+            { type: "action", action: "keyUp", value: "a" },
           ],
         },
       ],
@@ -862,10 +862,10 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Overlapping different modifiers",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Shift" },
-            { action: "keyDown", value: "Control" },
-            { action: "keyUp", value: "Control" },
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -890,15 +890,15 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Test 1 - valid",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Control" },
-            { action: "keyUp", value: "Control" },
+            { type: "action", action: "keyDown", value: "Control" },
+            { type: "action", action: "keyUp", value: "Control" },
           ],
         },
         {
           name: "Test 2 - invalid",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyUp", value: "Shift" },
+            { type: "action", action: "keyUp", value: "Shift" },
           ],
         },
       ],
@@ -921,8 +921,8 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Invalid modifier",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Enter" },
-            { action: "keyUp", value: "Enter" },
+            { type: "action", action: "keyDown", value: "Enter" },
+            { type: "action", action: "keyUp", value: "Enter" },
           ],
         },
       ],
@@ -941,8 +941,8 @@ describe("keyDown/keyUp pairing validation", () => {
           name: "Invalid modifier",
           startUrl: "https://example.com",
           steps: [
-            { action: "keyDown", value: "Shift" },
-            { action: "keyUp", value: "b" },
+            { type: "action", action: "keyDown", value: "Shift" },
+            { type: "action", action: "keyUp", value: "b" },
           ],
         },
       ],
@@ -985,7 +985,7 @@ describe("visibility pairing validation", () => {
           startUrl: "https://example.com",
           steps: [
             { action: "expectVisible", target: "page.div.settings" },
-            { action: "press", value: "Escape" },
+            { type: "action", action: "press", value: "Escape" },
             { action: "expectNotVisible", target: "page.div.settings" },
           ],
         },
@@ -1798,8 +1798,8 @@ describe("Default values", () => {
           name: "Mouse down/up with default button",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseDown" },
-            { action: "mouseUp" },
+            { type: "action", action: "mouseDown" },
+            { type: "action", action: "mouseUp" },
           ],
         },
       ],
@@ -1884,7 +1884,7 @@ describe("Default values", () => {
           name: "Mouse click with default button",
           startUrl: "https://example.com",
           steps: [
-            { action: "mouseClick", x: 100, y: 200 },
+            { type: "action", action: "mouseClick", x: 100, y: 200 },
           ],
         },
       ],

--- a/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/plan-schema.test.ts
@@ -1020,6 +1020,60 @@ describe("visibility pairing validation", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts multiple assertions for different elements with single action", () => {
+    const input = {
+      suiteName: "Visibility test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Multiple elements visibility change",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "expectNotVisible", target: "modal.div.thing-one" },
+            { action: "expectVisible", target: "modal.div.thing-two" },
+            { action: "expectNotVisible", target: "modal.div.thing-three" },
+            { action: "click", target: "page.button.toggle" },
+            { action: "expectVisible", target: "modal.div.thing-one" },
+            { action: "expectNotVisible", target: "modal.div.thing-two" },
+            { action: "expectVisible", target: "modal.div.thing-three" },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects visibility pair with two actions between", () => {
+    const input = {
+      suiteName: "Visibility test",
+      source: { repo: "some-repo", path: "path/to/file.md" },
+      tests: [
+        {
+          name: "Two actions between visibility checks",
+          startUrl: "https://example.com",
+          steps: [
+            { action: "expectNotVisible", target: "modal.div.dialog" },
+            { action: "click", target: "page.button.open" },
+            { action: "fill", target: "form.input.name", value: "test" },
+            { action: "expectVisible", target: "modal.div.dialog" },
+          ],
+        },
+      ],
+    };
+
+    const result = testSuiteSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues;
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain("modal.div.dialog");
+      expect(issues[0].message).toContain("2 action(s)");
+      expect(issues[0].message).toContain("must have exactly 1 action");
+    }
+  });
+
   it("rejects unpaired expectVisible", () => {
     const input = {
       suiteName: "Visibility test",
@@ -1041,9 +1095,9 @@ describe("visibility pairing validation", () => {
     if (!result.success) {
       const issues = result.error.issues;
       expect(issues).toHaveLength(1);
-      expect(issues[0].path).toEqual(["tests", 0, "steps", 1, "action"]);
-      expect(issues[0].message).toContain("expectVisible at step 1");
-      expect(issues[0].message).toContain("must be paired with expectNotVisible");
+      expect(issues[0].message).toContain("modal.div.dialog");
+      expect(issues[0].message).toContain("1 visibility assertion");
+      expect(issues[0].message).toContain("must have exactly 2");
     }
   });
 
@@ -1068,9 +1122,9 @@ describe("visibility pairing validation", () => {
     if (!result.success) {
       const issues = result.error.issues;
       expect(issues).toHaveLength(1);
-      expect(issues[0].path).toEqual(["tests", 0, "steps", 0, "action"]);
-      expect(issues[0].message).toContain("expectNotVisible at step 0");
-      expect(issues[0].message).toContain("must be paired with expectVisible");
+      expect(issues[0].message).toContain("page.div.info");
+      expect(issues[0].message).toContain("1 visibility assertion");
+      expect(issues[0].message).toContain("must have exactly 2");
     }
   });
 
@@ -1095,8 +1149,9 @@ describe("visibility pairing validation", () => {
     if (!result.success) {
       const issues = result.error.issues;
       expect(issues).toHaveLength(1);
-      // Either step 0 or 1 will fail (whichever is checked first)
-      expect(issues[0].message).toContain("must be paired");
+      expect(issues[0].message).toContain("modal.div.dialog");
+      expect(issues[0].message).toContain("0 action(s)");
+      expect(issues[0].message).toContain("must have exactly 1 action");
     }
   });
 
@@ -1123,9 +1178,9 @@ describe("visibility pairing validation", () => {
     if (!result.success) {
       const issues = result.error.issues;
       expect(issues).toHaveLength(1);
-      // Either step 0 or 3 will fail
-      expect(issues[0].message).toContain("must be paired");
-      expect(issues[0].message).toContain("exactly one action between");
+      expect(issues[0].message).toContain("modal.div.dialog");
+      expect(issues[0].message).toContain("2 action(s)");
+      expect(issues[0].message).toContain("must have exactly 1 action");
     }
   });
 
@@ -1151,8 +1206,8 @@ describe("visibility pairing validation", () => {
     if (!result.success) {
       const issues = result.error.issues;
       expect(issues).toHaveLength(1);
-      // One of the assertions will fail to find a matching pair
-      expect(issues[0].message).toContain("must be paired");
+      expect(issues[0].message).toContain("1 visibility assertion");
+      expect(issues[0].message).toContain("must have exactly 2");
     }
   });
 
@@ -1166,7 +1221,7 @@ describe("visibility pairing validation", () => {
           startUrl: "https://example.com",
           steps: [
             { action: "expectNotVisible", target: "modal.div.dialog" },
-            { action: "expectText", target: "header.title", value: "Welcome" },
+            { action: "expectText", target: "page.text.title", value: "Welcome" },
             { action: "expectVisible", target: "modal.div.dialog" },
           ],
         },
@@ -1177,11 +1232,10 @@ describe("visibility pairing validation", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const issues = result.error.issues;
-      // Both assertions will fail to find a matching pair since there's an assertion between them
-      expect(issues.length).toBeGreaterThanOrEqual(1);
-      // Check that at least one error is about visibility pairing
-      const hasPairingError = issues.some(issue => issue.message.includes("must be paired"));
-      expect(hasPairingError).toBe(true);
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain("modal.div.dialog");
+      expect(issues[0].message).toContain("0 action(s)");
+      expect(issues[0].message).toContain("must have exactly 1 action");
     }
   });
 
@@ -1752,8 +1806,8 @@ describe("Default values", () => {
     };
 
     const result = testSuiteSchema.parse(input);
-    expect(result.tests[0].steps[0]).toEqual({ action: "mouseDown", button: "left" });
-    expect(result.tests[0].steps[1]).toEqual({ action: "mouseUp", button: "left" });
+    expect(result.tests[0].steps[0]).toEqual({ type: "action", action: "mouseDown", button: "left" });
+    expect(result.tests[0].steps[1]).toEqual({ type: "action", action: "mouseUp", button: "left" });
   });
 
   it("applies default 'left' button when omitted for doubleClick", () => {
@@ -1772,7 +1826,7 @@ describe("Default values", () => {
     };
 
     const result = testSuiteSchema.parse(input);
-    expect(result.tests[0].steps[0]).toEqual({ action: "doubleClick", x: 100, y: 200, button: "left" });
+    expect(result.tests[0].steps[0]).toEqual({ type: "action", action: "doubleClick", x: 100, y: 200, button: "left" });
   });
 
   it("preserves explicit button value when provided", () => {
@@ -1791,7 +1845,7 @@ describe("Default values", () => {
     };
 
     const result = testSuiteSchema.parse(input);
-    expect(result.tests[0].steps[0]).toEqual({ action: "doubleClick", x: 150, y: 250, button: "right" });
+    expect(result.tests[0].steps[0]).toEqual({ type: "action", action: "doubleClick", x: 150, y: 250, button: "right" });
   });
 
   it("applies default 'left' button when omitted for drag", () => {
@@ -1811,6 +1865,7 @@ describe("Default values", () => {
 
     const result = testSuiteSchema.parse(input);
     expect(result.tests[0].steps[0]).toEqual({
+      type: "action",
       action: "drag",
       fromX: 100,
       fromY: 100,
@@ -1836,6 +1891,6 @@ describe("Default values", () => {
     };
 
     const result = testSuiteSchema.parse(input);
-    expect(result.tests[0].steps[0]).toEqual({ action: "mouseClick", x: 100, y: 200, button: "left" });
+    expect(result.tests[0].steps[0]).toEqual({ type: "action", action: "mouseClick", x: 100, y: 200, button: "left" });
   });
 });

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
@@ -4,7 +4,7 @@ import { _renderStep, type Step } from "../translate-plan-to-tests";
 describe("renderStep", () => {
   it.each<[Step, number, string[]]>([
     [
-      { action: "click", target: "#btn" },
+      { type: "action", action: "click", target: "#btn" },
       3,
       [
         'await expect(page.getByTestId("#btn")).toHaveCount(1);',
@@ -13,7 +13,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "doubleClick", x: 100, y: 200, button: "left" },
+      { type: "action", action: "doubleClick", x: 100, y: 200, button: "left" },
       4,
       [
         'await page.mouse.dblclick(100, 200);',
@@ -21,7 +21,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "doubleClick", x: 50, y: 75, button: "right" },
+      { type: "action", action: "doubleClick", x: 50, y: 75, button: "right" },
       5,
       [
         'await page.mouse.dblclick(50, 75, { button: "right" });',
@@ -29,7 +29,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "drag", fromX: 100, fromY: 100, toX: 200, toY: 200, button: "left" },
+      { type: "action", action: "drag", fromX: 100, fromY: 100, toX: 200, toY: 200, button: "left" },
       6,
       [
         'await page.mouse.move(100, 100);',
@@ -40,7 +40,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "drag", fromX: 50, fromY: 75, toX: 150, toY: 200, button: "right" },
+      { type: "action", action: "drag", fromX: 50, fromY: 75, toX: 150, toY: 200, button: "right" },
       7,
       [
         'await page.mouse.move(50, 75);',
@@ -51,7 +51,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "drag", fromX: 10, fromY: 20, toX: 30, toY: 40, button: "middle" },
+      { type: "action", action: "drag", fromX: 10, fromY: 20, toX: 30, toY: 40, button: "middle" },
       8,
       [
         'await page.mouse.move(10, 20);',
@@ -62,7 +62,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "expectNotVisible", target: "#modal" },
+      { type: "assertion", action: "expectNotVisible", target: "#modal" },
       1,
       [
         'try {',
@@ -74,7 +74,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "expectVisible", target: "#modal" },
+      { type: "assertion", action: "expectVisible", target: "#modal" },
       2,
       [
         'await expect(page.getByTestId("#modal")).toHaveCount(1);',
@@ -83,7 +83,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "expectText", target: "#msg", value: "Hello" },
+      { type: "assertion", action: "expectText", target: "#msg", value: "Hello" },
       4,
       [
         'await expect(page.getByTestId("#msg")).toHaveCount(1);',
@@ -92,7 +92,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "fill", target: "#email", value: "a@b.com" },
+      { type: "action", action: "fill", target: "#email", value: "a@b.com" },
       5,
       [
         'await expect(page.getByTestId("#email")).toHaveCount(1);',
@@ -101,7 +101,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "select", target: "#role", value: "admin" },
+      { type: "action", action: "select", target: "#role", value: "admin" },
       6,
       [
         'await expect(page.getByTestId("#role")).toHaveCount(1);',
@@ -110,7 +110,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "goto", value: "https://example.com" },
+      { type: "action", action: "goto", value: "https://example.com" },
       1,
       [
         'await page.goto("https://example.com");',
@@ -118,7 +118,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "hover", target: "#tooltip-trigger" },
+      { type: "action", action: "hover", target: "#tooltip-trigger" },
       3,
       [
         'await expect(page.getByTestId("#tooltip-trigger")).toHaveCount(1);',
@@ -127,7 +127,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "reload" },
+      { type: "action", action: "reload" },
       2,
       [
         'await page.reload();',
@@ -135,7 +135,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "expectUrl", value: "dashboard" },
+      { type: "assertion", action: "expectUrl", value: "dashboard" },
       1,
       [
         "await expect(page).toHaveURL(/\\/dashboard(?:\\/(?:[?#]|$)|[?#]|$)/);",
@@ -143,7 +143,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseClick", x: 100, y: 200, button: "left" },
+      { type: "action", action: "mouseClick", x: 100, y: 200, button: "left" },
       1,
       [
         'await page.mouse.click(100, 200);',
@@ -151,7 +151,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseClick", x: 50, y: 75, button: "right" },
+      { type: "action", action: "mouseClick", x: 50, y: 75, button: "right" },
       2,
       [
         'await page.mouse.click(50, 75, { button: "right" });',
@@ -159,7 +159,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseDown", button: "left" },
+      { type: "action", action: "mouseDown", button: "left" },
       3,
       [
         'await page.mouse.down();',
@@ -167,7 +167,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseDown", button: "middle" },
+      { type: "action", action: "mouseDown", button: "middle" },
       4,
       [
         'await page.mouse.down({ button: "middle" });',
@@ -175,7 +175,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseMove", x: 150, y: 250 },
+      { type: "action", action: "mouseMove", x: 150, y: 250 },
       5,
       [
         'await page.mouse.move(150, 250);',
@@ -183,7 +183,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseUp", button: "left" },
+      { type: "action", action: "mouseUp", button: "left" },
       6,
       [
         'await page.mouse.up();',
@@ -191,7 +191,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "mouseUp", button: "right" },
+      { type: "action", action: "mouseUp", button: "right" },
       7,
       [
         'await page.mouse.up({ button: "right" });',
@@ -199,7 +199,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "scroll", direction: "down", amount: 100 },
+      { type: "action", action: "scroll", direction: "down", amount: 100 },
       8,
       [
         'await page.mouse.wheel(0, 100);',
@@ -207,7 +207,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "scroll", direction: "up", amount: 50 },
+      { type: "action", action: "scroll", direction: "up", amount: 50 },
       9,
       [
         'await page.mouse.wheel(0, -50);',
@@ -215,7 +215,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "scroll", direction: "right", amount: 75 },
+      { type: "action", action: "scroll", direction: "right", amount: 75 },
       10,
       [
         'await page.mouse.wheel(75, 0);',
@@ -223,7 +223,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "scroll", direction: "left", amount: 25 },
+      { type: "action", action: "scroll", direction: "left", amount: 25 },
       11,
       [
         'await page.mouse.wheel(-25, 0);',
@@ -231,7 +231,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "keyDown", value: "Shift" },
+      { type: "action", action: "keyDown", value: "Shift" },
       7,
       [
         'await page.keyboard.down("Shift");',
@@ -239,7 +239,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "press", value: "Enter" },
+      { type: "action", action: "press", value: "Enter" },
       9,
       [
         'await page.keyboard.press("Enter");',
@@ -247,7 +247,7 @@ describe("renderStep", () => {
       ],
     ],
     [
-      { action: "keyUp", value: "Shift" },
+      { type: "action", action: "keyUp", value: "Shift" },
       8,
       [
         'await page.keyboard.up("Shift");',

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-plan.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-plan.test.ts
@@ -18,10 +18,10 @@ describe("translatePlan (golden file)", () => {
           startUrl: "https://example.com",
           tags: ["@wip"],
           steps: [
-            { action: "click", target: "login.form.login" },
-            { action: "fill", target: "login.form.email", value: "a@b.com" },
-            { action: "expectText", target: "login.header.h1", value: "Welcome" },
-            { action: "expectUrl", value: "dashboard" },
+            { type: "action", action: "click", target: "login.form.login" },
+            { type: "action", action: "fill", target: "login.form.email", value: "a@b.com" },
+            { type: "assertion", action: "expectText", target: "login.header.h1", value: "Welcome" },
+            { type: "assertion", action: "expectUrl", value: "dashboard" },
           ],
         },
       ],
@@ -49,7 +49,7 @@ describe("translatePlan - suiteName validation", () => {
         {
           name: "Test name",
           startUrl: "https://example.com",
-          steps: [{ action: "goto", value: "https://example.com" }],
+          steps: [{ type: "action", action: "goto", value: "https://example.com" }],
         },
       ],
     };
@@ -72,7 +72,7 @@ describe("translatePlan - source annotation", () => {
         {
           name: "Test name",
           startUrl: "https://example.com",
-          steps: [{ action: "goto", value: "https://example.com" }],
+          steps: [{ type: "action", action: "goto", value: "https://example.com" }],
         },
       ],
     };

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-single-plan.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.translate-single-plan.test.ts
@@ -6,7 +6,7 @@ describe("_translateSingleTest", () => {
     const testInput: Test = {
       name: "happy path",
       startUrl: "https://example.com",
-      steps: [{ action: "goto", value: "https://example.com/foo" }],
+      steps: [{ type: "action", action: "goto", value: "https://example.com/foo" }],
     };
 
     const out = _translateSingleTest(testInput);
@@ -22,7 +22,7 @@ describe("_translateSingleTest", () => {
       name: "tagged test",
       startUrl: "/",
       tags: ["@fast"],
-      steps: [{ action: "expectUrl", value: "/" }],
+      steps: [{ type: "assertion", action: "expectUrl", value: "/" }],
     };
   
     const out = _translateSingleTest(testInput);
@@ -36,7 +36,7 @@ describe("_translateSingleTest", () => {
       name: "tagged test",
       startUrl: "/",
       tags: ["@fast", "@smoke"],
-      steps: [{ action: "expectUrl", value: "/" }],
+      steps: [{ type: "assertion", action: "expectUrl", value: "/" }],
     };
   
     const out = _translateSingleTest(testInput);
@@ -49,8 +49,8 @@ describe("_translateSingleTest", () => {
       name: "order matters",
       startUrl: "/",
       steps: [
-        { action: "goto", value: "/one" },
-        { action: "expectUrl", value: "one" },
+        { type: "action", action: "goto", value: "/one" },
+        { type: "assertion", action: "expectUrl", value: "one" },
       ],
     };
 
@@ -70,7 +70,7 @@ describe("_translateSingleTest", () => {
     const testInput: Test = {
       name: "formatting",
       startUrl: "/",
-      steps: [{ action: "expectUrl", value: "x" }],
+      steps: [{ type: "assertion", action: "expectUrl", value: "x" }],
     };
 
     const out = _translateSingleTest(testInput);


### PR DESCRIPTION
This PR updates the visibility assertion validation to allow multiple elements to change visibility from a single action. 

Previously, the validator required visibility checks to be exactly 2 steps apart (check -> action -> check), which could be quite limiting. 

Now it groups assertions by target and counts only actions between pairs, ignoring other assertions. This enables test scenarios where multiple elements appear or disappear from one user action, like clicking a toggle that shows/hides several UI components at once.