### PR TITLE
fix: improve ts poor practices based on feedback from `accelint-ts-best-practices`

### DIFF
--- a/skills/accelint-ac-to-playwright/SKILL.md
+++ b/skills/accelint-ac-to-playwright/SKILL.md
@@ -4,7 +4,7 @@ description: Convert and validate acceptance criteria for Playwright test automa
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.7"
+  version: "1.1.8"
 ---
 
 # AC To Playwright

--- a/skills/accelint-ac-to-playwright/scripts/cli/append-json-summary-entry.ts
+++ b/skills/accelint-ac-to-playwright/scripts/cli/append-json-summary-entry.ts
@@ -82,7 +82,7 @@ export function run(
 ): number {
   // Parse args
   const parsed = parseArgs(argv.slice(2));
-  const commonErrors = handleCliCommonErrors({
+  const exitCode = handleCliCommonErrors({
     parsed,
     runtime,
     printUsage,
@@ -93,7 +93,7 @@ export function run(
       test: "Error: Missing required option: --test <spec.ts>",
     },
   });
-  if (commonErrors !== null) return commonErrors;
+  if (exitCode >= 0) return exitCode;
   if (!parsed.summaryJson || !parsed.input || !parsed.plan || !parsed.test) {
     return 1;
   }

--- a/skills/accelint-ac-to-playwright/scripts/cli/create-markdown-summary.ts
+++ b/skills/accelint-ac-to-playwright/scripts/cli/create-markdown-summary.ts
@@ -76,7 +76,7 @@ export function run(
 ): number {
   // Parse args
   const parsed = parseArgs(argv.slice(2));
-  const commonErrors = handleCliCommonErrors({
+  const exitCode = handleCliCommonErrors({
     parsed,
     runtime,
     printUsage,
@@ -85,7 +85,7 @@ export function run(
       summaryMd: "Error: Missing required option: --summary-md <path>",
     },
   });
-  if (commonErrors !== null) return commonErrors;
+  if (exitCode >= 0) return exitCode;
   if (!parsed.summaryJson || !parsed.summaryMd) return 1;
 
   // Grab the summary file

--- a/skills/accelint-ac-to-playwright/scripts/cli/generate-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/cli/generate-tests.ts
@@ -79,7 +79,7 @@ export function run(
 ): number {
   // Parse args
   const parsed = parseArgs(argv.slice(2));
-  const commonErrors = handleCliCommonErrors({
+  const exitCode = handleCliCommonErrors({
     parsed,
     runtime,
     printUsage,
@@ -88,7 +88,7 @@ export function run(
       summaryDir: "Error: Missing required option: --summary-dir <path>",
     },
   });
-  if (commonErrors !== null) return commonErrors;
+  if (exitCode >= 0) return exitCode;
   if (!parsed.testsDir || !parsed.summaryDir) return 1;
 
   const summaryJsonPath = runtime.path.join(

--- a/skills/accelint-ac-to-playwright/scripts/cli/generate-tests.ts
+++ b/skills/accelint-ac-to-playwright/scripts/cli/generate-tests.ts
@@ -18,8 +18,11 @@ import { run as createMarkdownSummary } from "./create-markdown-summary";
 type FsSubset = {
   existsSync: (path: fs.PathLike) => boolean;
   statSync: (path: fs.PathLike) => fs.Stats;
-  // readdirSync has complex overloads - using loose typing here
-  readdirSync: (path: fs.PathLike, options?: any) => any;
+  // Explicitly type the withFileTypes overload used in expandSegment()
+  readdirSync: (
+    path: fs.PathLike,
+    options: { withFileTypes: true }
+  ) => fs.Dirent[];
   readFileSync: (
     path: fs.PathOrFileDescriptor,
     encoding: BufferEncoding,

--- a/skills/accelint-ac-to-playwright/scripts/tests/generate-tests.run.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/generate-tests.run.test.ts
@@ -359,7 +359,7 @@ describe("run()", () => {
   it("returns empty listings for unknown directories", () => {
     const state = makeRuntime();
 
-    const result = state.runtime.fs.readdirSync("/repo/unknown");
+    const result = state.runtime.fs.readdirSync("/repo/unknown", { withFileTypes: true });
 
     expect(result).toEqual([]);
   });

--- a/skills/accelint-ac-to-playwright/scripts/tests/generate-tests.test-utils.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/generate-tests.test-utils.ts
@@ -3,7 +3,8 @@ import * as path from "node:path";
 import { vi } from "vitest";
 import type { CliRuntime } from "../cli/generate-tests";
 
-type FakeDirent = { name: string };
+// Minimal Dirent implementation - only includes what production code actually uses
+type FakeDirent = Pick<fs.Dirent, "name">;
 
 type FakeStat = {
   isDirectory: () => boolean;
@@ -60,10 +61,15 @@ export function makeRuntime(overrides?: RuntimeOverrides): RuntimeState {
         return stat as fs.Stats;
       }),
 
-      readdirSync: vi.fn((p) => {
+      readdirSync: vi.fn((p, opts) => {
+        // Production code only uses { withFileTypes: true }. Validate to prevent test bugs.
+        if (!opts || !opts.withFileTypes) {
+          throw new Error(
+            `readdirSync mock called with invalid options. Expected { withFileTypes: true }, got: ${JSON.stringify(opts)}`
+          );
+        }
         const entries = dirListings.get(toPathKey(p)) ?? [];
-        // Return FakeDirent[] which has .name property used by production code
-        return entries;
+        return entries as fs.Dirent[];
       }),
 
       readFileSync: vi.fn<CliRuntime["fs"]["readFileSync"]>(),
@@ -101,7 +107,7 @@ export function makeRuntime(overrides?: RuntimeOverrides): RuntimeState {
 export function addDir(state: RuntimeState, dirPath: string, entries: string[]): string {
   const abs = path.resolve(dirPath);
   state.dirs.add(abs);
-  state.dirListings.set(abs, entries.map((name) => ({ name })));
+  state.dirListings.set(abs, entries.map((name): FakeDirent => ({ name })));
   return abs;
 }
 

--- a/skills/accelint-ac-to-playwright/scripts/tests/utils-cli.test.ts
+++ b/skills/accelint-ac-to-playwright/scripts/tests/utils-cli.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { handleCliCommonErrors } from "../utils/cli";
 
 describe("handleCliCommonErrors", () => {
-  it("returns null when there are no help/errors and required is omitted", () => {
+  it("returns -1 when there are no help/errors and required is omitted", () => {
     const log = vi.fn();
     const error = vi.fn();
     const printUsage = vi.fn();
@@ -13,13 +13,13 @@ describe("handleCliCommonErrors", () => {
       printUsage,
     });
 
-    expect(result).toBeNull();
+    expect(result).toBe(-1);
     expect(printUsage).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
   });
 
-  it("returns null when required keys are present and truthy", () => {
+  it("returns -1 when required keys are present and truthy", () => {
     const log = vi.fn();
     const error = vi.fn();
     const printUsage = vi.fn();
@@ -31,7 +31,7 @@ describe("handleCliCommonErrors", () => {
       required: { summaryJson: "Error: Missing required option: --summary-json <path>" },
     });
 
-    expect(result).toBeNull();
+    expect(result).toBe(-1);
     expect(printUsage).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();

--- a/skills/accelint-ac-to-playwright/scripts/utils/cli.ts
+++ b/skills/accelint-ac-to-playwright/scripts/utils/cli.ts
@@ -11,12 +11,18 @@ type ParsedArgs = {
 
 type UsagePrinter = (log: (...args: unknown[]) => void) => void;
 
+/**
+ * Handle common CLI errors (help flag, parse errors, missing required options).
+ * Returns -1 to signal "no errors found, caller should continue".
+ * Returns 0 for help text displayed successfully.
+ * Returns 1 for validation errors.
+ */
 export function handleCliCommonErrors(params: {
   parsed: ParsedArgs;
   runtime: CliRuntime;
   printUsage: UsagePrinter;
   required?: Record<string, string>;
-}): number | null {
+}): number {
   const { parsed, runtime, printUsage, required } = params;
 
   if (parsed.help) {
@@ -41,7 +47,7 @@ export function handleCliCommonErrors(params: {
     }
   }
 
-  return null;
+  return -1;
 }
 
 function failRequired(


### PR DESCRIPTION
I ran the `accelint-ts-best-practices` skill on the Playwright skill and it found two things I could improve - removing an any type that had snuck in, and having a function return a sensical value rather than null. Fixed both those here.

Full results if anyone is interested: https://gitlab.accelint.dev/buildex/meta/-/issues/21

This should be merged after #112 