### PR TITLE
refactor: update selectOption to use label

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.4"
+  version: "1.1.5"
 ---
 
 # AC To Playwright
@@ -208,6 +208,7 @@ Use `npx validate-plan path/to/plan.json` to validate a plan against `references
 
 ## NEVER Do
 
+- **NEVER use bare string values with selectOption** — Playwright's `selectOption()` matches HTML `value` attributes by default, not visible text. AC writers specify visible option text (e.g., "Premium Plan"), so always use `{ label: "text" }` syntax: `.selectOption({ label: "Premium Plan" })`. Using bare strings (`.selectOption("Premium Plan")`) causes silent mismatches where tests pass locally but fail in production because the value attribute differs from display text.
 - **NEVER generate artifacts in assessment mode** — when the user asks to review/evaluate/assess AC, analyze the AC text only and provide the formatted report. Do not generate JSON plans or test files. Do not assume they want full conversion.
 - **NEVER skip controlled vocabulary checks in assessment** — verify that area and component keywords in targets match the lists in `test-hooks.md`. 
 - **NEVER use `goto` action in steps** — tests start at `startUrl`, navigation happens via clicks or fills that trigger page changes. Using goto mid-test breaks Playwright's navigation lifecycle and causes race conditions where assertions run before the page is ready, leading to flaky tests that pass locally but fail in CI.

--- a/skills/accelint-ac-to-playwright/references/acceptance-criteria.md
+++ b/skills/accelint-ac-to-playwright/references/acceptance-criteria.md
@@ -42,8 +42,9 @@ And a user clicks the Submit button on the login form
 - Start URL: the default starting page is `/`. If a test needs a different starting page, state it at the start of your AC.
   - Example: "Given the user is on the settings page"
 - Action verbs: use clear action verbs so that the agent can map to test steps (such as "click", "fill", "select", "hover", "reload", "press", "see"). Avoid vague verbs like "interact" or "use".
-- Input values: include exact values for fills/selects.
+- Input values: include exact values for fills/selects. For dropdowns, specify the visible option text that users see.
   - Example: "the user fills the email input field with 'test@example.com'"
+  - Example: "the user selects 'Premium Plan' from the plan dropdown on the form"
 - Expected outcomes: state exactly what should happen and how to verify it.
   - Example: "success text that says 'Submitted' appears on a toast"
 - Visibility changes: be explicit when something appears/disappears. The agent is looking for clue words to understand that visibility changes are expected (e.g., "visible", "appears", "shows", "see", "changes", "hides", and similar wording).

--- a/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/translate-plan-to-tests.render-step.test.ts
@@ -105,7 +105,7 @@ describe("renderStep", () => {
       6,
       [
         'await expect(page.getByTestId("#role")).toHaveCount(1);',
-        'await page.getByTestId("#role").selectOption("admin");',
+        'await page.getByTestId("#role").selectOption({ label: "admin" });',
         'attachFailureArtifacts({ page, testInfo, stepIndex: 6, action: "select", testId: "#role" })'
       ],
     ],

--- a/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/translate-plan-to-tests.ts
@@ -379,7 +379,7 @@ function renderStep(step: Step, stepIndex: number): string {
       return [
         `    try {`,
         `      await expect(${locator}).toHaveCount(1);`,
-        `      await ${locator}.selectOption(${JSON.stringify(step.value)});`,
+        `      await ${locator}.selectOption({ label: ${JSON.stringify(step.value)} });`,
         `    } catch (error) {`,
         `      await attachFailureArtifacts({ page, testInfo, stepIndex: ${stepIndex}, action: "${step.action}", testId: ${JSON.stringify(step.target)} });`,
         `      throw error;`,


### PR DESCRIPTION
Currently, when a user wants to use a select dropdown menu, they must specify the value of the option they want. That's not intuitive - users will select the label of the option they want. This quick refactor addresses that.