### PR TITLE
fix: qrspi-apply context and step completion

### DIFF
--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## [1.2.0] - 2026-06-24
+
+### Added
+- **Phase 2: Load Project Context** — New phase between task parsing and execution that loads `openspec/config.yaml` context and injects it into sub-agent prompts
+  - Reads and parses the `context` section from `openspec/config.yaml`
+  - Extracts Stack Facts, coding patterns, testing conventions, and anti-patterns (typically ~221 lines)
+  - Injects context into both sequential and parallel sub-agent prompts via `<project_context>` block
+  - Gracefully handles missing config or empty context (proceeds without injection)
+- Updated sub-agent prompt templates to include `<project_context>` block with explicit instructions to apply constraints
+- Added background explanation in Phase 2 documenting OpenSpec CLI's limitation (apply command doesn't auto-load context)
+- Renumbered all subsequent phases sequentially: Execute (Phase 3), Verify (Phase 4), Update Docs (Phase 5), Report (Phase 6)
+
+### Changed
+- Sub-agent prompts now receive project context that was previously missing during apply phase
+- Instructions in sub-agent prompts clarify that project context provides constraints for the agent, not content to copy into files
+- **Phase 5: Update Living Documents** — Refactored to run in a sub-agent for better context management
+  - Documentation updates now MUST run if verification reports "✅ All Checks Passed" or "✅ No critical issues found"
+  - Sub-agent reads change artifacts (proposal, design, specs, tasks) to understand what was implemented
+  - All document updates (config.yaml, ARCHITECTURE.md, AGENTS.md, README.md) run sequentially within the sub-agent without pausing between documents
+  - Only pauses if user input is required for a specific update decision
+  - Reports back with summary of updates or confirmation that no updates were needed
+  - Main orchestrator no longer handles document updates directly — delegates entire phase to specialized sub-agent
+
+### Fixed
+- **CRITICAL FIX**: Sub-agents now receive Stack Facts, coding patterns, testing conventions, and anti-patterns during implementation
+  - Previously: OpenSpec's `apply` command didn't inject `config.yaml` context (unlike artifact creation commands)
+  - Impact: Sub-agents lacked project-specific guidance (type safety rules, performance constraints, testing patterns)
+  - Root cause: OpenSpec CLI's `generateApplyInstructions()` doesn't call `readProjectConfig()`
+  - Solution: Wrapper skill now manually loads and injects context into sub-agent prompts
+  - Verification: Confirmed via OpenSpec source code inspection (`commands/workflow/instructions.js`) and live testing
+- **CRITICAL: Skill now proceeds through all phases automatically** — Fixed issue where skill stopped after Phase 4 (Verify) instead of continuing to Phase 5 (Update Docs) and Phase 6 (Report)
+  - **Root cause**: Phase 4 presented verification results and said "Ready to archive!" which signaled completion, even though Phases 5 and 6 were still pending
+  - **Impact**: Documentation updates (Phase 5) were never executed, and final report (Phase 6) was never shown
+  - **Solution**:
+    - Phase 4 now explicitly transitions to Phase 5 after successful verification or to Phase 6 after failed verification
+    - Added "Immediately proceed to Phase N" instructions in Phases 4 and 5
+    - Added "CRITICAL: This phase runs AUTOMATICALLY" emphasis at Phase 5 start
+    - Added "CRITICAL: This is the FINAL phase" emphasis at Phase 6 start
+    - Removed misleading "Ready to archive!" message from Phase 4 (now only appears in Phase 6 final report)
+  - **Verification**: Phases now flow: Parse → Dependencies → Load Context → Execute → **Verify → Update Docs → Report** (full workflow)
+
+### Rationale
+- **Why this fix matters**: Without project context, sub-agents implementing tasks don't follow project conventions (e.g., using `any` types when project forbids them, missing performance constraints like bounded iteration). This leads to implementations that pass functional tests but violate project standards.
+- **Why Phase 2 location**: Context must be loaded after change selection (Phase 0) and task parsing (Phase 1), but before spawning sub-agents (Phase 3). This ensures context is available when building sub-agent prompts.
+- **Why `<project_context>` wrapper**: The XML-style tag clearly delineates background constraints from task instructions, making it explicit that this content guides the agent's behavior rather than being copied into code.
+- **Why graceful degradation**: If `config.yaml` is missing or has no context section, the skill still works (falls back to OpenSpec's default behavior). This maintains compatibility with projects that haven't configured custom context.
+- **Why workaround instead of upstream fix**: Upstream OpenSpec fix (modifying `generateApplyInstructions()` to call `readProjectConfig()`) would benefit all users, but requires contribution, review, and release cycle. This workaround provides immediate value while upstream fix is pursued.
+- **Why Phase 5 uses sub-agent**: Isolates documentation work from the main orchestration context, preventing context bloat during long implementation sessions. Sub-agent reads change artifacts to understand what was implemented and makes intelligent documentation decisions.
+- **Why sequential within sub-agent**: While slices can run in parallel (Phase 3), document updates must be sequential to avoid conflicts when multiple documents reference the same concepts (e.g., new tech stack in both config and ARCHITECTURE.md).
+- **Why mandatory after verification passes**: Successful verification means the change is complete and correct — documentation MUST be updated at this point to prevent drift. Making this mandatory ensures documentation stays synchronized.
+- **Why automatic transitions**: The skill is designed as a complete end-to-end workflow. Stopping after verification but before documentation updates breaks the workflow contract and leaves documentation out of sync.
+- **Why emphasis on automation**: Claude tends to interpret "presenting results" as "end of task" unless explicitly instructed to continue. The "CRITICAL" and "AUTOMATICALLY" keywords make the continuation unambiguous.
+- **Why remove "Ready to archive!" from Phase 4**: This phrase signals task completion, making Claude think the workflow is done. Moving it to Phase 6 (the actual final phase) aligns the signal with reality.
+
+### Known Limitations
+- **Context window impact**: Injecting ~221 lines of project context into each sub-agent prompt adds to context usage. Monitor sub-agent context window consumption, especially for changes with many parallel slices.
+- **Workaround scope**: This fix only applies to `accelint-qrspi-apply` skill. Users invoking `/opsx:apply` directly (without this wrapper) will still not receive project context.
+- **Manual extraction**: YAML parsing is done manually (reading and extracting the `context: |` block). If config.yaml uses non-standard YAML formatting, extraction may fail.
+
+### Next Steps
+- Monitor context window usage in production to assess ~221-line injection impact
+- Open issue/PR with OpenSpec package to add context injection to `generateApplyInstructions()`
+- If upstream fix is merged, remove Phase 2 workaround in future version
+
+### Version
+- Bumped from 1.1.0 → 1.2.0
+
 ## [1.1.0] - 2026-06-18
 
 ### Added
@@ -17,7 +84,7 @@
 
 ### Changed
 - Workflow Overview diagram updated to include "Update Docs" phase between Verify and Report
-- Phase 4 renamed to Phase 5 (Report and Next Steps remains the final phase)
+- Phase numbers adjusted: Update Docs became Phase 5, Report became Phase 6
 - Documentation update phase only runs if verification passed (no CRITICAL issues)
 
 ### Rationale

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Accelint QRSPI Apply
@@ -37,6 +37,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 ├─────────────────────────────────────────────────────────────────┤
 │  Parse          Extract parallelization       Dependency graph  │
 │  Dependencies   Identify blocking tasks       Execution plan    │
+│  Load Context   Read config.yaml context      Project context   │
 │  Execute        Run slices (parallel/serial)  Implemented code  │
 │  Verify         Run opsx:verify               Verification rpt  │
 │  Update Docs    Sync living documents         Updated docs      │
@@ -77,12 +78,12 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    - If tasks use numbered lists (1. 2. 3.) or plain bullets (- without [ ]):
      ```
      ❌ Invalid tasks.md format
-     
+
      This skill requires tasks in markdown checklist format (`- [ ] task`) for
      progress tracking and resumption detection.
-     
+
      Found format: [numbered lists / plain bullets / other]
-     
+
      Please regenerate tasks.md using the accelint-qrspi-propose skill or convert
      manually to checklist format before applying.
      ```
@@ -132,7 +133,69 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 
 **Output**: Dependency graph, execution plan, and resumption point if applicable
 
-### Phase 2: Execute Tasks (Sequential + Parallel)
+### Phase 2: Load Project Context
+
+**Goal**: Load project context from `openspec/config.yaml` to inject into sub-agent prompts. This compensates for OpenSpec CLI's limitation where the `apply` command doesn't automatically load project context (unlike artifact creation commands).
+
+**Background**: OpenSpec's `openspec instructions apply` command does NOT inject the `context` field from `config.yaml` (confirmed via code inspection and testing). This means sub-agents implementing tasks don't receive Stack Facts, coding patterns, testing conventions, or anti-patterns that should guide implementation. We work around this limitation by manually loading and injecting the context.
+
+**Steps**:
+
+1. Check if `openspec/config.yaml` exists:
+   ```bash
+   test -f openspec/config.yaml && echo "exists" || echo "missing"
+   ```
+
+2. If the file exists, read it:
+   ```bash
+   cat openspec/config.yaml
+   ```
+
+3. Parse and extract the `context` section (YAML block under `context: |`):
+   - The context starts after the line `context: |`
+   - The context continues until the next top-level YAML key (e.g., `rules:`, `schema:`)
+   - Lines in the context block are indented (usually 2 spaces)
+   - Preserve all whitespace and newlines in the context block
+   - You MUST inform the user that you found and loaded the config.
+
+4. Store the extracted context for injection into sub-agent prompts in Phase 3
+
+5. If no `context` field exists or the file is missing:
+   - Set context to empty string
+   - Proceed without context injection (sub-agents will rely on OpenSpec's default behavior)
+   - You MUST inform the user that you could NOT find and load the config.
+
+**Example config.yaml structure**:
+```yaml
+schema: spec-driven
+
+context: |
+  # STACK FACTS
+  ## Project Identity
+  auditkit-cli: TypeScript-based code quality audit CLI
+
+  ## Dependencies
+  - @fission-ai/openspec: ^1.2.0
+  - vitest: ^2.1.8
+
+  # CODING PATTERNS
+  - Use Result<T,E> for fallible operations (never throw)
+  - Data-last parameter ordering for currying
+  - No `any` types — use `unknown` with type guards
+
+  # TESTING CONVENTIONS
+  - AAA pattern (Arrange/Act/Assert)
+  - One assertion per test
+  - Use descriptive test names
+
+rules:
+  proposal: [...]
+  design: [...]
+```
+
+**Output**: Extracted project context string (may be empty if not present)
+
+### Phase 3: Execute Tasks (Sequential + Parallel)
 
 **Goal**: Implement tasks following the dependency graph, spawning parallel sub-agents where possible.
 
@@ -141,8 +204,13 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 For each level in the dependency graph (starting from level 0):
 
 1. If the level has only one slice:
-   - Spawn a single sub-agent with this prompt:
+   - Spawn a single sub-agent with this prompt (inject project context from Phase 2):
      ```
+     <project_context>
+     <!-- Background constraints for your implementation. Do NOT copy into code. -->
+     {INJECTED_CONFIG_CONTEXT}
+     </project_context>
+
      /opsx:apply <change-name>
 
      CRITICAL: You MUST use the /opsx:apply command to implement tasks.
@@ -150,22 +218,27 @@ For each level in the dependency graph (starting from level 0):
      load context and guide implementation.
 
      IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
-     
+
      Context: This slice must complete before other slices can proceed.
      Other slices will start after you finish.
 
      Instructions:
      - Work ONLY on tasks in Slice N: [list slice N tasks/sections]
      - Do NOT implement tasks from other slices (Slices X, Y, Z will be handled separately)
+     - Apply the code patterns, conventions, and constraints from <project_context>
      - Follow the normal OpenSpec apply workflow:
        * OpenSpec will load context files (proposal, design, specs, tasks)
        * Implement the tasks assigned to Slice N
        * Mark tasks complete as you go: `- [ ]` → `- [x]`
        * Test your changes if tests are specified in the tasks
      - Report completion with summary of changes made
+     - The <project_context> provides Stack Facts, coding patterns, testing conventions,
+       and anti-patterns to avoid. These are constraints for YOU, not content to include in files.
 
      Focus exclusively on Slice N. Leave other slice tasks unchecked.
      ```
+
+     Note: If no project context was loaded in Phase 2, omit the `<project_context>` block entirely
 
 2. Wait for completion before proceeding to the next level
 
@@ -173,8 +246,13 @@ For each level in the dependency graph (starting from level 0):
 
 For each level with multiple independent slices:
 
-1. Spawn all sub-agents in parallel in a single turn (one per slice):
+1. Spawn all sub-agents in parallel in a single turn (one per slice, inject project context from Phase 2):
    ```
+   <project_context>
+   <!-- Background constraints for your implementation. Do NOT copy into code. -->
+   {INJECTED_CONFIG_CONTEXT}
+   </project_context>
+
    /opsx:apply <change-name>
 
    CRITICAL: You MUST use the /opsx:apply command to implement tasks.
@@ -182,35 +260,40 @@ For each level with multiple independent slices:
    load context and guide implementation.
 
    IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
-   
+
    Context: This slice is independent and runs in parallel with Slices X, Y.
    Other agents are working on those slices simultaneously.
 
    Instructions:
    - Work ONLY on tasks in Slice N: [list slice N tasks/sections]
    - Do NOT implement tasks from other slices - they are being handled in parallel
+   - Apply the code patterns, conventions, and constraints from <project_context>
    - Follow the normal OpenSpec apply workflow:
        * OpenSpec will load context files (proposal, design, specs, tasks)
        * Implement the tasks assigned to Slice N
        * Mark tasks complete as you go: `- [ ]` → `- [x]`
        * Test your changes if tests are specified in the tasks
    - Report completion with summary of changes made
+   - The <project_context> provides Stack Facts, coding patterns, testing conventions,
+     and anti-patterns to avoid. These are constraints for YOU, not content to include in files.
 
    Focus exclusively on Slice N. Leave other slice tasks unchecked.
    Your work is independent and should not block or depend on other slices.
    ```
 
+   Note: If no project context was loaded in Phase 2, omit the `<project_context>` block entirely
+
 2. Track completion as each sub-agent finishes
 3. When all slices in the level are done, **pause and offer context management**:
    ```
    ✅ Level N complete
-   
+
    Completed slices:
    - Slice X: [summary]
    - Slice Y: [summary]
-   
+
    Next: Level N+1 has M slice(s) to run [list slices]
-   
+
    Options:
    (a) Continue to next level
    (b) Clear context and resume — I'll pick up from Level N+1
@@ -251,7 +334,7 @@ For each level with multiple independent slices:
 
 The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove CLI Surface", "## Slice 2: Remove Implementation"), making it straightforward for sub-agents to identify their scope.
 
-### Phase 3: Verify Implementation
+### Phase 4: Verify Implementation
 
 **Goal**: Verify that the implementation matches the change artifacts (specs, tasks, design).
 
@@ -271,138 +354,179 @@ Do NOT skip this phase or mark the change as complete without running verificati
    - Validate design adherence (decisions followed)
    - Generate a verification report with CRITICAL/WARNING/SUGGESTION issues
 
-3. Present the verification report to the user as-is
+3. Present the verification report to the user
 
-4. If CRITICAL issues exist:
+4. Determine next steps based on verification results:
+
+   **If CRITICAL issues exist:**
    ```
-   ⚠️ Critical issues found. Cannot archive until resolved.
-   
+   ⚠️ Critical issues found. Cannot proceed to documentation updates.
+
    [verification report from opsx:verify]
-   
+
    Options:
    1. Fix issues manually and re-verify
    2. I can attempt to fix issues automatically
    ```
 
-5. If only warnings/suggestions:
+   If the user chooses option 1 or 2, fix the issues, re-run verification, and continue. If verification still fails or user declines to fix, **skip directly to Phase 6 (Report)** with failure status.
+
+   **If no CRITICAL issues (passed or warnings only):**
    ```
-   ✅ No critical issues found
-   
+   ✅ Verification passed
+
    [verification report from opsx:verify]
-   
-   Ready to archive! (Note warnings above for future consideration)
    ```
 
-**Output**: Verification report from `opsx:verify`
+   **Immediately proceed to Phase 5 (Update Living Documents)**. Do NOT wait for user input or stop here.
 
-### Phase 4: Update Living Documents
+**Output**: Verification report from `opsx:verify`, then automatic transition to Phase 5 or Phase 6
+
+### Phase 5: Update Living Documents
 
 **Goal**: After successful verification, update project documentation to reflect the implemented changes.
 
-CRITICAL: This phase runs ONLY if verification passed (no CRITICAL issues). If verification failed, skip to Phase 5 reporting.
+**CRITICAL: This phase runs AUTOMATICALLY after Phase 4 if verification passed.** Do NOT stop after Phase 4 — immediately proceed to this phase without waiting for user input.
+
+**When this phase runs**:
+- ✅ Verification passed (no CRITICAL issues) → **Run this phase NOW**
+- ❌ Verification failed (CRITICAL issues) → Skip directly to Phase 6 with failure report
 
 **Why this matters**: OpenSpec changes represent significant architectural decisions and feature additions. Living documents (ARCHITECTURE.md, AGENTS.md, README.md, openspec config) provide human-readable context about the system's current state. Keeping them synchronized prevents documentation drift and ensures the next engineer (or Claude) has accurate context.
 
+**Implementation**: This phase MUST be executed in a sub-agent to maintain context separation and allow efficient parallel processing of documentation updates.
+
 **Steps**:
 
-1. Check if the change is in a repository or package root by looking for `.git/` or `package.json`
-2. Determine the repo/package root (may be current directory or a parent)
-3. For each living document, check if it exists and if an Accelint skill is available to update it:
-
-   **a) Update OpenSpec config** (`<repo-root>/openspec/config.yaml`):
-   - Check if `accelint-onboard-openspec` skill is installed:
-     ```bash
-     # Check available skills for the openspec onboarding skill
-     # If found, use it; if not, update manually
-     ```
-   - If skill is available:
-     ```
-     /accelint-onboard-openspec Given this change, we need to make sure that the config is current and up to date
-     ```
-   - If skill is NOT available, read `openspec/config.yaml` and update manually focusing on **project DNA (WHAT the project is)**:
-     - **Tech Stack section**: Add new dependencies, frameworks, or libraries introduced by this change with versions
-     - **Domain Concepts section**: Add new entities or domain terms if this change introduces them
-     - **Code Patterns section**: Update if this change establishes new patterns (exports, error handling, validation approaches)
-     - **Architecture Patterns section**: Add new design patterns if introduced (factory, repository, observer, etc.)
-     - **Patterns to Avoid section**: Add any anti-patterns this change deprecates or makes explicit
-     - **Per-artifact rules** (`rules:` section): Update if this change affects proposal/design/tasks/spec requirements
-     - **DO NOT** add agent behavior (commit conventions, workflow steps, tool preferences belong in AGENTS.md)
-   
-   **b) Update ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
-   - Check if `accelint-architecture-doc` skill is installed
-   - If skill is available:
-     ```
-     /accelint-architecture-doc Given this change, we need to make sure that the ARCHITECTURE.md is current and up to date
-     ```
-   - If skill is NOT available, read `ARCHITECTURE.md` and update manually focusing on **system structure (HOW components relate)**:
-     - **Section 1 (Project Structure)**: Update directory tree if new top-level directories or significant reorganization occurred
-     - **Section 2 (High-Level System Diagram)**: Update ASCII diagram if component relationships changed or new services were added
-     - **Section 3 (Core Components)**: Add new components, services, or packages introduced by this change with their architectural roles
-     - **Section 4 (Data Stores)**: Add new databases, caches, or data stores if introduced
-     - **Section 5 (External Integrations)**: Add new third-party services or APIs this change integrates with
-     - **Section 6 (Deployment & Infrastructure)**: Update if deployment model changed or new infrastructure was added
-     - **Section 8 (Technology Stack)**: Update if this change introduced new runtime dependencies or frameworks
-     - **DO NOT** add coding patterns, testing conventions, or agent behavior (those belong in config.yaml or AGENTS.md)
-   
-   **c) Update AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
-   - Check if `accelint-onboard-agent` skill is installed
-   - If skill is available:
-     ```
-     /accelint-onboard-agent Given this change, we need to make sure that the AGENTS.md is current and up to date
-     ```
-   - If skill is NOT available, read `AGENTS.md` and update manually focusing on **agent behavior (HOW agents should act)**:
-     - **Workflow Procedures section**: Update if this change introduces new workflow steps (e.g., new pre-commit checks, new PR requirements)
-     - **Decision Heuristics section**: Add new decision rules if this change creates situations requiring agent judgment
-     - **Tool Preferences section**: Update if new tools were introduced or tool usage changed (e.g., new test runner, new linter)
-     - **Guardrails section**: Add new "never do" or "always ask first" rules if this change creates new risk areas
-     - **Pre-Commit Checklist**: Add new validation commands if required before commit
-     - **Commit Messages section**: Update if commit convention changed
-     - **DO NOT** add tech stack facts, domain concepts, or coding patterns (those belong in config.yaml)
-   
-   **d) Update README.md** (`<repo-root>/README.md`) — IF it exists:
-   - Check if `accelint-readme-writer` skill is installed
-   - If skill is available:
-     ```
-     /accelint-readme-writer Given this change, we need to make sure that the README.md is current and up to date
-     ```
-   - If skill is NOT available, read `README.md` and update manually focusing on **user-facing documentation**:
-     - **Installation section**: Update commands if new dependencies or setup steps were added
-     - **Features section**: Add bullet points for new user-facing features introduced by this change
-     - **Quick Start section**: Update if the basic usage pattern changed
-     - **Usage / API Reference section**: Update code examples if public API signatures changed or new exports were added
-     - **Configuration section**: Add new configuration options if introduced
-     - **Examples section**: Add new usage examples for new functionality
-     - **DO NOT** document internal implementation details, architectural decisions, or non-exported functions
-
-4. After updating documents, run `git status` to show which docs were modified
-5. Present summary:
+1. Spawn a sub-agent with the following prompt:
    ```
-   📝 Living documents updated
-   
-   Updated documents:
-   - openspec/config.yaml [via accelint-onboard-openspec / manually]
-   - ARCHITECTURE.md [via accelint-architecture-doc / manually]
-   - AGENTS.md [via accelint-onboard-agent / manually]  
-   - README.md [via accelint-readme-writer / manually]
-   
-   These changes ensure documentation stays synchronized with implementation.
+   Update living documents for OpenSpec change: <change-name>
+
+   CRITICAL: Read the change artifacts to understand what was implemented:
+   - openspec/changes/<change-name>/proposal.md
+   - openspec/changes/<change-name>/design.md
+   - openspec/changes/<change-name>/specs/**/*.md
+   - openspec/changes/<change-name>/tasks.md
+
+   Based on the change content, update living documents sequentially:
+
+   1. Check if the change is in a repository or package root by looking for `.git/` or `package.json`
+   2. Determine the repo/package root (may be current directory or a parent)
+   3. For each living document, check if it exists and if an Accelint skill is available to update it:
+
+      **a) Update OpenSpec config** (`<repo-root>/openspec/config.yaml`):
+      - Check if `accelint-onboard-openspec` skill is installed
+      - If skill is available:
+        ```
+        /accelint-onboard-openspec Given this change, we need to make sure that the config is current and up to date
+        ```
+      - If skill is NOT available, read `openspec/config.yaml` and update manually focusing on **project DNA (WHAT the project is)**:
+        - **Tech Stack section**: Add new dependencies, frameworks, or libraries introduced by this change with versions
+        - **Domain Concepts section**: Add new entities or domain terms if this change introduces them
+        - **Code Patterns section**: Update if this change establishes new patterns (exports, error handling, validation approaches)
+        - **Architecture Patterns section**: Add new design patterns if introduced (factory, repository, observer, etc.)
+        - **Patterns to Avoid section**: Add any anti-patterns this change deprecates or makes explicit
+        - **Per-artifact rules** (`rules:` section): Update if this change affects proposal/design/tasks/spec requirements
+        - **DO NOT** add agent behavior (commit conventions, workflow steps, tool preferences belong in AGENTS.md)
+
+      **b) Update ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
+      - Check if `accelint-architecture-doc` skill is installed
+      - If skill is available:
+        ```
+        /accelint-architecture-doc Given this change, we need to make sure that the ARCHITECTURE.md is current and up to date
+        ```
+      - If skill is NOT available, read `ARCHITECTURE.md` and update manually focusing on **system structure (HOW components relate)**:
+        - **Section 1 (Project Structure)**: Update directory tree if new top-level directories or significant reorganization occurred
+        - **Section 2 (High-Level System Diagram)**: Update ASCII diagram if component relationships changed or new services were added
+        - **Section 3 (Core Components)**: Add new components, services, or packages introduced by this change with their architectural roles
+        - **Section 4 (Data Stores)**: Add new databases, caches, or data stores if introduced
+        - **Section 5 (External Integrations)**: Add new third-party services or APIs this change integrates with
+        - **Section 6 (Deployment & Infrastructure)**: Update if deployment model changed or new infrastructure was added
+        - **Section 8 (Technology Stack)**: Update if this change introduced new runtime dependencies or frameworks
+        - **DO NOT** add coding patterns, testing conventions, or agent behavior (those belong in config.yaml or AGENTS.md)
+
+      **c) Update AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
+      - Check if `accelint-onboard-agent` skill is installed
+      - If skill is available:
+        ```
+        /accelint-onboard-agent Given this change, we need to make sure that the AGENTS.md is current and up to date
+        ```
+      - If skill is NOT available, read `AGENTS.md` and update manually focusing on **agent behavior (HOW agents should act)**:
+        - **Workflow Procedures section**: Update if this change introduces new workflow steps (e.g., new pre-commit checks, new PR requirements)
+        - **Decision Heuristics section**: Add new decision rules if this change creates situations requiring agent judgment
+        - **Tool Preferences section**: Update if new tools were introduced or tool usage changed (e.g., new test runner, new linter)
+        - **Guardrails section**: Add new "never do" or "always ask first" rules if this change creates new risk areas
+        - **Pre-Commit Checklist**: Add new validation commands if required before commit
+        - **Commit Messages section**: Update if commit convention changed
+        - **DO NOT** add tech stack facts, domain concepts, or coding patterns (those belong in config.yaml)
+
+      **d) Update README.md** (`<repo-root>/README.md`) — IF it exists:
+      - Check if `accelint-readme-writer` skill is installed
+      - If skill is available:
+        ```
+        /accelint-readme-writer Given this change, we need to make sure that the README.md is current and up to date
+        ```
+      - If skill is NOT available, read `README.md` and update manually focusing on **user-facing documentation**:
+        - **Installation section**: Update commands if new dependencies or setup steps were added
+        - **Features section**: Add bullet points for new user-facing features introduced by this change
+        - **Quick Start section**: Update if the basic usage pattern changed
+        - **Usage / API Reference section**: Update code examples if public API signatures changed or new exports were added
+        - **Configuration section**: Add new configuration options if introduced
+        - **Examples section**: Add new usage examples for new functionality
+        - **DO NOT** document internal implementation details, architectural decisions, or non-exported functions
+
+   4. After updating documents, run `git status` to show which docs were modified
+   5. Report back:
+      - If NO updates were needed: "No living document updates required for this change"
+      - If updates were made: List which documents were updated and how (skill vs manual)
+
+   **Skill availability detection**: To check if an Accelint skill is installed, use one of:
+   - Check if skill appears in the available skills list in the system reminder
+   - Attempt to invoke the skill and catch errors if it doesn't exist
+   - Use Glob to search `.claude/skills/` for the skill name
+
+   **When to skip updates for a specific document**:
+   - Change is trivial (typo fixes, comment updates) and doesn't affect that document's scope
+   - Document doesn't exist
+   - Change content doesn't introduce anything requiring updates to that document
+
+   Process all documents sequentially, one after another, without pausing between them unless updates are actually needed and user input is required.
    ```
 
-**Skill availability detection**: To check if an Accelint skill is installed, use one of:
-- Check if skill appears in the available skills list in the system reminder
-- Attempt to invoke the skill and catch errors if it doesn't exist
-- Use Glob to search `.claude/skills/` for the skill name
+2. Wait for the sub-agent to complete
 
-**When to skip this phase**:
-- Verification failed (CRITICAL issues) → skip to Phase 5 reporting with failure status
-- Change is trivial (typo fixes, comment updates) → use judgment on whether docs need updating
-- No living documents exist → skip gracefully with message "No living documents found to update"
+3. Review the sub-agent's report and present summary:
 
-**Output**: Summary of updated documents and methods used (skill vs manual)
+   - If no updates were needed:
+     ```
+     📝 No living document updates required for this change
+     ```
 
-### Phase 5: Report and Next Steps
+   - If updates were made:
+     ```
+     📝 Living documents updated
+
+     Updated documents:
+     - openspec/config.yaml [via accelint-onboard-openspec / manually]
+     - ARCHITECTURE.md [via accelint-architecture-doc / manually]
+     - AGENTS.md [via accelint-onboard-agent / manually]
+     - README.md [via accelint-readme-writer / manually]
+
+     These changes ensure documentation stays synchronized with implementation.
+     ```
+
+4. **Immediately proceed to Phase 6 (Report and Next Steps)**. Do NOT wait for user input or stop here.
+
+**When to skip this phase entirely**:
+- Verification failed (CRITICAL issues) → already skipped to Phase 6 from Phase 4
+
+**Output**: Summary of updated documents and methods used (skill vs manual), or confirmation that no updates were needed, then automatic transition to Phase 6
+
+### Phase 6: Report and Next Steps
 
 **Goal**: Summarize the implementation session and guide user on next steps.
+
+**CRITICAL: This is the FINAL phase.** After Phase 5 completes (or if Phase 4 failed), automatically proceed to this phase without stopping.
 
 **Steps**:
 


### PR DESCRIPTION
Through discovery it was found that OpenSpec loads the openspec/config for all commands _except_ `apply`. This was causing qrspi to not have that context, which code standards and structures, when it applies a change spec. This addresses that shortcoming by loading it at the start of the skill. Also noticed that it was stopping at Step 4 due to the way opsx:verify completes. Which means the updating of living documents was being skipped.