### PR TITLE
refactor: doc updating

### DIFF
--- a/skills/accelint-architecture-doc/README.md
+++ b/skills/accelint-architecture-doc/README.md
@@ -61,7 +61,8 @@ The skill operates in three phases:
 Before scanning anything, the skill checks:
 
 1. **Monorepo detection** - figures out if you're at the repo root or inside a package, then adjusts scope
-2. **File state** - checks if ARCHITECTURE.md exists and whether it follows the standard template
+2. **Related documents** - looks for openspec/config.yml to extract stack facts and avoid redundant scanning
+3. **File state** - checks if ARCHITECTURE.md exists and whether it follows the standard template
 
 Based on what it finds, it picks one of three modes:
 
@@ -257,13 +258,17 @@ For each detected change, the skill asks questions to understand the context ins
 
 ### Agent Behavior Doc Integration
 
-If the skill finds `AGENTS.md` or `CLAUDE.md` during discovery, it adds a reference block at the top of ARCHITECTURE.md:
+After writing ARCHITECTURE.md, if the skill found `AGENTS.md` or `CLAUDE.md` during discovery, it updates the agent behavior file to reference ARCHITECTURE.md. This ensures agents know where to look for system architecture details.
+
+The skill adds this block to the agent behavior file:
 
 ```markdown
-> **Agent Behavior:** See [AGENTS.md](./AGENTS.md) for how AI agents should behave when working in this codebase.
+## System Architecture
+
+For technical architecture details (components, deployment, data stores, tech stack), see [ARCHITECTURE.md](./ARCHITECTURE.md).
 ```
 
-This connects architectural context with behavioral instructions.
+This creates a one-way reference: agent behavior docs point to architecture docs (not the reverse), since understanding system architecture informs agent behavior.
 
 ### Inference Source Annotations
 

--- a/skills/accelint-onboard-agent/README.md
+++ b/skills/accelint-onboard-agent/README.md
@@ -23,7 +23,7 @@ Trigger phrases: "create AGENTS.md", "set up agent rules", "configure claude cod
 
 **Phase 0: File state detection**
 
-Checks if AGENTS.md exists and picks a mode. In monorepos, also looks for a root-level AGENTS.md to avoid duplicating global instructions.
+First checks if this is a monorepo package — if a root-level AGENTS.md exists above the current directory, reads it to avoid duplicating global instructions. Then checks for related onboarding documents (openspec/config.yml, ARCHITECTURE.md, AGENTS.md/CLAUDE.md) to understand what already exists. Finally assesses the local AGENTS.md state and picks the right mode (Create, Import, or Refresh).
 
 **Phase 1: Discovery interview**
 
@@ -54,7 +54,7 @@ Shows you the complete file with source comments on inferred values:
 - Use Conventional Commits (`feat:`, `fix:`)  # inferred from commitlint.config.ts
 ```
 
-After you confirm, it writes the file without the source comments.
+After you confirm, it writes the file without the source comments. The generated file includes a Related Documentation section that cross-references other onboarding docs found in Phase 0 (openspec/config.yml, ARCHITECTURE.md, README.md) — only files that actually exist are included.
 
 ## AGENTS.md structure
 
@@ -171,6 +171,11 @@ Example: `feat(layer): add WebGPU fallback for Safari`
 - [ ] Never force-push to any branch       # inferred from branch protection
 - [ ] Never commit secrets or credentials
 - [ ] Never use `any` in TypeScript
+
+## Related Documentation
+- **openspec/config.yaml** — Project DNA: stack facts, coding patterns, domain concepts
+- **ARCHITECTURE.md** — System architecture, deployment overview, component interactions
+- **README.md** — Installation, quick start, usage guide for developers
 ```
 
 ## Version history

--- a/skills/accelint-onboard-openspec/README.md
+++ b/skills/accelint-onboard-openspec/README.md
@@ -40,6 +40,18 @@ You need Claude Code with agent spawning for parallel inference. A git repositor
 
 The entire process takes 5-10 minutes depending on project complexity and interview depth.
 
+## Related documentation checks
+
+Before running the interview, the skill checks for existing onboarding documents:
+
+- **ARCHITECTURE.md** - Used to pre-fill infrastructure/deployment questions, avoiding redundant questions
+- **AGENTS.md / CLAUDE.md** - Noted for cross-reference in "Related Documentation" section
+- **README.md** - Noted for cross-reference in "Related Documentation" section
+
+When ARCHITECTURE.md exists, the skill announces: "Found ARCHITECTURE.md — I'll use it to avoid asking questions about deployment that are already documented."
+
+This ensures consistency across documentation and reduces interview time.
+
 ## Configuration modes
 
 The skill has three modes based on file state:
@@ -183,6 +195,24 @@ rules:
 
 Every section matters. Missing fields degrade the AI artifacts that use this config. Unresolved fields get marked `# TODO: fill in` rather than omitted.
 
+The complete template structure is defined in the skill and includes:
+
+- **Stack Facts** - Project identity, tech stack, architecture patterns, domain concepts, performance targets
+- **Patterns to Follow** - Code patterns, architecture patterns, testing patterns with AAA structure
+- **Patterns to Avoid** - Code anti-patterns, performance anti-patterns, testing anti-patterns, documentation anti-patterns
+- **Per-Artifact Rules** - Checkpoints for proposals, designs, tasks, and specifications
+- **Related Documentation** - Links to ARCHITECTURE.md, AGENTS.md/CLAUDE.md, README.md (only if files exist)
+
+### Interaction principles
+
+The interview follows conversational design:
+
+- **Bundle questions** - Group related questions into natural turns, not bullet-dump forms
+- **Infer and confirm** - "You mentioned Vitest — I'll assume testing-library for React; correct?" beats asking from scratch
+- **Examples reduce ambiguity** - When asking about conventions, provide examples for pattern-matching
+- **Preview before writing** - Show full config with confirmation before touching filesystem
+- **Infer before asking, ask before omitting** - Attempt codebase inference for all fields; mark unresolved as `# TODO:` rather than dropping sections
+
 ## YAML safety features
 
 The skill enforces YAML generation rules:
@@ -220,19 +250,57 @@ Before writing, the skill checks:
 
 After writing, it reads the file back to verify it's valid YAML.
 
+## YAML generation safety
+
+The skill enforces strict YAML syntax rules to prevent parse errors.
+
+### Quoting requirements
+
+Values starting with special characters need quotes:
+
+| Special Character | Example | Solution |
+|------------------|---------|----------|
+| `(`, `)` | `(internal) auth` | `"(internal) auth"` |
+| `[`, `]` | `[PKG:auth]` | `"[PKG:auth]"` |
+| `|` | `some|other` | `"some|other"` |
+| `:` in value | `Time: 5pm` | `"Time: 5pm"` |
+| `"`, `'` | `npm run "test"` | `'npm run "test"'` |
+
+### Block scalars
+
+Multi-line content uses literal block indicators:
+
+```yaml
+context: |
+  Line 1
+  Line 2
+  Line 3
+```
+
+### Validation checklist
+
+After generating config, the skill verifies:
+- No tab characters (YAML requires spaces)
+- Matching quote pairs
+- Consistent 2-space indentation
+- Aligned list items
+- Quoted special characters
+
+It reads the file back after writing to catch any parse errors.
+
 ## Smart defaults
 
 The skill suggests stack-specific conventions. Next.js + TypeScript + Tailwind gets questions about App Router vs Pages Router, Server Component boundaries, and `"use client"` directive placement. React + Vitest assumes `userEvent` over `fireEvent` and role-based queries. Python + FastAPI asks about Pydantic v1 vs v2 and dependency injection. Node.js + Prisma asks about transaction patterns and soft-delete conventions.
 
 This reduces open-ended questions.
 
-## Companion skill: `accelint-onboard-agent`
+## Companion skill: `accelint-onboard-agents`
 
-This skill produces the project DNA layer (structural facts). Its companion `accelint-onboard-agent` produces the behavior layer (`AGENTS.md` / `CLAUDE.md`) covering how the agent acts, communicates, and makes decisions.
+This skill produces the project DNA layer (structural facts). Its companion `accelint-onboard-agents` produces the behavior layer (`AGENTS.md` / `CLAUDE.md`) covering how the agent acts, communicates, and makes decisions.
 
 If you volunteer behavioral content during the OpenSpec interview (commit conventions, workflow steps, tool preferences), the skill will redirect you:
 
-> "That's behavioral - it belongs in AGENTS.md. I'll note it here for reference, but the `accelint-onboard-agent` skill is where to capture it."
+> "That's behavioral - it belongs in AGENTS.md. I'll note it here for reference, but the `accelint-onboard-agents` skill is where to capture it."
 
 The two skills don't overlap.
 
@@ -309,6 +377,6 @@ Apache-2.0
 
 ## Related skills
 
-- `accelint-onboard-agent` - Generate behavioral configuration (`AGENTS.md` / `CLAUDE.md`)
+- `accelint-onboard-agents` - Generate behavioral configuration (`AGENTS.md` / `CLAUDE.md`)
 - `accelint-readme-writer` - Generate README documentation
-- `accelint-architecture-doc` - Create architecture.md with parallel discovery (pattern reference for this skill)
+- `accelint-architecture-doc` - Create ARCHITECTURE.md with parallel discovery (pattern reference for this skill)

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -536,17 +536,19 @@ context: |
   # ═══════════════════════════════════════════════════════════════════════════
 
   ## Code Patterns
-  - Exports:        [named / default / mixed — and when each applies]
-  - Naming:         [files, variables, functions, constants, types]
-  - Error handling: [throw / Result<T,E> / boundaries / other]
-  - Validation:     [approach and library]
-  - Constants:      Use `as const` objects, never `enum`
-  - Classes:        Prefer functions over classes unless state management required or extending existing class
-  - Return values:  Return zero values (empty array, empty string, 0) instead of null/undefined
-  - Type safety:    Avoid `any` (use `unknown` or generics); avoid `enum` (use `as const` objects); use `type` over `interface`
-  - Immutability:   Prefer `const`, immutable data structures, pure functions
-  - Documentation:  Comprehensive JSDoc for all exported code (@param, @returns, @template, @example)
-  - Order:          Internal functions, variables and types should be defined before they are used (internal/export types -> internal/export constants -> internal/export functions)
+  - Exports:         [named / default / mixed — and when each applies]
+  - Naming:          [files, variables, functions, constants, types]
+  - Error handling:  [throw / Result<T,E> / boundaries / other]
+  - Validation:      [approach and library]
+  - Constants:       Use `as const` objects, never `enum`
+  - Classes:         Prefer functions over classes unless state management required or extending existing class
+  - Return values:   Return zero values (empty array, empty string, 0) instead of null/undefined
+  - Type safety:     Avoid `any` (use `unknown` or generics); avoid `enum` (use `as const` objects); use `type` over `interface`
+  - Immutability:    Prefer `const`, immutable data structures, pure functions
+  - Documentation:   Comprehensive JSDoc for all exported code (@param, @returns, @template, @example)
+  - Order:           Internal functions, variables and types should be defined before they are used (internal/export types -> internal/export constants -> internal/export functions)
+  - Parameter order: Data-last ordering — place the data being operated on as the final parameter. Enables partial application and composition.
+  - Composition:     Use curried functions when the same first parameter(s) recur across call sites.
 
   ## Architecture Patterns
   - [pattern name]: [brief description of how it's used here]

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.1.0] - 2026-06-18
+
+### Added
+- **Phase 4: Update Living Documents** — After successful verification, automatically updates project documentation to reflect implemented changes
+  - Updates openspec/config.yaml (project DNA: stack, patterns, domain concepts)
+  - Updates ARCHITECTURE.md if present (system structure: components, deployment, infrastructure)
+  - Updates AGENTS.md if present (agent behavior: workflow, tools, guardrails)
+  - Updates README.md if present (user documentation: installation, features, usage)
+- Skill availability detection to intelligently use Accelint skills when available or fall back to manual updates
+- Boundary-respecting manual update instructions for each document type:
+  - OpenSpec config: project DNA (what the project is) — tech stack, domain concepts, code patterns, per-artifact rules
+  - ARCHITECTURE.md: system structure (how components relate) — architecture layers, system diagrams, components, data stores
+  - AGENTS.md: agent behavior (how agents act) — workflows, decision heuristics, tool preferences, guardrails
+  - README.md: user documentation (public API) — installation, features, usage examples, configuration
+
+### Changed
+- Workflow Overview diagram updated to include "Update Docs" phase between Verify and Report
+- Phase 4 renamed to Phase 5 (Report and Next Steps remains the final phase)
+- Documentation update phase only runs if verification passed (no CRITICAL issues)
+
+### Rationale
+- **Why update docs post-verification**: OpenSpec changes represent significant architectural decisions and feature additions. Living documents provide human-readable context about the system's current state. Updating them post-implementation prevents documentation drift and ensures the next engineer (or Claude) has accurate context.
+- **Why skill-first with manual fallback**: Using dedicated Accelint skills ensures consistency and leverages specialized knowledge. Manual fallback instructions respect each document's scope boundaries, preventing cross-contamination (e.g., not adding agent behavior to config.yaml).
+- **Why boundary-specific instructions**: Each document serves a distinct purpose in the agent instruction stack. Manual updates must respect these boundaries to maintain separation of concerns (project DNA vs system structure vs agent behavior vs user docs).
+
+### Version
+- Bumped from 1.0.0 → 1.1.0
+
 ## [1.0.0] - 2026-05-04
 
 ### Added

--- a/skills/accelint-qrspi-apply/README.md
+++ b/skills/accelint-qrspi-apply/README.md
@@ -58,7 +58,7 @@ openspec update
 
 ## How It Works
 
-### The Four-Phase Workflow
+### The Workflow
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -68,6 +68,7 @@ openspec update
 │  Dependencies   Identify blocking tasks       Execution plan    │
 │  Execute        Run slices (parallel/serial)  Implemented code  │
 │  Verify         Run opsx:verify               Verification rpt  │
+│  Update Docs    Sync living documents         Updated docs      │
 │  Report         Show results + next steps     Archive or fix    │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -131,7 +132,22 @@ This prevents sub-agents from stepping on each other's work while maintaining fu
 4. If CRITICAL issues exist, blocks archival and offers fix options
 5. If only warnings/suggestions, approves for archive
 
-### Phase 4: Report and Next Steps
+### Phase 4: Update Living Documents
+
+**Runs ONLY if verification passed** (no CRITICAL issues):
+
+Updates project documentation to reflect implemented changes:
+
+- **openspec/config.yaml**: Updates via `accelint-onboard-openspec` or manually (project DNA: tech stack, domain concepts, code patterns)
+- **ARCHITECTURE.md**: Updates via `accelint-architecture-doc` or manually (system structure: components, deployment, infrastructure)
+- **AGENTS.md**: Updates via `accelint-onboard-agent` or manually (agent behavior: workflows, tools, guardrails)
+- **README.md**: Updates via `accelint-readme-writer` or manually (user documentation: installation, features, usage)
+
+The skill detects which Accelint skills are available and uses them when possible, falling back to manual updates with boundary-respecting instructions for each document type.
+
+**Why this matters**: OpenSpec changes represent significant architectural decisions. Living documents provide human-readable context about the system's current state. Keeping them synchronized prevents documentation drift and ensures the next engineer (or Claude) has accurate context.
+
+### Phase 5: Report and Next Steps
 
 Presents completion report:
 
@@ -225,6 +241,12 @@ Starting Level 1: Slices 2 and 3 in parallel
 Running validation...
 ✅ Validation passed
 
+Updating living documents...
+📝 Living documents updated
+- openspec/config.yaml [via accelint-onboard-openspec]
+- ARCHITECTURE.md [via accelint-architecture-doc]
+- README.md [via accelint-readme-writer]
+
 ✅ Implementation complete
 
 Ready to archive! Run: `/opsx:archive remove-security-ruleset`
@@ -258,6 +280,9 @@ Skill: Attempting to fix validation errors...
 Re-running validation...
 ✅ Validation passed
 
+Updating living documents...
+📝 Living documents updated
+
 Ready to archive!
 ```
 
@@ -281,6 +306,9 @@ Starting Level 1: Slices 3 and 4 in parallel
 
 Running validation...
 ✅ Validation passed
+
+Updating living documents...
+📝 Living documents updated
 
 Ready to archive!
 ```
@@ -330,8 +358,10 @@ Trust the resumption detection. If you clear context mid-implementation, re-invo
 ## Related Skills
 
 - `accelint-qrspi-propose` - Create QRSPI-planned changes with parallelization strategies (phase 1, prerequisite for this skill)
-- `accelint-onboard-openspec` - Set up OpenSpec configuration for your project
-- `accelint-onboard-agent` - Create AGENTS.md with behavior rules
+- `accelint-onboard-openspec` - Set up OpenSpec configuration (used in Phase 4 doc updates)
+- `accelint-onboard-agent` - Create AGENTS.md with behavior rules (used in Phase 4 doc updates)
+- `accelint-architecture-doc` - Update ARCHITECTURE.md documentation (used in Phase 4 doc updates)
+- `accelint-readme-writer` - Update README.md documentation (used in Phase 4 doc updates)
 
 ## OpenSpec Commands
 

--- a/skills/accelint-qrspi-apply/README.md
+++ b/skills/accelint-qrspi-apply/README.md
@@ -1,0 +1,347 @@
+# Accelint QRSPI Apply
+
+Implement OpenSpec changes with intelligent parallelization. This skill orchestrates parallel execution of independently-sliced tasks from QRSPI-planned changes, dramatically reducing implementation time while maintaining correctness.
+
+## What This Does
+
+Takes a QRSPI-planned OpenSpec change (created via `accelint-qrspi-propose`) and implements it using parallel sub-agents when possible:
+
+- Parses the parallelization strategy from tasks.md
+- Spawns sub-agents to implement independent slices in parallel
+- Tracks progress across dependency levels
+- Verifies implementation matches specs before archival
+- Supports pause/resume workflow for context management
+
+The skill stops after verification. You manually archive when ready.
+
+## When to Use This
+
+Invoke this skill when:
+
+- You have a QRSPI-planned change ready to implement
+- Your tasks.md includes a "Parallelization Strategy" section
+- You want to leverage parallel execution for faster implementation
+- You need progress tracking and resumption support across context clears
+
+Trigger phrases:
+- "apply this QRSPI change"
+- "implement with parallelization"
+- "run the parallel slices"
+- "apply [change-name] using QRSPI"
+
+**Note**: Standard OpenSpec changes without parallelization strategies should use `/opsx:apply` directly.
+
+## Prerequisites
+
+This skill requires:
+
+1. **OpenSpec CLI** - Installed and initialized
+2. **Sub-agent support** - For parallel execution (Claude Code, not Claude.ai)
+3. **Expanded OpenSpec workflows** - `explore`, `new`, `continue` enabled
+4. **QRSPI-planned change** - Created via `accelint-qrspi-propose` skill with "Parallelization Strategy" in tasks.md
+
+### Check workflow configuration:
+
+```bash
+openspec config list
+```
+
+Look for `explore`, `new`, and `continue` in the `workflows:` section.
+
+### Enable if missing:
+
+```bash
+openspec config profile
+# Select "expanded" from the list
+openspec update
+```
+
+## How It Works
+
+### The Four-Phase Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Phase          Action                        Output            │
+├─────────────────────────────────────────────────────────────────┤
+│  Parse          Extract parallelization       Dependency graph  │
+│  Dependencies   Identify blocking tasks       Execution plan    │
+│  Execute        Run slices (parallel/serial)  Implemented code  │
+│  Verify         Run opsx:verify               Verification rpt  │
+│  Report         Show results + next steps     Archive or fix    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Phase 0: Preflight and Change Selection
+
+1. Identifies the change to apply (from arguments or context)
+2. If ambiguous, prompts you to select from available changes
+3. Verifies tasks.md exists and uses markdown checklist format
+4. Exits early with clear errors if prerequisites aren't met
+
+### Phase 1: Parse Tasks and Parallelization Strategy
+
+1. Reads tasks.md from the OpenSpec change directory
+2. Validates checklist format (`- [ ] task` or `- [x] task`)
+3. Detects partial completion from checked tasks (resumption support)
+4. Parses "Parallelization Strategy" section to build dependency graph
+5. Creates execution plan showing which slices run sequentially vs in parallel
+
+**Example dependency graph:**
+
+```
+Level 0 (must run first):
+  - Slice 1: Remove CLI surface
+
+Level 1 (can run in parallel after Level 0):
+  - Slice 2: Remove implementation
+  - Slice 3: Docs/verification
+```
+
+If no strategy is found, falls back to sequential execution (safe default).
+
+### Phase 2: Execute Tasks
+
+Implements tasks following the dependency graph:
+
+**Sequential execution** (for slices with dependencies):
+- Spawns one sub-agent per slice
+- Waits for completion before proceeding to next level
+- Each sub-agent invokes `/opsx:apply` with instructions to work only on its assigned slice
+
+**Parallel execution** (for independent slices):
+- Spawns all slice sub-agents simultaneously
+- Tracks completion as each finishes
+- After each level completes, offers pause/clear/resume options
+
+**Slice isolation**: Each sub-agent receives:
+- Full context files (proposal, design, specs, tasks)
+- Explicit instructions to implement ONLY its assigned slice
+- Awareness that other slices may be running in parallel
+
+This prevents sub-agents from stepping on each other's work while maintaining full visibility.
+
+### Phase 3: Verify Implementation
+
+**MANDATORY** verification before declaring ready to archive:
+
+1. Calls `/opsx:verify <change-name>`
+2. Checks task completion, spec coverage, design adherence
+3. Generates verification report with CRITICAL/WARNING/SUGGESTION issues
+4. If CRITICAL issues exist, blocks archival and offers fix options
+5. If only warnings/suggestions, approves for archive
+
+### Phase 4: Report and Next Steps
+
+Presents completion report:
+
+```
+✅ Implementation complete
+
+**Change:** remove-security-ruleset
+**Tasks:** 12/12 complete
+**Verification:** ✅ Passed
+**Files changed:** 67
+
+### Summary
+- Slice 1: Removed CLI commands and help text
+- Slice 2: Removed implementation files and tests
+- Slice 3: Updated docs and verification
+
+### Changed files
+[output from git status]
+
+### Next steps
+1. Review the changes: `git diff`
+2. Run tests: pnpm test
+3. Archive this change: `/opsx:archive remove-security-ruleset`
+
+Ready to archive!
+```
+
+## Key Concepts
+
+### Context Management and Resumption
+
+The skill supports pause/clear/resume at dependency level boundaries:
+
+- **Pause points**: After each level completes, you can continue or clear context
+- **Resumption detection**: Re-invoking reads task checkboxes to detect completed slices and resumes from next incomplete level
+- **Progress tracking**: Task completion tracked in tasks.md via checkboxes, durable across context clears
+
+Long implementations with many slices can bloat context. By offering pause points between levels, you maintain flexibility to clear context while preserving work progress.
+
+### Intelligent Parallelization
+
+The skill automatically detects parallelization opportunities from the "Parallelization Strategy" section in tasks.md. When slices are independent, it spawns multiple sub-agents to work in parallel, significantly reducing implementation time.
+
+**Example**: A 3-slice change with dependencies might take:
+- Sequential: 8 min (Slice 1) + 6 min (Slice 2) + 7 min (Slice 3) = 21 minutes
+- Parallel: 8 min (Slice 1) + max(6, 7) min (Slices 2&3 parallel) = 15 minutes
+
+### Safe Defaults
+
+If no parallelization strategy is found, the skill runs tasks sequentially. This ensures correctness even for changes that weren't planned with parallelization in mind.
+
+### Validation Before Archive
+
+The skill always runs `/opsx:verify` before declaring the change "ready to archive". This catches incomplete tasks, broken references, or schema violations before archival.
+
+### Vertical Slicing Requirement
+
+This skill is designed specifically for QRSPI's vertical slicing methodology. Each slice must be:
+
+- A complete end-to-end feature increment
+- Independent with minimal file overlap
+- Testable in isolation
+- Safe to implement in parallel
+
+Horizontal (layer-by-layer) slicing breaks this model and should be converted to vertical slices in the propose phase.
+
+## Example Usage
+
+### Scenario 1: Change with parallelization strategy
+
+```
+User: Apply the remove-security-ruleset change
+
+Skill: Applying change: remove-security-ruleset
+
+Parsing parallelization strategy...
+
+Execution plan:
+- Level 0 (sequential): Slice 1 (Remove CLI surface)
+- Level 1 (parallel): Slice 2 (Remove implementation), Slice 3 (Docs/verification)
+
+Starting Level 0: Slice 1
+[spawns sub-agent]
+✓ Slice 1 complete (4 tasks, ~8 minutes)
+
+Starting Level 1: Slices 2 and 3 in parallel
+[spawns 2 sub-agents simultaneously]
+✓ Slice 2 complete (4 tasks, ~6 minutes)
+✓ Slice 3 complete (4 tasks, ~7 minutes)
+
+Running validation...
+✅ Validation passed
+
+✅ Implementation complete
+
+Ready to archive! Run: `/opsx:archive remove-security-ruleset`
+```
+
+### Scenario 2: Validation failure
+
+```
+User: Apply the auth-refactor change
+
+[implementation proceeds...]
+
+Running validation...
+❌ Validation failed
+
+Errors:
+- Task 3.2 in tasks.md is incomplete (checkbox not marked)
+- Spec file specs/auth-service.md references non-existent file: src/old-auth.ts
+
+Options:
+1. Fix issues manually and re-validate
+2. I can attempt to fix issues automatically
+
+User: Fix them automatically
+
+Skill: Attempting to fix validation errors...
+
+- Marking task 3.2 as complete in tasks.md
+- Updating spec reference from src/old-auth.ts → src/auth-service.ts
+
+Re-running validation...
+✅ Validation passed
+
+Ready to archive!
+```
+
+### Scenario 3: Partial completion (resumption)
+
+```
+User: Apply the multi-stage-refactor change
+
+Skill: Applying change: multi-stage-refactor
+
+Detected partial completion. Resuming from Slice 3.
+
+Execution plan:
+✓ Level 0 complete: Slice 1, Slice 2 (already done)
+- Level 1 (current): Slice 3, Slice 4 (starting now)
+
+Starting Level 1: Slices 3 and 4 in parallel
+[spawns 2 sub-agents]
+✓ Slice 3 complete
+✓ Slice 4 complete
+
+Running validation...
+✅ Validation passed
+
+Ready to archive!
+```
+
+## Error Handling
+
+**If tasks.md uses invalid format** (numbered lists or plain bullets):
+- Exits early with error message
+- Asks you to regenerate tasks.md with `accelint-qrspi-propose` or convert manually
+
+**If sub-agent fails or times out**:
+- Reports which slice failed and why
+- Asks if you want to retry that slice or handle manually
+- Does not proceed to dependent slices until blocking slice succeeds
+
+**If circular dependencies detected**:
+- Reports error showing the circular dependency
+- Asks you to fix the parallelization strategy in tasks.md
+
+**If no sub-agent support** (e.g., Claude.ai):
+- Falls back to sequential execution (implements all tasks itself)
+- Informs you: "Sub-agents not available. Running tasks sequentially."
+
+## Configuration Requirements
+
+This skill assumes:
+
+1. OpenSpec installed and initialized (`openspec/` directory exists)
+2. The change exists and has a tasks.md file with markdown checklist format
+3. Sub-agent support available (for parallel execution)
+4. Git initialized (for checking file changes)
+
+If any are missing, the skill reports the issue and guides you through setup.
+
+## Tips
+
+Review the parallelization strategy before running. Make sure slices are truly independent.
+
+Use pause points between levels to clear context on long implementations. Progress is saved in task checkboxes.
+
+The verification phase is mandatory. Don't skip it, even if you're confident in the implementation.
+
+If a slice fails, fix it and retry. The skill won't proceed past blocking slices.
+
+Trust the resumption detection. If you clear context mid-implementation, re-invoke the skill and it'll pick up where you left off.
+
+## Related Skills
+
+- `accelint-qrspi-propose` - Create QRSPI-planned changes with parallelization strategies (phase 1, prerequisite for this skill)
+- `accelint-onboard-openspec` - Set up OpenSpec configuration for your project
+- `accelint-onboard-agent` - Create AGENTS.md with behavior rules
+
+## OpenSpec Commands
+
+This skill uses these OpenSpec CLI commands:
+
+- `/opsx:apply <change-name>` - Implement tasks (delegated to sub-agents)
+- `/opsx:verify <change-name>` - Verify implementation matches artifacts
+- `openspec list --json` - List available changes for selection
+- `openspec status --change "<name>" --json` - Check change state
+
+After this skill completes, you'll use:
+
+- `/opsx:archive <change-name>` - Archive the completed change

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Accelint QRSPI Apply
@@ -39,6 +39,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 │  Dependencies   Identify blocking tasks       Execution plan    │
 │  Execute        Run slices (parallel/serial)  Implemented code  │
 │  Verify         Run opsx:verify               Verification rpt  │
+│  Update Docs    Sync living documents         Updated docs      │
 │  Report         Show results + next steps     Archive or fix    │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -294,7 +295,112 @@ Do NOT skip this phase or mark the change as complete without running verificati
 
 **Output**: Verification report from `opsx:verify`
 
-### Phase 4: Report and Next Steps
+### Phase 4: Update Living Documents
+
+**Goal**: After successful verification, update project documentation to reflect the implemented changes.
+
+CRITICAL: This phase runs ONLY if verification passed (no CRITICAL issues). If verification failed, skip to Phase 5 reporting.
+
+**Why this matters**: OpenSpec changes represent significant architectural decisions and feature additions. Living documents (ARCHITECTURE.md, AGENTS.md, README.md, openspec config) provide human-readable context about the system's current state. Keeping them synchronized prevents documentation drift and ensures the next engineer (or Claude) has accurate context.
+
+**Steps**:
+
+1. Check if the change is in a repository or package root by looking for `.git/` or `package.json`
+2. Determine the repo/package root (may be current directory or a parent)
+3. For each living document, check if it exists and if an Accelint skill is available to update it:
+
+   **a) Update OpenSpec config** (`<repo-root>/openspec/config.yaml`):
+   - Check if `accelint-onboard-openspec` skill is installed:
+     ```bash
+     # Check available skills for the openspec onboarding skill
+     # If found, use it; if not, update manually
+     ```
+   - If skill is available:
+     ```
+     /accelint-onboard-openspec Given this change, we need to make sure that the config is current and up to date
+     ```
+   - If skill is NOT available, read `openspec/config.yaml` and update manually focusing on **project DNA (WHAT the project is)**:
+     - **Tech Stack section**: Add new dependencies, frameworks, or libraries introduced by this change with versions
+     - **Domain Concepts section**: Add new entities or domain terms if this change introduces them
+     - **Code Patterns section**: Update if this change establishes new patterns (exports, error handling, validation approaches)
+     - **Architecture Patterns section**: Add new design patterns if introduced (factory, repository, observer, etc.)
+     - **Patterns to Avoid section**: Add any anti-patterns this change deprecates or makes explicit
+     - **Per-artifact rules** (`rules:` section): Update if this change affects proposal/design/tasks/spec requirements
+     - **DO NOT** add agent behavior (commit conventions, workflow steps, tool preferences belong in AGENTS.md)
+   
+   **b) Update ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
+   - Check if `accelint-architecture-doc` skill is installed
+   - If skill is available:
+     ```
+     /accelint-architecture-doc Given this change, we need to make sure that the ARCHITECTURE.md is current and up to date
+     ```
+   - If skill is NOT available, read `ARCHITECTURE.md` and update manually focusing on **system structure (HOW components relate)**:
+     - **Section 1 (Project Structure)**: Update directory tree if new top-level directories or significant reorganization occurred
+     - **Section 2 (High-Level System Diagram)**: Update ASCII diagram if component relationships changed or new services were added
+     - **Section 3 (Core Components)**: Add new components, services, or packages introduced by this change with their architectural roles
+     - **Section 4 (Data Stores)**: Add new databases, caches, or data stores if introduced
+     - **Section 5 (External Integrations)**: Add new third-party services or APIs this change integrates with
+     - **Section 6 (Deployment & Infrastructure)**: Update if deployment model changed or new infrastructure was added
+     - **Section 8 (Technology Stack)**: Update if this change introduced new runtime dependencies or frameworks
+     - **DO NOT** add coding patterns, testing conventions, or agent behavior (those belong in config.yaml or AGENTS.md)
+   
+   **c) Update AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
+   - Check if `accelint-onboard-agent` skill is installed
+   - If skill is available:
+     ```
+     /accelint-onboard-agent Given this change, we need to make sure that the AGENTS.md is current and up to date
+     ```
+   - If skill is NOT available, read `AGENTS.md` and update manually focusing on **agent behavior (HOW agents should act)**:
+     - **Workflow Procedures section**: Update if this change introduces new workflow steps (e.g., new pre-commit checks, new PR requirements)
+     - **Decision Heuristics section**: Add new decision rules if this change creates situations requiring agent judgment
+     - **Tool Preferences section**: Update if new tools were introduced or tool usage changed (e.g., new test runner, new linter)
+     - **Guardrails section**: Add new "never do" or "always ask first" rules if this change creates new risk areas
+     - **Pre-Commit Checklist**: Add new validation commands if required before commit
+     - **Commit Messages section**: Update if commit convention changed
+     - **DO NOT** add tech stack facts, domain concepts, or coding patterns (those belong in config.yaml)
+   
+   **d) Update README.md** (`<repo-root>/README.md`) — IF it exists:
+   - Check if `accelint-readme-writer` skill is installed
+   - If skill is available:
+     ```
+     /accelint-readme-writer Given this change, we need to make sure that the README.md is current and up to date
+     ```
+   - If skill is NOT available, read `README.md` and update manually focusing on **user-facing documentation**:
+     - **Installation section**: Update commands if new dependencies or setup steps were added
+     - **Features section**: Add bullet points for new user-facing features introduced by this change
+     - **Quick Start section**: Update if the basic usage pattern changed
+     - **Usage / API Reference section**: Update code examples if public API signatures changed or new exports were added
+     - **Configuration section**: Add new configuration options if introduced
+     - **Examples section**: Add new usage examples for new functionality
+     - **DO NOT** document internal implementation details, architectural decisions, or non-exported functions
+
+4. After updating documents, run `git status` to show which docs were modified
+5. Present summary:
+   ```
+   📝 Living documents updated
+   
+   Updated documents:
+   - openspec/config.yaml [via accelint-onboard-openspec / manually]
+   - ARCHITECTURE.md [via accelint-architecture-doc / manually]
+   - AGENTS.md [via accelint-onboard-agent / manually]  
+   - README.md [via accelint-readme-writer / manually]
+   
+   These changes ensure documentation stays synchronized with implementation.
+   ```
+
+**Skill availability detection**: To check if an Accelint skill is installed, use one of:
+- Check if skill appears in the available skills list in the system reminder
+- Attempt to invoke the skill and catch errors if it doesn't exist
+- Use Glob to search `.claude/skills/` for the skill name
+
+**When to skip this phase**:
+- Verification failed (CRITICAL issues) → skip to Phase 5 reporting with failure status
+- Change is trivial (typo fixes, comment updates) → use judgment on whether docs need updating
+- No living documents exist → skip gracefully with message "No living documents found to update"
+
+**Output**: Summary of updated documents and methods used (skill vs manual)
+
+### Phase 5: Report and Next Steps
 
 **Goal**: Summarize the implementation session and guide user on next steps.
 

--- a/skills/accelint-qrspi-propose/README.md
+++ b/skills/accelint-qrspi-propose/README.md
@@ -2,6 +2,10 @@
 
 Automate the planning phase of spec-driven development. This skill walks you through Questions → Research → Design → Structure (QRSPI), with mandatory review checkpoints before code gets written.
 
+**This is Phase 1 of a two-phase workflow:**
+- **Phase 1 (this skill)**: Plan the change (Questions → Research → Design → Structure)
+- **Phase 2** (`accelint-qrspi-apply`): Implement with intelligent parallelization
+
 ## What This Does
 
 Takes a ticket or feature request and produces a complete OpenSpec change:
@@ -10,8 +14,9 @@ Takes a ticket or feature request and produces a complete OpenSpec change:
 - Design document (decisions, trade-offs, architectural choices)
 - Delta specs (what changes in the system)
 - Task breakdown (vertical slices for implementation)
+- Parallelization strategy (which tasks can run concurrently)
 
-The skill stops after planning. You run `/opsx:apply` when you're ready to implement.
+The skill stops after planning. You run `/accelint-qrspi-apply` (or `/opsx:apply` for manual implementation) when you're ready to implement.
 
 ## When to Use This
 
@@ -53,9 +58,24 @@ openspec update
 
 The skill will check this before running and guide you if configuration is needed.
 
+## Two-Phase QRSPI Workflow
+
+This skill is Phase 1 (Planning). After completion, you proceed to Phase 2 (Implementation).
+
+| Phase | Skill | Purpose | Output |
+|-------|-------|---------|--------|
+| 1 | `accelint-qrspi-propose` (this skill) | Plan the change | OpenSpec artifacts (proposal, design, specs, tasks) |
+| 2 | `accelint-qrspi-apply` | Implement with parallelization | Working code, tests, validation |
+
+The separation allows you to:
+- Plan multiple changes before implementing any
+- Review and refine plans without wasting implementation effort
+- Clear context between planning and coding
+- Parallelize implementation across independent task slices
+
 ## How It Works
 
-### The Five-Phase Workflow
+### The Five Planning Phases
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -87,11 +107,15 @@ Mandatory checkpoint: You review the design before continuing. This is the "brai
 
 Generate delta specs and task breakdown. A sub-agent receives questions + research + approved design (NO ticket) and creates remaining artifacts with emphasis on vertical slicing.
 
+The skill automatically validates that tasks use vertical slicing (end-to-end feature deliverables) rather than horizontal slicing (architectural layers). If horizontal slicing is detected, the skill converts it to vertical slices automatically.
+
+The skill also ensures a "Parallelization Strategy" section exists in tasks.md, identifying which slices can run in parallel and which have sequential dependencies.
+
 Mandatory checkpoint: You review the task breakdown to ensure vertical slicing (not layer-by-layer).
 
 #### Phase 5: Completion
 
-The skill reports completion and exits. You decide when to run `/opsx:apply` to start implementation.
+The skill reports completion and exits. You decide when to run `/accelint-qrspi-apply` (for parallel implementation) or `/opsx:apply` (for manual implementation) to start building.
 
 ## Key Concepts
 
@@ -139,7 +163,18 @@ Phase 3: All API changes
 Phase 4: All frontend changes
 ```
 
-The skill checks for horizontal slicing and warns you if detected.
+The skill checks for horizontal slicing and automatically converts to vertical slicing if detected.
+
+### Parallelization Strategy
+
+After task generation, the skill ensures tasks.md includes a "Parallelization Strategy" section that identifies:
+
+- **Independent slices**: Tasks that can run in parallel with no blocking dependencies
+- **Sequential dependencies**: Tasks that must complete before others can start
+- **Critical path**: The longest chain of dependent tasks
+- **Recommended order**: Suggested implementation sequence for optimal parallelization
+
+This section is consumed by `accelint-qrspi-apply` (Phase 2) to orchestrate parallel sub-agent execution. If the section is missing or incomplete, the skill adds it automatically.
 
 ### No Automatic Implementation
 
@@ -149,7 +184,9 @@ The skill stops after planning. This allows:
 - Clearing context between planning and coding
 - User control over when implementation begins
 
-Run `/clear` and `/opsx:apply` when you're ready to start building.
+Run `/clear` and then:
+- `/accelint-qrspi-apply` to implement with intelligent parallelization (recommended for multi-slice changes)
+- `/opsx:apply` to implement manually (for simpler changes or when you want direct control)
 
 ## Example Usage
 
@@ -204,7 +241,7 @@ Generated artifacts:
 Next steps:
 1. Review the artifacts one more time if needed
 2. Run /clear to start fresh context for implementation
-3. Run /opsx:apply to begin implementation
+3. Run /accelint-qrspi-apply to begin parallel implementation
 ```
 
 ## Configuration Requirements
@@ -226,19 +263,30 @@ If a sub-agent fails, you'll see the error and can retry that phase or provide m
 
 If artifacts are missing after generation, the skill checks file paths and provides the expected locations for manual inspection.
 
+## Important Notes
+
+### Vertical vs Horizontal Slicing
+
+The skill automatically detects and converts horizontal (layer-by-layer) task structures to vertical (end-to-end feature) slices. Each slice should:
+- Deliver a working, testable increment
+- Cross architectural boundaries
+- Be demonstrable to stakeholders
+- Have minimal dependencies on other slices
+
 ## Tips
 
 Start with clear tickets. The better the input, the better the questions. Include constraints, performance targets, and existing patterns to follow.
 
 The design checkpoint is your leverage point. A 5-minute review here prevents hours of rework later.
 
-If the skill warns about horizontal slicing, listen. Layer-by-layer development hides integration issues until the end.
+Trust the skill's vertical slicing validation. Layer-by-layer development hides integration issues until the end.
 
 Don't rush to implementation. It's fine to create multiple specs before coding. Planning artifacts are cheap; code is expensive.
 
 ## Related Skills
 
+- `accelint-qrspi-apply` - **Phase 2**: Implement QRSPI-planned changes with intelligent parallelization (recommended for multi-slice changes)
 - `accelint-onboard-openspec` - Set up OpenSpec configuration for your project
 - `accelint-onboard-agent` - Create AGENTS.md with behavior rules
-- `opsx:apply` - Implement tasks from the generated change
+- `opsx:apply` - Manual implementation alternative to accelint-qrspi-apply
 - `opsx:verify` - Verify implementation matches artifacts before archiving


### PR DESCRIPTION
Update README's and add a section to qrspi-apply to automatically check and update context documents when completing change spec. To prevent them from becoming stale and drifting.