### PR TITLE
refactor: alter context doc skills to provide cross links

### DIFF
--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -80,6 +80,20 @@ Determine whether the current working directory is a monorepo root or a package 
 
 ---
 
+#### Step 1.5 — Check for Related Documents
+
+Before detecting ARCHITECTURE.md state, check for related onboarding documents:
+
+1. **Check for openspec/config.yml or openspec/config.yaml**
+   - If exists: Read it to extract stack facts (runtime, frameworks, libraries, patterns)
+   - Use this info to pre-fill tech stack sections and avoid redundant scanning
+   - Note its existence for cross-referencing in generated doc
+   - Announce: "Found openspec/config.yml — I'll use it as the source of truth for stack facts and coding patterns."
+
+This reduces scanning work and ensures consistency with the project's defined stack.
+
+---
+
 #### Step 2 — File Detection
 
 ```
@@ -199,7 +213,7 @@ Ask only about what discovery couldn't determine. Group related questions into n
 
 2. Ask: *"Does this look right? Any sections to correct before I write?"*
 
-3. After confirmation, write to ARCHITECTURE.md at the target location (root or package dir), **stripping inference source comments** — they are for review only, not the final file.
+3. After confirmation, write to ARCHITECTURE.md at the target location (root or package dir), **stripping inference source comments** — they are for review only, not the final file. **For openspec/config.yml references:** only include them if the file actually exists (checked in Step 1.5). Do not add references to files that don't exist.
 
 4. **Update agent behavior doc if present** — if Agent A found AGENTS.md or CLAUDE.md, check whether it references ARCHITECTURE.md. If not, append a reference block to help agents understand the system structure (see instructions below).
 

--- a/skills/accelint-architecture-doc/references/template.md
+++ b/skills/accelint-architecture-doc/references/template.md
@@ -7,6 +7,9 @@ Use this exact structure. Fill every `[placeholder]` with content from codebase 
 ```markdown
 # Architecture Overview
 
+<!-- If openspec/config.yml exists, add this reference after the title: -->
+<!-- > **Tech Stack:** See [openspec/config.yml](./openspec/config.yml) for detailed stack facts, coding patterns, and domain concepts. -->
+
 This document serves as a critical, living reference designed to equip agents and engineers with a rapid and comprehensive understanding of the codebase's architecture. Update this document as the codebase evolves.
 
 ## 1. Project Structure
@@ -25,6 +28,9 @@ This document serves as a critical, living reference designed to equip agents an
      Annotate each entry with its architectural role, not just its name. -->
 
 ## 2. High-Level System Diagram
+
+<!-- If openspec/config.yml exists, add this intro: -->
+<!-- > Complete stack facts and coding patterns are in [openspec/config.yml](./openspec/config.yml). This section provides deployment and runtime context. -->
 
 <!-- Use ASCII art for a simple block diagram showing major components and data flow.
      Keep it at a 10,000-foot view — no schemas, no function signatures. -->
@@ -114,6 +120,9 @@ This document serves as a critical, living reference designed to equip agents an
 **Key Security Tools / Practices:** [e.g., Dependabot, SAST via CodeQL, WAF via Cloudflare]
 
 ## 8. Development & Testing Environment
+
+<!-- If openspec/config.yml exists, add this intro: -->
+<!-- > Testing patterns and standards are defined in [openspec/config.yml](./openspec/config.yml); this section covers local setup and commands. -->
 
 **Local Setup:** [Link to CONTRIBUTING.md, or brief steps: `cp .env.example .env && docker-compose up`]
 

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -109,6 +109,20 @@ directory is a package inside a monorepo. If a root-level `AGENTS.md` or
    repeating the content. If the user flags additions or overrides: ask the
    normal turn questions scoped to what's actually missing or different.
 
+**Step 1.5 — Check for Related Documents**
+
+Before detecting local AGENTS.md state, check for related onboarding documents:
+
+1. **Check for openspec/config.yml or openspec/config.yaml**
+   - If exists: Read it to understand the project's stack and patterns
+   - Note its existence for the "Related Documentation" section
+   - Announce: "Found openspec/config.yml — I'll reference it for the separation of concerns boundary."
+
+2. **Check for ARCHITECTURE.md**
+   - If exists: Read it to understand system structure
+   - Note its existence for the "Related Documentation" section
+   - Announce: "Found ARCHITECTURE.md — I'll reference it in the behavioral docs."
+
 **Step 2 — Local file detection**
 
 ```
@@ -403,7 +417,9 @@ rather than omitting the section.
 3. After confirmation, write to `AGENTS.md` at the project root (or
    `CLAUDE.md` if the user is using Claude Code conventions), **stripping
    the inference source comments** — they are for review only, not the
-   final file.
+   final file. **For the Related Documentation section:** only include
+   links to files that actually exist in the repository. Check for each file
+   (openspec/config.yml, ARCHITECTURE.md, README.md) before including its link.
 4. Print a brief summary of what was generated, what was inferred vs.
    answered directly, and which `<!-- TODO -->` sections still need human
    input.
@@ -591,6 +607,18 @@ with placeholder text.
 ### Security Sensitivity
 - [any areas requiring special care, e.g., "treat all environment variable
   names as sensitive — never log them, even in debug output"]
+
+---
+
+## Related Documentation
+
+<!-- Include only files that actually exist in the repository -->
+
+- **openspec/config.yaml** — Project DNA: stack facts, coding patterns, domain concepts  
+  *(Separation of concerns: this file defines WHAT the project is; AGENTS.md defines HOW agents behave)*
+- **ARCHITECTURE.md** — System architecture, deployment overview, component interactions  
+  *(Reference this when behavioral decisions depend on understanding system structure)*
+- **README.md** — Installation, quick start, usage guide for developers
 ```
 
 ---

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -53,7 +53,23 @@ Before any interview question is asked, check whether `openspec/config.yaml`
 exists and assess its state. Never silently pick a mode — always announce the
 detected mode to the user and confirm before proceeding.
 
-**Detection logic:**
+**Step 1 — Check for Related Documents**
+
+Before detecting config.yaml state, check for related onboarding documents:
+
+1. **Check for ARCHITECTURE.md**
+   - If exists: Read it to understand deployment and infrastructure
+   - Use it to pre-fill answers for Turn 2 (infrastructure/deployment questions)
+   - Note its existence for the "Related Documentation" section
+   - Announce: "Found ARCHITECTURE.md — I'll use it to avoid asking questions
+     about deployment that are already documented."
+
+Note: AGENTS.md and README.md should NOT influence config.yml generation since
+they contain behavioral/usage info, not project DNA.
+
+**Step 2 — Detect Config State**
+
+After checking related documents, assess the config file state:
 
 ```
 Does openspec/config.yaml exist?
@@ -359,7 +375,9 @@ is an invisible gap.
    the file?"*
 3. After confirmation, write to `openspec/config.yaml` (create directory if
    needed), **stripping the inference source comments** — they are for review
-   only, not the final file.
+   only, not the final file. **For the Related Documentation section:** only include
+   links to files that actually exist in the repository. Check for each file
+   (ARCHITECTURE.md, AGENTS.md/CLAUDE.md, README.md) before including its link.
 4. **Validate the generated YAML** — after writing, read the file back and verify:
    - No tabs (YAML requires spaces for indentation)
    - Values with special characters are properly quoted
@@ -646,6 +664,14 @@ rules:
     - Include concrete example data relevant to the domain
     - Document edge cases explicitly
     [user-specific spec rules]
+
+# ═══════════════════════════════════════════════════════════════════════════
+# RELATED DOCUMENTATION
+# ═══════════════════════════════════════════════════════════════════════════
+# Include only files that actually exist in the repository:
+# - ARCHITECTURE.md: System overview, deployment, component interactions, data flows
+# - AGENTS.md: Agent behavior rules, workflow procedures, communication style
+# - README.md: Installation, quick start, usage guide
 ```
 
 ---

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -54,6 +54,33 @@ project-root/           # README here documents entire monorepo
 └── README.md
 ```
 
+### Step 1.5: Check for Related Documentation
+
+Before analyzing the codebase, check if other onboarding documents exist:
+
+1. **Check for openspec/config.yml or openspec/config.yaml**
+   - If exists: Read it to extract:
+     - Package manager (use this instead of lockfile detection)
+     - Tech stack summary
+     - Key libraries and frameworks
+   - Skip redundant codebase scanning for these facts
+
+2. **Check for ARCHITECTURE.md**
+   - If exists: Read it to understand:
+     - System components and their purposes
+     - Deployment model
+     - External integrations
+   - Use for "Architecture & Development Guides" cross-reference section
+
+3. **Check for AGENTS.md or CLAUDE.md**
+   - If exists: Note for "Contributing" section
+   - Reference it for contribution guidelines
+
+**Benefits:**
+- Reduces scanning when other docs exist
+- Ensures consistency (README uses same package manager as config.yml)
+- Creates proper cross-references automatically
+
 ### Step 2: Parallel Codebase Discovery
 
 **Use parallel sub-agents when available** to discover different aspects of the codebase simultaneously. If sub-agents are not available, perform these discovery tasks inline but in the same systematic order.
@@ -102,6 +129,8 @@ If a README exists, identify gaps:
 Follow the [README Structure](references/readme-structure.md) and apply [Writing Principles](references/writing-principles.md).
 
 Use the [README Template](references/readme-template.md) as a starting point for new READMEs.
+
+**For the Architecture & Development Guides section (section 11):** only include it if at least one of the related docs exists (checked in Step 1.5). Within the section, only list files that actually exist — do not include links to missing files. If none of the three docs exist (openspec/config.yml, ARCHITECTURE.md, AGENTS.md/CLAUDE.md), omit this section entirely.
 
 ## README Workflow Decision Tree
 

--- a/skills/accelint-readme-writer/references/readme-structure.md
+++ b/skills/accelint-readme-writer/references/readme-structure.md
@@ -19,7 +19,8 @@ READMEs must follow this section order. Users expect to find information in pred
 8.  Examples
 9.  Further Reading (optional)
 10. License
-11. Contributing (optional)
+11. Architecture & Development Guides (optional)
+12. Contributing (optional)
 ```
 
 ---
@@ -350,7 +351,30 @@ MIT - see [LICENSE](./LICENSE) for details.
 
 ---
 
-## 11. Contributing (Optional)
+## 11. Architecture & Development Guides (Optional)
+
+<!-- Include this section only if any of these files exist: openspec/config.yml, ARCHITECTURE.md, AGENTS.md -->
+
+Links to deeper technical and behavioral documentation that complements the README.
+
+**✅ Correct**
+```markdown
+## Architecture & Development Guides
+
+For deeper technical and behavioral context:
+
+- **[openspec/config.yml](./openspec/config.yml)** — Tech stack, coding patterns, and domain concepts
+- **[ARCHITECTURE.md](./ARCHITECTURE.md)** — System architecture, deployment, and data flows
+- **[AGENTS.md](./AGENTS.md)** — How AI agents should behave when working in this codebase
+
+These documents form a layered guidance system: config.yml defines what the project is, ARCHITECTURE.md explains how it's structured and deployed, and AGENTS.md governs how agents collaborate on it.
+```
+
+**Note:** Only include files that actually exist. Check for openspec/config.yml (or config.yaml), ARCHITECTURE.md, and AGENTS.md/CLAUDE.md before adding this section. If none exist, omit this section entirely.
+
+---
+
+## 12. Contributing (Optional)
 
 How to contribute to the project.
 


### PR DESCRIPTION
Adds cross links to other context documents, related to #95 