### PR TITLE
feat: add archive and synthesis skill, update others to complete worflow

### DIFF
--- a/skills/accelint-architecture-doc/CHANGELOG.md
+++ b/skills/accelint-architecture-doc/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-08
+
+### Added
+- **External findings support in MODE 2: Refresh** — skill now accepts `findings:` list from invoking prompt
+  - Parses invoking prompt for a `findings:` section (bulleted list of factual statements)
+  - Each finding is phrased as something already known to be true, never as an instruction
+  - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+  - Findings are merged with drift detection findings before presenting to user
+  - Allows upstream workflows (e.g., `accelint-qrspi-apply`) to pass change-specific context that should influence documentation updates
+  - If external findings exist, notes their source (e.g., "from completed OpenSpec change")
+  - Rationale: Documentation refresh after completing OpenSpec changes should incorporate decisions made during that change. Without external findings, the skill would only detect drift via file changes but miss semantic decisions that haven't yet manifested in the codebase.
+
+### Changed
+- **MODE 2: Refresh workflow expanded** — now includes 4-step process instead of 2-step
+  - Step 1: Extract external findings from invoking prompt (if any)
+  - Step 2: Drift detection (scan codebase for changes)
+  - Step 3: Merge and announce all findings (external + drift) before asking anything
+  - Step 4: After targeted interview, show diff-style preview before writing
+  - Rationale: Explicit merge step makes it clear that external and drift findings are treated equally, and announcing them together upfront gives the user full context before the interview begins
+
+### Version
+- Bumped from 1.0.0 → 1.1.0
+
 ## [1.0.0] - 2026-05-11
 
 ### Added

--- a/skills/accelint-architecture-doc/README.md
+++ b/skills/accelint-architecture-doc/README.md
@@ -61,8 +61,7 @@ The skill operates in three phases:
 Before scanning anything, the skill checks:
 
 1. **Monorepo detection** - figures out if you're at the repo root or inside a package, then adjusts scope
-2. **Related documents** - looks for openspec/config.yml to extract stack facts and avoid redundant scanning
-3. **File state** - checks if ARCHITECTURE.md exists and whether it follows the standard template
+2. **File state** - checks if ARCHITECTURE.md exists and whether it follows the standard template
 
 Based on what it finds, it picks one of three modes:
 
@@ -258,17 +257,13 @@ For each detected change, the skill asks questions to understand the context ins
 
 ### Agent Behavior Doc Integration
 
-After writing ARCHITECTURE.md, if the skill found `AGENTS.md` or `CLAUDE.md` during discovery, it updates the agent behavior file to reference ARCHITECTURE.md. This ensures agents know where to look for system architecture details.
-
-The skill adds this block to the agent behavior file:
+If the skill finds `AGENTS.md` or `CLAUDE.md` during discovery, it adds a reference block at the top of ARCHITECTURE.md:
 
 ```markdown
-## System Architecture
-
-For technical architecture details (components, deployment, data stores, tech stack), see [ARCHITECTURE.md](./ARCHITECTURE.md).
+> **Agent Behavior:** See [AGENTS.md](./AGENTS.md) for how AI agents should behave when working in this codebase.
 ```
 
-This creates a one-way reference: agent behavior docs point to architecture docs (not the reverse), since understanding system architecture informs agent behavior.
+This connects architectural context with behavioral instructions.
 
 ### Inference Source Annotations
 

--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -4,7 +4,7 @@ description: Generate or update an ARCHITECTURE.md living document for any codeb
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Architecture Doc
@@ -112,8 +112,9 @@ Does ARCHITECTURE.md exist at the target location?
           │    System Diagram, ## 3. Core Components, ## 4. Data Stores,
           │    ## 6. Deployment & Infrastructure)
           │     → MODE 2: Refresh
-          │       Drift detection + targeted questions for changed or
-          │       missing sections only.
+          │       Extract external findings from invoking prompt (if any) +
+          │       drift detection + merge findings + targeted questions for
+          │       changed or missing sections only.
           │
           └── Has real content but does NOT follow the template?
                 → MODE 3: Restructure (offer proactively — see below)
@@ -130,6 +131,25 @@ Does ARCHITECTURE.md exist at the target location?
 > **(c) Dry run** — I'll show exactly what the restructured doc would look like with no filesystem changes. Use this to evaluate fit before committing."
 
 If **(a)** is chosen: carry all existing content forward into the appropriate template sections. Flag any content that doesn't map cleanly — present it to the user and ask where it belongs rather than silently dropping it.
+
+**MODE 2: Refresh** — When the file follows the template structure, run an abbreviated process:
+
+1. **Extract external findings** — check if the invoking prompt includes a `findings:` list:
+   - Parse the prompt for a `findings:` section (a bulleted list of factual statements)
+   - Each finding is phrased as something already known to be true, never as an instruction
+   - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+   - Store these findings for merging in step 3
+
+2. **Drift detection** — scan the codebase for changes since the file was last updated (see signals table in Phase 1)
+
+3. **Merge and announce all findings** before asking anything:
+   - Combine external findings (from step 1) with drift findings (from step 2)
+   - Present the merged list to the user:
+     > "I found [N] external findings and [M] sections that may have drifted.
+     > I'll only ask about those — the rest looks current."
+   - If external findings exist, note their source (e.g., "from completed OpenSpec change")
+
+4. After the targeted interview, show a diff-style preview (changed sections only) before writing
 
 ---
 

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -1,0 +1,570 @@
+# Accelint Archive Synthesis
+
+Periodic consistency checker for OpenSpec archives. Scans the entire corpus of archived changes to detect decision drift and structural over-coupling — the one gap nothing else in the QRSPI/OpenSpec stack covers.
+
+## What This Does
+
+Looks backward across the full archive history to verify internal consistency:
+
+- Detects **decision drift** where past decisions contradict later changes
+- Flags **structural coupling** when capabilities accumulate too many relationships
+- Routes confirmed findings to living documents via the shared `findings:` interface
+- Updates archive status to mark superseded decisions
+
+This implements the "lint" operation from Karpathy's LLM Wiki pattern. Every other drift check in the stack is forward-looking (change vs. artifacts, docs vs. code). This is the only backward-looking check (archive vs. itself).
+
+## When to Use This
+
+Invoke this skill when:
+
+- ~15 changes have archived since the last synthesis run (suggested by `accelint-qrspi-archive`)
+- You want to audit the archive for contradictions or inconsistencies
+- You're investigating whether an old design decision still holds
+- You suspect a capability has become over-coupled and needs refactoring
+- You want to run a corpus health check manually
+
+Trigger phrases:
+- "run archive synthesis"
+- "lint the openspec archive"
+- "check for decision drift"
+- "audit the spec archive for contradictions"
+- "find stale specs"
+- "check capability coupling"
+
+**Never runs automatically** — always either a direct human invocation or an accepted suggestion.
+
+## Prerequisites
+
+This skill requires:
+
+1. **OpenSpec CLI** - Installed and initialized
+2. **accelint-qrspi-archive** - In regular use (produces the indexes this skill reads)
+3. **Archive indexes** - Both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` exist with at least one row
+4. **Sub-agent support** - For reading `design.md` files without polluting parent context
+5. **Writer skills with findings interface** - `accelint-architecture-doc`, `accelint-onboard-openspec`, `accelint-onboard-agent`, `accelint-readme-writer` supporting Mode 3 Refresh with `findings:` input
+
+### Check archive state:
+
+```bash
+ls -la openspec/changes/archive/INDEX.md openspec/specs/INDEX.md
+```
+
+Both files should exist. If missing, run `accelint-qrspi-archive` on at least one change first.
+
+### Minimum corpus size:
+
+The skill works with any corpus size but warns if fewer than ~10 archived changes exist (low signal-to-noise ratio).
+
+## How It Works
+
+### The Workflow
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│  Phase            Action                                            Output    │
+├───────────────────────────────────────────────────────────────────────────────┤
+│  Preflight        Read SYNTHESIS-LOG.md, verify dependencies        Go/no-go  │
+│                   exist, sanity-check thresholds                    + notes   │
+│  Scan Indexes     Read archive/INDEX.md + specs/INDEX.md, load      In-memory │
+│                   prior dismissed pairs from the log                model     │
+│  Decision Drift   Coarse-scan Decision column for collisions,       Candidate │
+│                   SUBAGENT opens design.md for verification         findings  │
+│  Structural       Median related-count across specs/INDEX.md,       Candidate │
+│  Coupling         flag outliers ≥5 and ≥2× median                   findings  │
+│  Compile Report   Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
+│                   findings, /opsx:verify register                   report    │
+│  Human Review     Present report; human confirms, dismisses, or     Confirmed │
+│                   defers each finding                               findings  │
+│  Route            Update Status (confirmed contradictions only)     Docs +    │
+│                   + invoke affected writer skill(s) via findings:   Status    │
+│  Log + Report     Append run checkpoint + any new dismissed pairs   Summary   │
+│                   to SYNTHESIS-LOG.md, summarize                              │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Phase 0: Preflight
+
+Confirms this run has something to check before reading anything else:
+
+1. **Task A - trigger cadence sanity-check**: Read `SYNTHESIS-LOG.md` to find the last run's date and row count. If it doesn't exist yet (first run), skip cadence math. Otherwise, compute average time-between-archives to check if the 15-change trigger is sensible for this project's velocity. Report mismatches but never adjust automatically.
+
+2. **Task B - dependency check**: Confirm both indexes exist and contain at least one row each. If either is missing or empty, stop and suggest running `accelint-qrspi-archive` first. If corpus has fewer than ~10 rows, note that synthesis has little to find and ask before proceeding.
+
+3. **Task C - structural coupling threshold sanity-check**: Compute actual median `related:` count across `specs/INDEX.md`. Note if the fixed floor of 5 or 2× multiplier would flag too many/none. Report observation, never change threshold.
+
+### Phase 1: Scan Indexes
+
+Builds an in-memory model of the archive without opening any change folders:
+
+1. Read `archive/INDEX.md` in full: every row's Change, Date, Decision summary, Specs touched list, and Status
+2. Read `specs/INDEX.md` in full: every row's Capability, Purpose, Related list, and Last touched by/date
+3. Read every `dismissed:` sub-list from `SYNTHESIS-LOG.md`'s full history, build flat set of dismissed-pair identities in form `<change-A>|<change-B>|<capability>` (alphabetically sorted)
+
+If log doesn't exist, set starts empty (first run).
+
+### Phase 2: Decision Drift Detection
+
+Finds archived decisions that no longer cohere, without opening every `design.md`:
+
+**Step 1 - group by shared/related capability**: Use Specs touched + related: fields to cluster changes touching the same capability or connected capabilities.
+
+**Step 2 - coarse scan**: Drop any pair in dismissed-pair set (already judged not real). For the rest, compare Decision one-liners for opposing patterns:
+- polling vs. push/websocket
+- synchronous vs. asynchronous
+- in-process vs. external service
+- monolith vs. microservice
+- eager vs. lazy
+- centralized vs. distributed
+- client-side vs. server-side
+
+Also flag stated rationale contradicted by later rationale, and capabilities with clustered activity while spec's Last touched by is conspicuously earlier. This step works off index text in memory — no file I/O yet.
+
+**Step 3 - targeted verification**: For each candidate, spawn one sub-agent per pair to open full `design.md` files and confirm/dismiss using complete `choice`/`rationale`/`alternatives` fields. Return only structured verdict (confirmed/dismissed + quote-free summary), never raw design.md contents.
+
+**Step 4 - staleness flag**: Flag any capability where `Last touched by` date is old relative to cluster of recent related activity.
+
+**Classification**: Confirmed contradiction is CRITICAL if affected capability's Last touched by date falls AFTER earlier contradicting change (something built on top). Otherwise WARNING. Staleness flags are SUGGESTION.
+
+### Phase 3: Structural Coupling Signal
+
+Surfaces capabilities whose `related:` count suggests boundary overgrowth — at zero extra cost since counts already exist:
+
+1. Compute median `related:` list length across every row from Phase 1
+2. Flag any capability with count both ≥5 AND ≥2× median as SUGGESTION
+3. Phrase as plain fact: "sync/protocol relates to 14 other capabilities, more than double the index median of 6"
+
+**Example**: For counts `[1,2,2,3,3,4,4,5,5,5,6,6,6,7,7,8,8,9,10,11,14,14]`, median is 6. Floor is `max(5, 2×6) = 12`, so only the two at 14 get flagged.
+
+### Phase 4: Compile Report
+
+Assembles everything into one report using `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register:
+
+```
+## Archive Synthesis Report — <date>
+
+Corpus: <N> archived changes, <M> capabilities, checked back to <last checkpoint or "project start">.
+
+### CRITICAL
+- [Confirmed decision contradiction with live capability]
+
+### WARNING
+- [Confirmed decision contradiction on dormant capability]
+
+### SUGGESTION
+- [Staleness flag]
+- [Structural coupling flag]
+
+### Threshold notes (informational only)
+- [Any cadence or median mismatch worth attention]
+```
+
+Never present findings as already-resolved — every item is a candidate for Phase 5.
+
+### Phase 5: Human Review
+
+Lets a human decide what actually happens with each finding:
+
+Present each finding with three options:
+
+**For decision-drift finding**:
+```
+Finding 1 [CRITICAL]: add-live-sync's stated budget constraint for
+sync/protocol may no longer hold, given adopt-notification-gateway's
+later message-broker adoption.
+  (a) Confirm — I'll ask which change stands, then update Status and
+      notify the relevant doc skill(s)
+  (b) Dismiss — Recorded permanently; this exact pair won't be
+      flagged again
+  (c) Defer  — Left as-is; resurfaces next run
+```
+
+**For structural coupling finding**:
+```
+Finding 2 [SUGGESTION]: sync/protocol relates to 14 capabilities,
+over double the index median of 6.
+  (a) Confirm — Routes to ARCHITECTURE.md's Known Technical Debt review
+  (b) Dismiss — Not persisted; will still be re-checked next run
+  (c) Defer  — Left as-is; resurfaces next run
+```
+
+Only confirmed findings proceed to Phase 6. For decision drift, "Confirm" starts a decision, doesn't end one — Phase 6 still asks which side stands. Deferred findings resurface next run unchanged. Dismissed decision-drift findings persist to log; dismissed coupling findings do not (count is moving snapshot).
+
+If human stops partway, treat unaddressed findings as deferred. Phase 7 logs what was confirmed; rest resurfaces next time.
+
+### Phase 6: Route Confirmed Findings
+
+Hands off to where they can change something, using shared `findings:` interface:
+
+**For confirmed decision contradiction**:
+1. Ask which side stands (never infer from recency)
+2. Update that row's Status to `superseded by <slug> (<date>)` (only write this skill ever makes to archive/INDEX.md)
+3. Invoke writer skill(s) whose hub doc covers affected capability:
+   - Tech stack/dependencies/patterns → `accelint-onboard-openspec` (config.yaml)
+   - System structure/components → `accelint-architecture-doc` (ARCHITECTURE.md)
+   - Agent workflow/behavior → `accelint-onboard-agent` (AGENTS.md)
+   - User-facing docs → `accelint-readme-writer` (README.md)
+
+Single finding can target multiple writer skills. Each invocation succeeds/fails independently.
+
+**For confirmed staleness/coupling flag**:
+- No Status update
+- Route to `accelint-architecture-doc`'s Known Technical Debt slot
+
+**For dismissed decision-drift**:
+- No Status write, but Phase 7 records pair to SYNTHESIS-LOG.md dismissed: list
+
+**For dismissed coupling or any deferred**:
+- No write anywhere, resurfaces next run
+
+### Phase 7: Log and Report
+
+Leaves checkpoint for next run and summarizes:
+
+1. Append one line to `SYNTHESIS-LOG.md`:
+   ```
+   2026-07-06 — checked through row 42 — 2 confirmed, 1 dismissed, 1 deferred
+     dismissed: [add-live-sync|adopt-notification-gateway|sync/protocol]
+   ```
+
+2. Close with short summary: findings by type, confirmed/dismissed/deferred counts, which writer skills invoked
+
+## Key Concepts
+
+### Cost Control at Scale
+
+- **Index-first scanning**: Reads structured indexes (stay cheap regardless of history length), not raw files
+- **Targeted verification**: Opens `design.md` only for specific candidates coarse scan flagged
+- **Sub-agent delegation**: Keeps raw design content out of parent context on every run
+- **Dismissed-pair tracking**: Skips pairs already ruled out permanently
+
+### The Two Indexes (Owned Elsewhere)
+
+Neither is written by this skill. Both written/maintained by `accelint-qrspi-archive`:
+
+```
+openspec/changes/archive/INDEX.md — one row per archived change:
+| Change        | Date       | Decision                                  | Specs touched                      | Status  |
+|---------------|------------|-------------------------------------------|------------------------------------|---------|
+| add-live-sync | 2026-03-02 | polling with 5s interval, no infra budget | sync/protocol, ui/status-indicator | current |
+
+openspec/specs/INDEX.md — one row per capability, rebuilt on every archive:
+| Capability    | Purpose                                     | Related             | Last touched by            |
+|---------------|---------------------------------------------|---------------------|----------------------------|
+| sync/protocol | Defines how client and server exchange state | ui/status-indicator | add-live-sync (2026-03-02) |
+```
+
+Decision column is condensed one-liner from `design.md` frontmatter. This skill's Phase 2 works off that summary first, only opens full design.md for flagged candidates.
+
+### The Log (Owned by This Skill)
+
+`openspec/changes/archive/SYNTHESIS-LOG.md` — plain append-only list:
+- One line per run: date + row count checked + confirmed/dismissed/deferred counts
+- Optional indented `dismissed:` sub-list of decision-drift pairs explicitly dismissed
+- Only decision-drift dismissals persist (structural coupling dismissals don't — count is moving snapshot)
+- Never edited/removed by skill; reconsidering dismissed pair is manual edit
+
+### Findings Interface (Shared Contract)
+
+Uses exact same `findings:` shape `accelint-qrspi-apply` Phase 4 uses:
+
+```
+/accelint-architecture-doc
+We found the following during periodic archive synthesis. Treat this as known
+context and refresh the affected section(s).
+
+findings:
+- [Plain factual statement about what archive shows, never instruction]
+```
+
+Writer skill merges with its own codebase scan before presenting to human — same Mode 3 Refresh path manual run would take.
+
+**Rephrasing discipline**: Every findings: line is plain fact about what archive shows ("sync/protocol's stated budget constraint may no longer hold, given later message-broker adoption"), never instruction ("update sync/protocol's spec to remove constraint") — that would pre-empt writer skill's Mode 3 interview.
+
+### Relationship to `/opsx:verify`
+
+Borrows CRITICAL/WARNING/SUGGESTION register deliberately so reports read as familiar artifacts. But they check fundamentally different things:
+
+- `/opsx:verify`: Forward-looking, per-change, before archival (does implementation match its own design.md/tasks.md?)
+- This skill: Backward-looking, cross-archive, periodic (does archive agree with itself?)
+
+Complementary, not redundant. A change can pass verification cleanly and still surface in decision-drift finding years later.
+
+## Example Usage
+
+### Scenario 1: Suggested run, one confirmed contradiction, one structural flag
+
+```
+[accelint-qrspi-archive, at end of summary]
+ℹ️ 15 changes have archived since last synthesis run (2026-01-10).
+  Consider running accelint-archive-synthesis.
+
+User: Yes, run archive synthesis.
+
+Skill: Preflight —
+✓ Task B: both indexes present, 47 archived changes, 22 capabilities
+✓ Task A: actual cadence ~1.1 changes/week; 15-change trigger implies
+  checking roughly every 10 weeks — no mismatch worth flagging
+✓ Task C: index median related-count is 6; 5-and-2× floor looks reasonable
+
+Scanning archive/INDEX.md and specs/INDEX.md...
+
+Decision drift —
+[spawns subagent: verify sync/protocol candidate]
+✓ Confirmed: add-live-sync (2026-03-02) chose polling for sync/protocol,
+  citing no infra budget for a message broker. adopt-notification-gateway
+  (2026-06-18) later adopted a message broker for an unrelated capability.
+  sync/protocol has been touched twice since — CRITICAL.
+
+Structural coupling —
+✓ sync/protocol relates to 14 other capabilities, more than double the
+  index median of 6 — SUGGESTION.
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 47 archived changes, 22 capabilities, checked back to 2026-01-10.
+
+### CRITICAL
+Finding 1: add-live-sync's stated budget constraint for sync/protocol may
+no longer hold, given adopt-notification-gateway's later message-broker
+adoption.
+  (a) Confirm — I'll ask which change stands, then update Status and
+      notify the relevant doc skill(s)
+  (b) Dismiss — Recorded permanently; this exact pair won't be flagged again
+  (c) Defer  — Left as-is; resurfaces next run
+
+### SUGGESTION
+Finding 2: sync/protocol relates to 14 capabilities, over double the
+median of 6.
+  (a) Confirm — Routes to ARCHITECTURE.md's Known Technical Debt review
+  (b) Dismiss — Not persisted; will still be re-checked next run
+  (c) Defer  — Left as-is; resurfaces next run
+
+User: Confirm Finding 1.
+
+Skill: For Finding 1 — which change should Status reflect as the one
+that stands: add-live-sync's original budget constraint, or
+adopt-notification-gateway's later message-broker adoption?
+
+User: adopt-notification-gateway — the budget constraint's gone now.
+
+Skill:
+✓ archive/INDEX.md: add-live-sync row Status → "superseded by
+  adopt-notification-gateway (2026-06-18)"
+[invokes accelint-architecture-doc with findings: — sync/protocol budget
+  constraint may be stale]
+
+Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
+
+✅ Synthesis complete: 1 confirmed, 0 dismissed, 0 deferred.
+```
+
+### Scenario 2: First-ever run, small corpus, nothing to report
+
+```
+User: Run archive synthesis on this repo, I don't think it's ever been done.
+
+Skill: Preflight —
+✓ Task B: both indexes present, 6 archived changes, 4 capabilities
+ℹ️ openspec/changes/archive/SYNTHESIS-LOG.md doesn't exist yet — this is the
+  first-ever run. Task A's cadence math needs a prior checkpoint, so it's
+  skipped this time.
+⚠️ 6 archived changes is a small corpus — cross-archive synthesis has little
+  to work with yet. Continue anyway with a low-signal run?
+
+User: Yes, go ahead.
+
+Skill: Scanning archive/INDEX.md and specs/INDEX.md...
+
+Decision drift — no candidate collisions found across 4 capabilities.
+Structural coupling — only 4 specs/INDEX.md rows; Phase 3 needs at least 2
+  to compute a median, but a corpus this small has nothing meaningful to
+  flag either way.
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 6 archived changes, 4 capabilities, checked back to project start.
+
+No CRITICAL, WARNING, or SUGGESTION findings this run.
+
+Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md
+  (file created fresh)...
+
+✅ Synthesis complete: nothing to confirm. Re-run once more changes have
+   archived — this corpus is too small yet for the signal to be meaningful.
+```
+
+### Scenario 3: Previously dismissed pair stays suppressed
+
+```
+[Run 1, three months earlier]
+Skill: Finding 1 [WARNING]: legacy-cache-warmer (2025-11-02) chose eager
+  cache warming for cache/layer, citing predictable traffic patterns.
+  adopt-lazy-init (2026-01-14) later chose lazy initialization for an
+  unrelated capability.
+
+User: Dismiss — these two were never actually in tension, different
+teams, different constraints.
+
+Skill: ✓ Recorded as dismissed.
+Appending checkpoint to SYNTHESIS-LOG.md...
+  dismissed: [adopt-lazy-init|legacy-cache-warmer|cache/layer]
+
+[Run 2, today]
+Skill: Preflight —
+✓ Task A: reading SYNTHESIS-LOG.md — last run 2026-04-02, checked
+  through row 31; 1 dismissed pair on record
+✓ Task B: both indexes present, 53 archived changes, 24 capabilities
+
+Scanning archive/INDEX.md and specs/INDEX.md...
+Loading dismissed-pair history — 1 entry found.
+
+Decision drift —
+- legacy-cache-warmer / adopt-lazy-init / cache/layer: matches a
+  dismissed pair on record, skipped without re-verification.
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 53 archived changes, 24 capabilities, checked back to 2026-04-02.
+(cache/layer's legacy-cache-warmer/adopt-lazy-init pair previously
+dismissed — not re-surfaced this run)
+
+No new CRITICAL or WARNING findings.
+```
+
+## Error Handling
+
+**If either index missing or empty**:
+- Stop before Phase 1
+- Tell user to run `accelint-qrspi-archive` first
+
+**If SYNTHESIS-LOG.md doesn't exist**:
+- Not an error — expected state on first-ever run
+- Task A skips cadence math, proceeds
+- Phase 7 creates file fresh
+
+**If corpus smaller than ~10 archived changes**:
+- Don't block, but say plainly corpus is small
+- Ask before proceeding with low-signal run
+
+**If flagged writer skill isn't installed or doesn't support findings:**:
+- Don't fail whole run
+- Present finding in report
+- Tell user handoff needs manual paste-in
+
+**If no sub-agent support**:
+- Fall back to opening `design.md` in parent context (Phase 2 Step 3)
+- Warn explicitly this run's raw contents sit in context
+
+**If design.md referenced by index no longer exists**:
+- Skip that row for targeted verification
+- Note as unverifiable in report
+- Don't treat absence as finding
+
+**If index row malformed**:
+- Skip that row for whatever phase needs missing field
+- Note as unparseable in report
+- Continue with every other row
+
+**If dismissed: entry references slug no longer in index**:
+- Drop from in-memory dismissed-pair set this run
+- Note once in report
+- Can't suppress if slug doesn't resolve
+
+**If corpus too small for Phase 3**:
+- Skip Phase 3 entirely (median needs enough rows)
+- Note in report
+
+**If Phase 2 produces unreasonably large candidate set**:
+- Don't spawn one subagent per pair unconditionally
+- Prioritize most recent pairs, verify those
+- Note how many older candidates weren't checked this run
+
+**If routing invocation fails after Status update**:
+- Don't undo Status update (two writes are independent)
+- Tell user Status landed but handoff didn't
+- Give findings:-formatted text for manual invoke
+
+**If human answers "which change stands" ambiguously or doesn't answer**:
+- Never infer from recency
+- Ask again rather than proceeding
+- Leave finding unresolved (deferred) until answer unambiguous
+
+**If human names slug for Status that doesn't appear in index**:
+- Stop, ask for correct slug
+- Don't write unverifiable reference
+
+## Configuration Requirements
+
+This skill assumes:
+
+1. OpenSpec installed and initialized (`openspec/` directory exists)
+2. `accelint-qrspi-archive` has run at least once (indexes exist and populated)
+3. Sub-agent support available (for reading `design.md` files)
+4. Writer skills installed and support `findings:` interface (optional, degrades gracefully)
+
+If missing, skill reports issue and guides setup.
+
+### Configuration Defaults
+
+| Setting | Default | Rationale |
+|---------|---------|-----------|
+| Trigger threshold | 15 archived changes since last run | Balances signal quality vs. cadence (reasoned starting point, adjust based on actual velocity) |
+| Structural coupling floor | ≥5 relationships | Prevents flagging minimally-connected specs |
+| Structural coupling multiplier | ≥2× median | Adapts to project's natural relationship density |
+
+Phase 0 reports mismatches but never adjusts automatically. Changing numbers is human's call.
+
+## Tips
+
+Check the archive cadence after first few runs. If 15 changes means checking twice yearly or every few days, adjust the threshold.
+
+Trust dismissed-pair tracking. A decision-drift dismissal is permanent (pair never re-flagged). A structural coupling dismissal is not (count rechecked every run).
+
+The verification report format matches `/opsx:verify` deliberately. Both check correctness, just at different scopes.
+
+When a finding targets multiple docs, each writer skill invocation is independent. One succeeding doesn't depend on another.
+
+If unsure whether an old decision still holds, run this manually rather than waiting for the 15-change threshold.
+
+## Related Skills
+
+- `accelint-qrspi-archive` - Archive OpenSpec changes, produce indexes this skill reads (prerequisite)
+- `accelint-qrspi-apply` - Implement changes with parallelization, Phase 4 uses same findings: interface
+- `accelint-onboard-openspec` - Update config.yaml (routing target for tech stack drift)
+- `accelint-architecture-doc` - Update ARCHITECTURE.md (routing target for structure/coupling drift)
+- `accelint-onboard-agent` - Update AGENTS.md (routing target for behavior drift)
+- `accelint-readme-writer` - Update README.md (routing target for user-facing drift)
+
+## Architecture Context
+
+This skill implements the "lint" operation from Karpathy's LLM Wiki pattern:
+
+```
+KARPATHY LLM WIKI              ACCELINT / OPENSPEC
+──────────────────             ────────────────────
+Tier 0: raw/                   openspec/changes/archive/*.md (immutable log)
+Tier 1: wiki/ pages            openspec/specs/<capability>/spec.md (current understanding)
+Tier 2: CLAUDE.md index        config.yaml + ARCHITECTURE.md + AGENTS.md + README.md (hub docs)
+
+Op: ingest                 →   /opsx:archive + qrspi-apply Phase 4
+Op: query                  →   artifact load at propose/apply time
+Op: lint                   →   accelint-archive-synthesis (this skill)
+```
+
+Every existing drift check is forward-looking (change vs. artifacts, docs vs. code). This is the only backward-looking check (archive vs. itself).
+
+## Build Order
+
+This skill is deliberately last in a four-piece stack, each a hard dependency:
+
+1. **`accelint-qrspi-archive`** - Produces the indexes this skill reads (foundational)
+2. **`accelint-qrspi-propose` Phase 2 extension** - Reads `specs/INDEX.md` at propose time (makes index load-bearing)
+3. **Shared `findings:` interface** - Mode 3 extension across writer skills + Phase 4 prompt change (routing destination)
+4. **This skill** - Consumes indexes, routes findings (builds on 1-3)
+
+Without 1, there's no corpus to lint. Without 2-3, skill can scan/report but has nowhere to route confirmed findings — degrades to "tell human what to do manually."
+
+## Documentation
+
+- [openspec/config.yaml](../../../openspec/config.yaml) - Project DNA: stack facts, coding patterns, domain concepts
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) - System architecture, deployment, component interactions
+- [AGENTS.md](../../../AGENTS.md) - Agent behavior, workflows, guardrails
+- [LLM Wiki Pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) - Original pattern this implements
+- [LLM-Readable Context Architecture](/Users/bryankizer/Projects/work-notes/AI Discussion/RPI Talk/LLM-Readable Context Architecture.md) - Gap analysis and design decisions behind this skill

--- a/skills/accelint-archive-synthesis/SKILL.md
+++ b/skills/accelint-archive-synthesis/SKILL.md
@@ -1,0 +1,604 @@
+---
+name: accelint-archive-synthesis
+description: Periodically lint the full OpenSpec archive for cross-change decision drift, index/spec reconciliation, and structural over-coupling, the gap nothing else in the QRSPI/OpenSpec stack covers, since every other drift check (accelint-onboard-openspec, accelint-architecture-doc, accelint-qrspi-apply Phase 4) only looks forward from a single change's own artifacts. Use this skill when the user wants to "run archive synthesis," "lint the openspec archive," "check for decision drift," "audit the spec archive for contradictions," "find stale specs," "reconcile the specs index," "check capability coupling," or when accelint-qrspi-archive has surfaced its own suggestion that 15+ changes have archived since the last synthesis run. Also use when the user asks whether an old design decision still holds given everything decided since, whether specs/INDEX.md still matches the actual spec.md files on disk, or whether some capability has become an over-coupled refactor candidate. This skill never runs automatically and never blocks another skill — it is always either a human-invoked audit or an offered suggestion the human accepts explicitly.
+license: Apache-2.0
+compatibility: Requires the OpenSpec CLI, sub-agent support, and a project already onboarded with accelint-qrspi-archive so that openspec/changes/archive/INDEX.md and openspec/specs/INDEX.md exist and are populated. Routing confirmed findings requires the shared findings: interface (Mode 3 Refresh support) in whichever writer skill(s) a given finding targets; without it, this skill still produces its report but degrades to manual guidance for that step.
+metadata:
+  author: accelint
+  version: "1.0.0"
+---
+
+# Accelint Archive Synthesis
+
+Read backward across the entire archived-change history to check whether it still agrees with itself, check the running index itself against the live files it claims to summarize, and surface any capability whose accumulated relationships suggest it has outgrown its own boundaries. This is the "lint" operation in Karpathy's LLM Wiki pattern: `ingest` already exists as `accelint-qrspi-archive`, `query` already exists as artifact loading at propose/apply time, but nothing periodically re-reads the whole corpus to check it is still internally consistent. Every existing drift check in this stack, including `accelint-qrspi-apply` Phase 4's own hub-doc refresh, is forward-looking and scoped to one change's own proposal and design. This skill is the only one that looks the other direction — and, since `accelint-qrspi-archive` moved to row-level index patching for its own efficiency, the only one that ever re-checks `specs/INDEX.md` against the `spec.md` files it summarizes at all.
+
+That backward-looking scope is also what keeps this skill's footprint small and deliberate. It reads two indexes and, for genuine candidates only, a handful of `design.md` files and, for the reconciliation check, a lightweight top-of-file read of every `spec.md`. It never rewrites a hub doc directly, and every write it does make — on either index — is a single targeted line, gated behind an explicit human confirmation of that specific finding, and never runs on its own initiative. A human always decides which findings get acted on.
+
+## What This Skill Does
+
+**Automates**: a periodic, corpus-wide consistency check across every archived OpenSpec change, surfacing contradictions between past decisions, flagging capabilities that have become structurally over-coupled, and flagging `specs/INDEX.md` rows that have drifted from the `spec.md` files they summarize.
+**Scope**: `openspec/changes/archive/INDEX.md`, `openspec/specs/INDEX.md`, and — for the reconciliation check only — a lightweight read of each `spec.md`'s `## Purpose` heading and `related:` frontmatter. This skill never originates a change, never implements a fix, and never edits a hub doc itself.
+**Output**: a CRITICAL / WARNING / SUGGESTION report in the same register as `/opsx:verify`, plus, only after a human confirms a specific finding, a `Status` column update on the relevant archive row, a single-row patch or removal on `specs/INDEX.md`, and/or an independent invocation of the affected writer skill(s) via the shared `findings:` interface — see Phase 7 for which finding types get which.
+**Does NOT**: run automatically, run as a blocking step inside any other skill's workflow, rewrite any document directly, write any `archive/INDEX.md` column other than `Status`, write to `specs/INDEX.md` beyond a single confirmed row's patch or removal, introduce any severity or status state beyond CRITICAL/WARNING/SUGGESTION and current/superseded, or reconcile a contradiction on its own judgment without a human confirming which side of it stands.
+
+## Prerequisites
+
+- OpenSpec CLI installed and initialized, with `accelint-qrspi-archive` already in regular use — this skill is a consumer of the indexes that skill produces, not a replacement for it.
+- `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` both exist and contain at least one row. See Verification Task B.
+- Sub-agent support, for the same reason `accelint-qrspi-archive`'s Phases 1 and 4 require it: opening a candidate change's `design.md`, or a capability's `spec.md` for reconciliation, should return a structured extract to the parent, not the raw file contents. This skill's Phase 2 and Phase 3 both always delegate those targeted reads to subagents.
+- Read access to every capability directory under `openspec/specs/` — plain file reads are sufficient, no OpenSpec CLI shellout needed, the same reasoning `accelint-qrspi-archive` already applies to its own local spec reads. Phase 3 is the only phase that needs this beyond the two index files.
+- For routing to actually land anywhere beyond the report itself, the four writer skills' Mode 3 Refresh path needs to accept a `findings:` list (the same shared interface `accelint-qrspi-apply` Phase 4 uses). If a targeted writer skill doesn't yet support this, this skill still produces the finding — it just can't hand it off automatically (see Error Handling).
+
+## Build Order Context
+
+This skill is deliberately the last of four pieces to exist, and each of the other three is a hard dependency, not a nice-to-have:
+
+1. **`accelint-qrspi-archive`** has to already be in regular use. It's what produces both indexes this skill reads and the `related:`/frontmatter fields Phase 2, Phase 3, and Phase 4 depend on — without it, there is no corpus here at all.
+2. **`accelint-qrspi-propose`'s Phase 2 extension** (reading `specs/INDEX.md` at propose time) needs to exist so that `specs/INDEX.md` is actually a load-bearing artifact in the workflow, not just a side effect of archiving — otherwise nothing downstream would notice or care if this skill's structural-coupling flags ever pointed at stale data.
+3. **The shared `findings:` interface** — the Mode 3 Refresh extension across the four writer skills, paired with `accelint-qrspi-apply` Phase 4's matching prompt change — has to land before this skill has anywhere to route a confirmed decision-drift or structural-coupling finding at all. Without it, Phase 7 has a report and a human decision but no destination for those two finding types. Index reconciliation findings (Phase 3) don't depend on this at all — they never route anywhere, confirmed or not, so that check works the same regardless of whether this interface exists yet.
+
+The practical consequence: if any of these three aren't in place yet, this skill can still run Phases 0 through 6 (scan, detect, report) and produce a valid report, but Phase 7 degrades to "tell the human what to do manually" for whichever half of the interface is missing, on decision-drift and structural-coupling findings only. It is never a reason to refuse the run outright.
+
+## The Two Indexes This Skill Reads (Owned Elsewhere)
+
+Neither index below is written by this skill in the general case. Both are written and maintained by `accelint-qrspi-archive`; this skill only ever reads them, with two narrow exceptions, both spelled out under Phase 7: a `Status` column update on `archive/INDEX.md`, and a single-row patch or removal on `specs/INDEX.md`.
+
+```
+openspec/changes/archive/INDEX.md, one row per archived change:
+
+| Change        | Date       | Decision                                               | Specs touched                      | Status  |
+|---------------|------------|---------------------------------------------------------|-------------------------------------|---------|
+| add-live-sync | 2026-03-02 | polling with 5s interval, no infra budget this quarter   | sync/protocol, ui/status-indicator  | current |
+
+openspec/specs/INDEX.md, one row per capability, rebuilt on every archive:
+
+| Capability    | Purpose                                                | Related              | Last touched by            |
+|---------------|----------------------------------------------------------|------------------------|------------------------------|
+| sync/protocol | Defines how client and server exchange live state       | ui/status-indicator   | add-live-sync (2026-03-02)  |
+```
+
+The `Decision` column is a condensed one-line summary of that change's `design.md` frontmatter (`choice` + `rationale`). This skill's Phase 2 works off that summary first, cheaply, and only opens the full `design.md` — for its `alternatives:` field and any nuance the one-liner compresses away — for the specific candidates flagged as plausibly contradictory. This mirrors the same cost-control discipline `accelint-qrspi-archive` uses when it defers opening a change's folder until its own index flags it as relevant.
+
+## The Log This Skill Owns
+
+Neither index above records a synthesis checkpoint — that's expected, since both are owned entirely by `accelint-qrspi-archive` and neither has a reason to know this skill exists. So this skill maintains one small file of its own, `openspec/changes/archive/SYNTHESIS-LOG.md`, purely to answer two questions neither index can: "how many changes have archived since I last ran," and "has a human already looked at this specific decision-drift pair and judged it not real." It's a plain append-only list of one line per completed run, date plus the `archive/INDEX.md` row count checked through, plus an optional `dismissed:` sub-list of decision-drift pairs a human explicitly dismissed that run.
+
+This file is not a column of either index and is never touched by `accelint-qrspi-archive` — it exists solely so **Phase 1** and **Phase 0, Task A** below can read it, and **Phase 2** can filter against its accumulated `dismissed:` history. Phase 8 is the only phase that ever appends to it, and it only ever appends — a dismissal recorded on one run is never later removed by this skill itself; if a human wants to reconsider a dismissed pair, that's a manual edit to the log file, outside this skill's own write path. The exact line format, including the `dismissed:` sub-list, is shown where Phase 8 writes it.
+
+**Only decision-drift dismissals get this treatment — structural coupling dismissals don't, on purpose.** A decision-drift pair is anchored to two specific, immutable archived changes; a human's judgment that a specific pair isn't a real contradiction stays true forever, since the underlying `design.md` files never change. A structural coupling finding is a live snapshot of a `related:` count that moves every time `accelint-qrspi-archive` runs — permanently silencing "sync/protocol is over-coupled" would blind this skill to sync/protocol's count climbing further, which is exactly the trend this signal exists to catch. So structural coupling findings always resurface every run regardless of a prior dismissal; only decision-drift dismissals are ever written to the log.
+
+## Findings Interface (Shared Contract, Not New)
+
+Routing a confirmed finding to a writer skill uses the exact same `findings:` shape `accelint-qrspi-apply` Phase 4 already uses — this skill is the interface's second caller, not a new one:
+
+```
+/accelint-architecture-doc
+We found the following during periodic archive synthesis. Treat this as known
+context and refresh the affected section(s).
+
+findings:
+- [Confirmed finding, rephrased as a plain factual statement, e.g., "add-live-sync
+  (2026-03-02) chose polling for sync/protocol citing no infra budget for a
+  message broker, but adopt-websocket-gateway (2026-09-14) later adopted a
+  message broker for an unrelated capability — worth confirming the original
+  budget constraint still holds before sync/protocol's spec is next touched"]
+```
+
+The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Phase 3) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Phase 7 for what happens to those instead.
+
+**Rephrasing discipline.** Every line inside `findings:` is a plain factual statement about what the archive shows, never an instruction and never a conclusion the writer skill hasn't reached itself yet. "sync/protocol's stated budget constraint may no longer hold, given a later change's message-broker adoption" is correctly phrased; "update sync/protocol's spec to remove the budget constraint" is not — that second phrasing pre-empts the writer skill's own Mode 3 interview, which is exactly the judgment call this skill's Phase 6/7 split exists to keep with a human, not hand to a downstream skill as a foregone conclusion.
+
+## Relationship to `/opsx:verify`
+
+This skill borrows `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register deliberately, so a report from either reads as a familiar artifact — but the two check fundamentally different things. `/opsx:verify` runs once, per change, before that change archives: forward-looking, scoped to whether one implementation matches its own `design.md` and `tasks.md`. This skill runs periodically, across the whole archive, after changes have already landed: backward-looking, scoped to whether the archive as a whole still agrees with itself. A change can pass `/opsx:verify` cleanly the day it archives and still surface in a decision-drift finding two years later, once enough later changes touch related capabilities. The two are complementary, not redundant, and neither substitutes for the other.
+
+## Workflow Overview
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│  Phase            Action                                            Output    │
+├───────────────────────────────────────────────────────────────────────────────┤
+│  0 Preflight      Read SYNTHESIS-LOG.md, verify dependencies        Go / no-go│
+│                   exist, sanity-check the two reasoned-default      + notes   │
+│                   thresholds (Tasks A, B, C)                                  │
+│  1 Scan indexes   Read archive/INDEX.md + specs/INDEX.md, load      In-memory │
+│                   prior dismissed: pairs from the log               model     │
+│  2 Decision drift Coarse-scan Decision column for same/related-     Candidate │
+│                   capability collisions, skipping already-dismissed findings  │
+│                   pairs; SUBAGENT opens design.md for the rest                │
+│  3 Reconciliation Confirm every spec.md still exists; read Purpose  Candidate │
+│                   + related: from each and diff against its         findings  │
+│                   specs/INDEX.md row                                          │
+│  4 Structural     Median related-count across specs/INDEX.md,       Candidate │
+│    coupling       flag outliers ≥5 and ≥2× median                   findings  │
+│  5 Compile report Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
+│                   findings, /opsx:verify register                   report    │
+│  6 Human review   Present report; human confirms, dismisses, or     Confirmed │
+│                   defers each finding                               findings  │
+│  7 Route          Update Status, or patch/remove a specs/INDEX.md   Docs +    │
+│                   row (confirmed findings only) + invoke affected   Status +  │
+│                   writer skill(s) via findings:                     specs row │
+│  8 Log + report   Append run checkpoint + any new dismissed:        Summary   │
+│                   pairs to SYNTHESIS-LOG.md, summarize                        │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+Phase 2's design.md reads and Phase 3's spec.md reads both always delegate to
+a subagent, one per candidate, regardless of how many candidates surface. This
+keeps raw design.md and spec.md contents out of the parent's context on every
+run, the same discipline accelint-qrspi-archive applies to its own Phase 1
+and Phase 4.
+```
+
+## Phase Breakdown
+
+### Phase 0: Preflight
+
+**Goal**: confirm this run has something to check and that its two reasoned-default thresholds still look reasonable, before reading anything else.
+
+**Verification Task A — trigger cadence sanity-check.** Read `openspec/changes/archive/SYNTHESIS-LOG.md` (introduced above, under "The Log This Skill Owns") to find the last completed run's date and the archive row count it checked through. If the file doesn't exist yet, this is the first-ever run — skip the cadence math entirely rather than dividing by a history that doesn't exist yet, and note in the report that no prior checkpoint exists. Otherwise, take the `Date` column across every `archive/INDEX.md` row appended since that checkpoint and derive an average time-between-archives. The 15-archived-changes-since-last-run trigger is a reasoned starting point, not a measured one, so if the actual cadence implies 15 changes would mean checking twice a year or checking every few days, surface this as an informational note in the final report — never adjust the threshold automatically. Changing it is a decision for the human reading the report, not this skill. This task never blocks a run: if a human manually invokes this skill the day after the last run, with zero new rows since the checkpoint, proceed anyway — say so plainly ("0 changes since the last run, proceeding at your request"), since freshness is informational, not a gate.
+
+**Verification Task B — dependency check.** Confirm both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` exist and contain at least one row each. If either is missing or empty, stop and report that `accelint-qrspi-archive` needs to run first — this skill has nothing to read yet, and guessing at index content would be worse than declining. If the archive has fewer than roughly 10 rows total, proceed only if the human explicitly wants a low-signal run anyway; note plainly in the report that a corpus this small has little for cross-archive synthesis to find, per the same reasoning that put this skill last in the build order.
+
+**Verification Task C — structural coupling threshold sanity-check.** "At least 5 and at least double the index median" is the same kind of reasoned-not-measured default as Task A's trigger count. Compute the actual median `related:` count across every row in `specs/INDEX.md` and note, informationally only, whether the fixed floor of 5 or the 2× multiplier look like they'd flag either far too many capabilities or none at all against this project's real distribution. Same rule as Task A: report the observation, never silently change the threshold.
+
+If Tasks A and C surface nothing unusual, say so briefly and move on — these are sanity checks, not a mandatory finding every run.
+
+### Phase 1: Scan Indexes
+
+**Goal**: build an in-memory model of the archive without opening a single change folder yet.
+
+Read `archive/INDEX.md` in full: every row's `Change`, `Date`, `Decision` summary, `Specs touched` list, and current `Status`. Read `specs/INDEX.md` in full: every row's `Capability`, `Purpose`, `Related` list, and `Last touched by`/date. Both files stay cheap regardless of how large the archive has grown — that is the entire point of maintaining them — so this phase never needs to look past them.
+
+Also read every `dismissed:` sub-list across `SYNTHESIS-LOG.md`'s full history (not just the most recent run — a pair dismissed three runs ago still needs to stay suppressed) and build one flat set of dismissed-pair identities, each in the form `<change-A slug>|<change-B slug>|<capability>` with the two slugs alphabetically sorted so the same pair always produces the same identity regardless of which run or which order they were first compared in. If the log doesn't exist yet, this set starts empty — same first-run handling as Task A.
+
+### Phase 2: Decision Drift Detection
+
+**Goal**: find archived decisions that no longer cohere with each other, without opening every `design.md` in the corpus to do it.
+
+**Step 1 — group by shared or related capability.** Using `Specs touched` from `archive/INDEX.md` and `related:` from `specs/INDEX.md`, cluster archived changes that touched the same capability directly, or touched capabilities each other's `related:` lists connect.
+
+**Step 2 — coarse scan.** Before comparing anything, drop any pair already present in Phase 1's dismissed-pair set — a human already looked at that exact pair and judged it not real, and that judgment doesn't expire. For everything else, within each cluster, compare `Decision` one-liners for signals of tension. A starter list of opposing-choice pairs worth pattern-matching on (extend it as a project's own vocabulary reveals its own oppositions — this isn't exhaustive):
+
+- polling vs. push/websocket
+- synchronous vs. asynchronous
+- in-process vs. external service/broker
+- monolith vs. microservice/split
+- eager vs. lazy (loading, evaluation, initialization)
+- centralized vs. distributed
+- client-side vs. server-side (validation, rendering, state)
+
+Beyond direct opposing pairs, also flag a stated rationale later contradicted by a rationale in a more recent change touching a related capability, and a capability with several changes clustered nearby in time while its own spec's `Last touched by` date sits conspicuously earlier. This step works entirely off the index text already in memory — no file I/O. A coarse-scan hit is cheap to be wrong about: it costs one subagent call in Step 3, not a bad finding in the final report, so this list is intentionally biased toward over-flagging rather than under-flagging.
+
+**Step 3 — targeted verification.** For each candidate the coarse scan flags, spawn one subagent per candidate pair to open the full `design.md` for each change involved and confirm or dismiss the contradiction using the complete `choice`/`rationale`/`alternatives` fields, not just the index's compressed summary. For example, given these two frontmatter blocks:
+
+```yaml
+# openspec/changes/archive/2026-03-02-add-live-sync/design.md
+---
+change: add-live-sync
+specs_touched: [sync/protocol, ui/status-indicator]
+decisions:
+  - id: D1
+    choice: polling with 5s interval
+    rationale: no infra budget for a message broker this quarter
+    alternatives: [websocket push, long polling]
+---
+```
+
+```yaml
+# openspec/changes/archive/2026-06-18-adopt-notification-gateway/design.md
+---
+change: adopt-notification-gateway
+specs_touched: [notifications/dispatch]
+decisions:
+  - id: D1
+    choice: message broker (RabbitMQ)
+    rationale: notification fan-out needed guaranteed delivery and retry
+    alternatives: [polling, webhook callbacks]
+---
+```
+
+the subagent reads both `choice`/`rationale` pairs directly and confirms a genuine contradiction candidate: `add-live-sync`'s stated constraint ("no infra budget for a message broker") is now in tension with a later change clearing exactly that obstacle for a different capability. Whether this actually rises to a finding, and at what severity, is settled by the rule below — not by this step alone. Return only a structured verdict (confirmed / dismissed, plus a supporting quote-free summary) to the parent — never the raw `design.md` contents.
+
+**Step 4 — staleness flag.** Separately, flag any capability where `specs/INDEX.md`'s `Last touched by` date is old relative to a cluster of recent, related activity nearby (per Step 1's grouping) — this doesn't require opening any `design.md`, since it's a pure date comparison already available from Phase 1's index scan.
+
+**Classification rule.** A confirmed contradiction is CRITICAL if the affected capability's `specs/INDEX.md` `Last touched by` date falls *after* the earlier of the two contradicting changes' dates — meaning something was built or touched on top of a decision that may no longer hold. Otherwise it's WARNING: the contradiction is real, but nothing has actively depended on the resolved version since. Both halves of this comparison come straight from the index model Phase 1 already built, so the rule needs no new lookup and produces the same classification on a re-run given the same data. Staleness flags (Step 4) are always SUGGESTION-level, since they're a signal to look, not a confirmed contradiction.
+
+### Phase 3: Index Reconciliation
+
+**Goal**: check whether `specs/INDEX.md` still matches the actual `spec.md` files it claims to summarize — the one thing nothing else in this pipeline verifies. `accelint-qrspi-archive`'s Phase 5 patches only the rows for capabilities the current batch's changes declared in `specs_touched`, and only performs a full corpus-wide scan once, at bootstrap, when the index doesn't exist yet. Every archive after that leaves every untouched row exactly as it was, indefinitely — a `spec.md` hand-edited outside the archive workflow, or a capability directory renamed or deleted directly, has no mechanism anywhere in this stack that would ever notice unless that specific capability happens to be touched by some future change. `accelint-qrspi-archive`'s own SKILL.md names this gap explicitly and names this skill as the natural place to close it, since periodic, corpus-wide checking is exactly this skill's charter.
+
+**Step 1 — existence check (every row, no content read).** For every row in `specs/INDEX.md`, confirm `openspec/specs/<capability>/spec.md` still exists on disk. This is a file-existence check, not a content read, so it costs nothing meaningful even against a large corpus. A missing file or directory is an immediate CRITICAL finding — every other phase in this pipeline that touches this row (Phase 2's clustering, Phase 4's median) is working from a reference that no longer resolves to anything.
+
+**Step 2 — content check (every row whose file exists).** Read just the top of each `spec.md` — its `## Purpose` heading body and `related:` frontmatter list, not the full spec body — and compare against that row's `Purpose` and `Related` columns. A mismatch on either is a WARNING finding: "specs/INDEX.md row for `<capability>` disagrees with its own spec.md — index says `<X>`, file currently says `<Y>`." This is a small, bounded read (frontmatter plus one heading, the same shape of read Phase 2 Step 3 already does against `design.md`), not a full-corpus content scan — it stays proportionate to corpus size the same way Phase 4's median calculation does, just with a per-row cost instead of a zero cost.
+
+**What this phase does not do.** It never writes anything itself — Phase 3 is detection only. It never routes a confirmed finding to a writer skill either, since this isn't a hub-doc content gap — it's the index itself being wrong. What happens after a human confirms a reconciliation finding is Phase 7's job, not this one; see Phase 7 for the narrow, confirmation-gated write permission this skill has on `specs/INDEX.md` for exactly this case.
+
+### Phase 4: Structural Coupling Signal
+
+**Goal**: surface capabilities whose `related:` count suggests they may have outgrown their own boundary — at zero extra cost, since the counts already exist in `specs/INDEX.md` for other reasons.
+
+Compute the median `related:` list length across every row read in Phase 1. Flag any capability whose count is both at least 5 and at least double that median as a SUGGESTION-level finding, phrased as a plain fact: for example, "sync/protocol relates to 14 other capabilities, more than double the index median of 6." This is a second reading of data the pipeline was already maintaining, not new bookkeeping, and it never requires opening any `design.md`.
+
+Worked example: across 22 capability rows, related-counts of `[1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8, 9, 10, 11, 14, 14]` sort to a median of 6 (the 11th and 12th of 22 values, both 6). The floor is `max(5, 2 × 6) = 12`, so only the two rows at 14 clear it — everything from 11 down, including the two rows already at 6, stays unflagged. This is exactly the kind of distribution Verification Task C checks against: if every project's median clustered near 1 or 2 instead, the fixed floor of 5 alone would already flag most of the corpus regardless of the 2× multiplier, which is precisely the mismatch Task C exists to surface.
+
+### Phase 5: Compile Report
+
+**Goal**: assemble everything Phases 2, 3, and 4 found into one report, in the same CRITICAL / WARNING / SUGGESTION register `/opsx:verify` already uses, so it reads as a familiar artifact rather than a new report format to learn.
+
+```
+## Archive Synthesis Report — <date>
+
+Corpus: <N> archived changes, <M> capabilities, checked back to <last synthesis
+checkpoint or "project start">.
+
+### CRITICAL
+- [Confirmed decision contradiction with a live, actively-touched capability]
+- [Index reconciliation: a specs/INDEX.md row's capability directory or
+  spec.md no longer exists]
+
+### WARNING
+- [Confirmed decision contradiction on a dormant capability]
+- [Index reconciliation: a specs/INDEX.md row's Purpose or related:
+  disagrees with its own spec.md]
+
+### SUGGESTION
+- [Staleness flag]
+- [Structural coupling flag]
+
+### Threshold notes (informational only, Tasks A & C)
+- [Any cadence or median mismatch worth a human's attention]
+```
+
+Never present a finding here as already-resolved — every CRITICAL/WARNING item is a candidate for Phase 6, not a conclusion.
+
+### Phase 6: Human Review
+
+**Goal**: let a human decide what actually happens with each finding — this skill never resolves a contradiction on its own authority.
+
+Present each finding individually, in severity order. The three options are always Confirm / Dismiss / Defer, but "Confirm" and "Dismiss" don't do the same thing for a decision-drift finding as they do for a structural coupling or index reconciliation finding, and the label has to say so — a person choosing between them shouldn't have to already know this skill's internals to know what they're picking:
+
+```
+Finding 1 [CRITICAL]: add-live-sync's stated budget constraint for
+sync/protocol may no longer hold, given adopt-notification-gateway's
+later message-broker adoption.
+  (a) Confirm — I'll ask which change stands, then update Status and
+      notify the relevant doc skill(s)
+  (b) Dismiss — Recorded permanently; this exact pair won't be
+      flagged again
+  (c) Defer  — Left as-is; resurfaces next run
+
+Finding 2 [SUGGESTION]: sync/protocol relates to 14 capabilities,
+over double the index median of 6.
+  (a) Confirm — Routes to ARCHITECTURE.md's Known Technical Debt review
+  (b) Dismiss — Not persisted; will still be re-checked and may
+      resurface next run if still elevated
+  (c) Defer  — Left as-is; resurfaces next run
+
+Finding 3 [CRITICAL]: specs/INDEX.md row for cache/layer points at
+openspec/specs/cache/layer/spec.md, which no longer exists.
+  (a) Confirm — I'll remove this row from specs/INDEX.md; if this
+      was a rename, the new capability gets its own row automatically
+  (b) Dismiss — Not persisted; will still be re-checked and may
+      resurface next run if still unresolved
+  (c) Defer  — Left as-is; resurfaces next run
+```
+
+Only confirmed findings proceed to Phase 7, and for a decision-drift finding, "Confirm" is the start of a decision, not the end of one — it only tells this skill the contradiction is real; Phase 7 still has to ask which side of it stands before anything gets written (see Phase 7 and Error Handling). Defer never writes anything — a deferred finding resurfaces on the next run exactly as before, since nothing about the underlying index data changed to stop Phase 2, Phase 3, or Phase 4 from re-detecting the same pattern. Dismiss behaves differently depending on the finding type, which is exactly why its label above isn't the same across all three: dismissing a **decision-drift finding** persists — Phase 8 records that specific pair's identity to `SYNTHESIS-LOG.md`, and Phase 2 Step 2 will skip it on every future run. Dismissing a **structural coupling** or **index reconciliation finding** does not persist — either resurfaces next run like a defer would, because both are live snapshots of current state (a `related:` count, or whether a `spec.md` still matches its index row) rather than fixed historical facts (see "The Log This Skill Owns" for the full reasoning).
+
+If the human stops reviewing partway through the list — ends the session, or moves on without responding to every finding — treat every unaddressed finding as deferred by default, never as confirmed. Phase 8 still logs the run and reports what was confirmed so far; whatever wasn't reached simply resurfaces next time, same as an explicit defer.
+
+### Phase 7: Route Confirmed Findings
+
+**Goal**: hand off confirmed findings to wherever they can actually change something, using the shared `findings:` interface, and, for the narrow set of writes this skill is ever allowed to make, make them.
+
+**For a confirmed decision contradiction**: confirming doesn't specify which side of the contradiction stands, so ask that directly first — never infer it from recency alone, even though "the later change" is often the reasonable guess (see Error Handling for why a wrong guess here is worse than a wrong guess almost anywhere else in this skill). Once the human names it, update that row's `Status` column in `archive/INDEX.md` to `superseded by <slug> (<date>)`, where `<slug>` and `<date>` identify the change that stands. This is the only write this skill ever makes to that file, and it only happens after both the initial confirmation and this follow-up answer — never automatically, never speculatively, never guessed. Then invoke the writer skill(s) whose hub doc covers the affected capability, using the Findings Interface format above.
+
+**Which writer skill a finding targets** follows the same purpose split `accelint-qrspi-apply` Phase 4 already uses to decide between the four hub docs — a decision-drift finding rarely belongs to exactly one, so route to whichever actually covers what the contradiction is about:
+
+- A contradiction over **tech stack, dependencies, or coding/architecture patterns** → `accelint-onboard-openspec` (`openspec/config.yaml`).
+- A contradiction over **system structure, components, or data flow** → `accelint-architecture-doc` (`ARCHITECTURE.md`). This is also always the target for structural coupling findings, landing in that skill's existing Known Technical Debt interview slot.
+- A contradiction over **agent workflow or behavior** → `accelint-onboard-agent` (`AGENTS.md`).
+- A contradiction over **user-facing setup or usage** → `accelint-readme-writer` (`README.md`).
+
+A single finding can legitimately target more than one — invoke each relevant writer skill separately, with the same finding rephrased once per invocation to fit that doc's own focus, exactly as `accelint-qrspi-apply` Phase 4 already treats each hub doc as an independent target rather than a single combined update. Each invocation succeeds or fails on its own — one writer skill being unavailable or erroring never blocks or rolls back a separate, successful invocation of another (see Error Handling for the specific case of a routing failure after `Status` has already been written).
+
+**For a confirmed staleness flag or structural coupling flag**: no `Status` update applies — these aren't contradictions between two specific rows, so there is nothing to mark superseded. Route the finding to `accelint-architecture-doc`'s existing Known Technical Debt interview slot via the same `findings:` interface.
+
+**For a confirmed index reconciliation finding — content mismatch (WARNING)**: unlike a decision-drift finding, this needs no disambiguating question — `spec.md` is the source of truth by construction, so once a human confirms the discrepancy is real, the correct value isn't a judgment call. Patch that single row in `specs/INDEX.md`: locate the line whose first cell exactly matches the capability name — anchored between the leading `| ` and the next `|`, the same precise match `accelint-qrspi-archive`'s own Phase 5 uses, so `cache/layer` never matches `cache/layer-v2` — and replace only the `Purpose` and `related:` cells with `spec.md`'s current values. Leave `last_touched_by` exactly as it reads. That field records which *archived change* last touched this capability, and a reconciliation patch isn't an archived change — overwriting it would misattribute a hand-edit fix to a change that never happened. Build the replacement row with `accelint-qrspi-archive`'s own formatting rules: single-space cell separation, no cross-row padding, every other row in the file untouched. Report the before/after diff once written.
+
+**For a confirmed index reconciliation finding — missing directory or file (CRITICAL)**: also unambiguous once confirmed — the row points at something that no longer exists, so the correct action is removing that row, regardless of whether the capability was renamed or genuinely retired. Locate the line by the same anchored match and delete it; every other row stays untouched. If it turns out this was a rename rather than a removal, this skill doesn't attempt to guess the new name or insert a row for it — Phase 3 never verified that new capability's content, so writing a row for it here would be a guess dressed up as a finding. The new capability picks up its own row the ordinary way, the next time `accelint-qrspi-archive` archives a change that touches it.
+
+**This skill's write permission on `specs/INDEX.md`** is exactly these two operations — patch or delete a single row — and only ever fires after Phase 6's explicit human confirmation of that specific discrepancy. It reuses `accelint-qrspi-archive`'s own row-patch mechanics rather than inventing separate logic that could drift from it over time; the two skills write the same file the same way, they just fire from different triggers.
+
+**For a dismissed decision-drift finding**: no `Status` write, but Phase 8 does record the pair's identity to `SYNTHESIS-LOG.md`'s `dismissed:` sub-list, so Phase 2 Step 2 skips it on every future run. This is the one case where a dismissal actually changes what happens next time.
+
+**For a dismissed structural coupling or index reconciliation finding, or any deferred finding**: no write anywhere. All resurface identically on the next synthesis run — a deferred finding because nothing about the underlying index changed, a dismissed coupling or reconciliation finding because both are live snapshots that deserve re-checking every run regardless of a prior dismissal (see "The Log This Skill Owns").
+
+### Phase 8: Log and Report
+
+**Goal**: leave a checkpoint for Task A's cadence math next time, persist any newly dismissed decision-drift pairs, and summarize the run.
+
+Append one line to `openspec/changes/archive/SYNTHESIS-LOG.md` (created fresh on first run) recording the date and the `archive/INDEX.md` row count this run checked through, followed by an indented `dismissed:` sub-list if any decision-drift finding was dismissed this run (omit the sub-list entirely if none were):
+
+```
+2026-07-06 — checked through row 42 — 2 confirmed, 1 dismissed, 1 deferred
+  dismissed: [add-live-sync|adopt-notification-gateway|sync/protocol]
+```
+
+This log is a new, standalone file this skill owns entirely — it is not a column of either index, so writing it never conflicts with the single-write-permission rule on `archive/INDEX.md`. It exists purely so Phase 0's next run can compute "changes since last run" without guessing, and so Phase 2 can skip pairs a human has already ruled out, since neither index records either of those things on its own. Every run only ever appends a new line — an existing `dismissed:` entry is never edited or removed by this skill; a human wanting to reconsider a dismissed pair does so by editing the log file directly, not through this skill.
+
+Close with a short summary: how many findings of each type, how many confirmed/dismissed/deferred, and which writer skill(s) were invoked as a result.
+
+## Explicitly Out of Scope
+
+- **No automatic doc rewriting, under any circumstance.** This skill produces a report and, on confirmation, a `findings:` handoff — it never edits a hub doc directly itself.
+- **No write to any `archive/INDEX.md` column except `Status`.** Every other column belongs to `accelint-qrspi-archive`, permanently, including on rows this skill's `Status` update touches.
+- **No third severity or status state.** Findings stay CRITICAL/WARNING/SUGGESTION; `Status` stays a two-state field, `current` or `superseded by <slug> (<date>)`.
+- **No automatic threshold adjustment.** Verification Tasks A and C report mismatches; they never change the 15-change trigger or the 5-and-2×-median coupling floor on their own.
+- **No running on its own initiative.** Always either a direct human invocation or an offered suggestion from `accelint-qrspi-archive` that the human separately accepts.
+- **No cross-repository synthesis.** This skill operates only on the local project's `openspec/changes/archive/` and `openspec/specs/`. OpenSpec's separate stores feature, for cross-repo spec references, is untouched by anything here — extending synthesis across repositories is a different, larger problem this skill doesn't attempt.
+- **No writes to any `design.md`, ever.** Phase 2 opens archived `design.md` files strictly to read `choice`/`rationale`/`alternatives` for verification — never to annotate, correct, or append anything back to them. An archived change's own record of its own reasoning stays exactly as it was written, even after a later synthesis run confirms it's now superseded.
+- **No writes to `specs/INDEX.md` beyond a single confirmed row's patch or removal.** This mirrors the `archive/INDEX.md` rule exactly: one narrow, confirmation-gated exception, using `accelint-qrspi-archive`'s own row-format logic rather than separate logic that could drift from it. No bulk edits, no full-file rewrites, no speculative inserts for a renamed capability this skill never verified.
+- **No writes to any `spec.md`, ever.** Phase 3 reads `## Purpose` and `related:` to compare against the index — it never corrects, annotates, or touches the file it's checking.
+- **No full-body reads of `spec.md` during reconciliation.** Phase 3 reads only the `## Purpose` heading and `related:` frontmatter — the same bounded, top-of-file read Phase 4's own source data already assumes, not a full spec review.
+
+## Error Handling
+
+**Either index missing or empty (Task B)**: stop before Phase 1; tell the user to run `accelint-qrspi-archive` first.
+
+**`SYNTHESIS-LOG.md` doesn't exist yet**: not an error, and not the same condition as the one above — this is the expected state on this skill's first-ever run. Task A skips its cadence math and proceeds; Phase 8 creates the file fresh.
+
+**Corpus smaller than ~10 archived changes**: don't block, but say plainly that a corpus this size has little for cross-archive synthesis to find, and ask before proceeding with a low-signal run.
+
+**A flagged writer skill isn't installed, or doesn't yet support `findings:` in its Mode 3 path**: don't fail the whole run. Still produce and present the finding in the report; for Phase 7 routing, tell the user this specific handoff needs to happen manually and summarize what the finding was so they can paste it in themselves.
+
+**No subagent support available**: fall back to opening flagged `design.md` candidates directly in the parent context for Phase 2 Step 3. Warn the user explicitly that this run's raw design.md contents will sit in context as a result — a degraded fallback, not the default.
+
+**A `design.md` referenced by an index row no longer exists** (moved, renamed, or the archive folder was otherwise disturbed outside this skill's own writes): skip that row for Phase 2's targeted verification, note it in the report as unverifiable, and do not treat its absence as itself a finding.
+
+**A row in either index is malformed** (a `Specs touched` or `Related` list that fails to parse, a missing `Date`, or similar): skip that single row for whatever phase needs the missing field, note it plainly in the report as unparseable, and continue with every other row. One bad row is a data-quality note for the human, not a reason to abandon the run.
+
+**A `dismissed:` entry in `SYNTHESIS-LOG.md` references a slug that no longer appears in `archive/INDEX.md`** (the log was hand-edited, or the archive was altered outside this skill's own flow): drop that one identity from the in-memory dismissed-pair set for this run and note it once in the report — it can't suppress anything if one of its two slugs no longer resolves to a real row, and guessing at what it originally meant would be worse than treating it as inert.
+
+**Fewer than 2 rows in `specs/INDEX.md`**: skip Phase 4 entirely — a median needs enough rows to mean anything, and this mirrors the same low-corpus reasoning as the archive-size check above.
+
+**Phase 2 Step 1 clustering produces an unreasonably large candidate set** (a capability with a very long `related:` list, or a corpus with many changes touching it): don't spawn one subagent per pair unconditionally. Prioritize the most recently archived pairs first, verify those, and note in the report how many older candidates in the same cluster weren't checked this run due to volume — they remain candidates and will resurface next run, same as any other unconfirmed finding. This is a volume cap for cost control, not a correctness shortcut: nothing here is dismissed on the skill's own authority.
+
+**A confirmed finding's routing invocation to a writer skill fails or times out**: this doesn't undo a `Status` update already made for that same finding — the two writes are independent, and `Status` reflects the human's confirmation, not whether the handoff succeeded. Tell the user plainly that the `Status` update landed but the writer-skill handoff didn't, and give them the same `findings:`-formatted text so they can invoke it manually.
+
+**The human answers Phase 7's "which change stands" follow-up ambiguously, or doesn't answer at all**: never infer it from recency alone, even though "the later change" is often the reasonable guess. Ask again rather than proceeding — a wrong guess here writes a permanent, human-facing claim into an audit-trail file, which is exactly the kind of write this skill's single-write-permission rule exists to keep deliberate. Leave the finding unresolved (equivalent to deferred) until the answer is unambiguous.
+
+**A human names a slug for `Status`'s `superseded by` value that doesn't actually appear in `archive/INDEX.md`**: stop and ask for the correct slug rather than writing an unverifiable reference — this field's entire value depends on it always resolving to a real row.
+
+**A `spec.md` exists but has no `## Purpose` heading** (`accelint-qrspi-archive`'s own Prerequisites require this heading before it will patch a row for that capability, but a hand-edit could still have removed it after the fact): treat this the same as a content mismatch — a WARNING finding noting the heading is missing entirely, not a CRITICAL one, since the directory and file both still resolve to something real.
+
+**The corpus has far more capabilities than is reasonable to content-check in one run**: prioritize capabilities whose `Last touched by` change is oldest relative to the archive's own history first — those are the rows that have gone longest without any patch at all, and so carry the highest risk of undetected drift. Note in the report how many capabilities' content checks were skipped this run due to volume; the existence check in Step 1 still runs against every row regardless, since that check is nearly free.
+
+**A confirmed reconciliation finding's target row changed between Phase 3's detection and Phase 7's write** (a rare race — `accelint-qrspi-archive` ran in between, or a human hand-edited the row during the review session): re-check the row immediately before writing. If it already matches `spec.md` (something else already fixed it), skip the write and report it as resolved rather than confirmed-and-patched. If it still needs the same fix, proceed. Never write based on what Phase 3 saw if that's no longer what's actually there.
+
+**The `specs/INDEX.md` patch or removal write itself fails**: report it plainly, the same way a failed writer-skill handoff is reported — this finding stays unresolved (equivalent to deferred) and resurfaces next run, since nothing was actually written.
+
+## NEVER Do This
+
+**NEVER run without an explicit human invocation or accepted suggestion** — this skill has no automatic trigger of its own; `accelint-qrspi-archive` only ever suggests, it never forces a run.
+
+**NEVER write any `archive/INDEX.md` column other than `Status`** — every other field is `accelint-qrspi-archive`'s, permanently, on every row this skill ever touches.
+
+**NEVER introduce a third state to `Status`** — it is always `current` or `superseded by <slug> (<date>)`, never anything else.
+
+**NEVER update `Status` without an explicit human confirmation of that specific contradiction** — a candidate surfacing in Phase 2 is not the same thing as a human agreeing it's real.
+
+**NEVER rewrite a hub doc directly** — always route a confirmed finding through the relevant writer skill's own Mode 3 Refresh path via the `findings:` interface, exactly like `accelint-qrspi-apply` Phase 4 already does.
+
+**NEVER open every `design.md` in the corpus wholesale** — Phase 2 only opens the specific candidates the cheap index-only scan in Step 2 flagged, one subagent per candidate.
+
+**NEVER silently adjust the 15-change trigger or the 5-and-2×-median coupling floor** — Tasks A and C only report a mismatch; changing either number is a human's call.
+
+**NEVER treat a missing or moved `design.md` as itself a finding** — it just means that row can't be verified this run; note it and move on.
+
+**NEVER tell a human a dismissed structural coupling finding is permanently suppressed** — only decision-drift dismissals persist to `SYNTHESIS-LOG.md`; a dismissed coupling finding resurfaces next run exactly like a deferred one, since its underlying count is a moving snapshot. Say this plainly rather than implying a guarantee this skill doesn't keep.
+
+**NEVER let this skill itself edit or remove an existing `dismissed:` entry** — Phase 8 only ever appends. Reconsidering a previously dismissed pair is a manual edit to `SYNTHESIS-LOG.md`, deliberately outside this skill's own write path.
+
+**NEVER roll back a `Status` update because a routing invocation afterward failed** — the two writes are independent. A confirmed finding's `Status` change reflects the human's confirmation, not whether the writer-skill handoff succeeded; a failed handoff gets reported and handed to the human manually, it never reverses a write that already landed.
+
+**NEVER write to `specs/INDEX.md` except a single confirmed row's patch or removal** — same discipline as the `Status` exception on `archive/INDEX.md`: one narrow, confirmation-gated write, never a bulk edit or full-file rewrite.
+
+**NEVER touch `last_touched_by` when patching a reconciliation finding** — that field records which archived change last touched the capability; a reconciliation patch isn't an archived change, and overwriting it would misattribute a hand-edit fix to a change that never happened.
+
+**NEVER guess a renamed capability's new name or insert a speculative row for it** — a missing-file CRITICAL finding only ever removes the stale row. Phase 3 never verified the new capability's content, so writing a row for it would be a guess dressed up as a finding.
+
+**NEVER re-pad or realign existing rows in `specs/INDEX.md` when patching or removing one row** — same rule `accelint-qrspi-archive` follows for its own row-level writes. Cell padding is per-row, not aligned to the table's widest value; touching every row's whitespace to keep columns visually lined up turns a one-line diff back into a full-file rewrite.
+
+**NEVER tell a human a dismissed index reconciliation finding is permanently suppressed** — same rule as structural coupling, and for the same reason: the comparison is against live file state, not a fixed historical fact, so it's re-checked every run regardless of a prior dismissal.
+
+**NEVER treat a missing `## Purpose` heading in an otherwise-existing `spec.md` as a directory-level CRITICAL** — the file and directory both resolve to something real; that's a content-level WARNING, same bucket as a `Purpose`/`related:` mismatch.
+
+## Terminology
+
+This skill uses several terms precisely and doesn't mix them — worth pinning down once rather than re-explaining in every phase:
+
+- **Candidate**: a possible contradiction, drift, or coupling signal the coarse scan (Phase 2 Step 2), the existence/content check (Phase 3), or the median check (Phase 4) has flagged, before any verification has happened. Not yet a finding.
+- **Confirmed**: a candidate that Phase 2 Step 3's targeted subagent verified against full `design.md` content, a Phase 3 discrepancy that simply is what the direct comparison against `spec.md` shows (no separate verification step needed, since it's already a direct read), or a Phase 4 structural signal that simply is what the index says it is (same reasoning).
+- **Finding**: a confirmed candidate, phrased as a plain fact, ready for Phase 5's report and Phase 6's human review. Only findings appear in the report — raw candidates that Step 3 dismissed never do.
+- **Confirmed (human)**: distinct from the verification-step "confirmed" above — this is the human's Phase 6 decision that a given finding warrants action. Context disambiguates which sense is meant; where it doesn't, this document says "human-confirmed" explicitly.
+- **Dismissed**: a Phase 6 human decision that a finding isn't real or doesn't need action. Persists for decision-drift findings (the pair is logged and never re-flagged); does not persist for structural coupling or index reconciliation findings (both are re-checked every run regardless, since both read a live, moving snapshot of current state rather than a fixed historical fact). See Phase 6 and "The Log This Skill Owns" for why they differ.
+- **Deferred**: a Phase 6 human decision that a finding is real but not ready to act on. Never persists, for any finding type — a deferred finding resurfaces next run exactly as before.
+- **`Status` = `current`**: the default state `accelint-qrspi-archive` writes for every row — not an assertion that the row is definitely correct, only that no synthesis run has yet confirmed a contradiction affecting it.
+- **`Status` = `superseded by <slug> (<date>)`**: the only other state this field ever holds, written exclusively by this skill's Phase 7, exclusively after a human-confirmed decision contradiction. Index reconciliation findings never produce a `Status` write — see Phase 7.
+- **`specs/INDEX.md` row patch or removal**: this skill's other write permission, exclusively on Phase 7, exclusively after a human-confirmed index reconciliation finding. A patch touches only `Purpose` and `related:`; a removal deletes the whole row. Neither ever touches `last_touched_by`, and neither is a `Status`-style state — the row is either present and current, or it's gone.
+
+## Example Usage
+
+**Scenario: suggested run, one confirmed contradiction, one structural flag**
+
+```
+[accelint-qrspi-archive, at the end of its own summary output]
+ℹ 15 changes have archived since the last synthesis run (2026-01-10).
+  Consider running accelint-archive-synthesis.
+
+User: Yes, run archive synthesis.
+
+Skill: Preflight —
+✓ Task B: both indexes present, 47 archived changes, 22 capabilities
+✓ Task A: actual cadence ~1.1 changes/week; 15-change trigger implies
+  checking roughly every 10 weeks — no mismatch worth flagging
+✓ Task C: index median related-count is 6; 5-and-2× floor looks reasonable
+  against this distribution
+
+Scanning archive/INDEX.md and specs/INDEX.md...
+
+Decision drift —
+[spawns subagent: verify sync/protocol candidate]
+✓ Confirmed: add-live-sync (2026-03-02) chose polling for sync/protocol,
+  citing no infra budget for a message broker. adopt-notification-gateway
+  (2026-06-18) later adopted a message broker for an unrelated capability.
+  sync/protocol has been touched twice since — CRITICAL.
+
+Index reconciliation —
+✓ Existence check: 22/22 capability directories present.
+[spawns subagent: content-check cache/layer]
+✓ Confirmed: cache/layer's specs/INDEX.md row lists related: [cli-core],
+  but cache/layer/spec.md's actual related: frontmatter currently reads
+  [cli-core, rule-engine] — added by a hand-edit, no archived change
+  touched this capability since — WARNING.
+
+Structural coupling —
+✓ sync/protocol relates to 14 other capabilities, more than double the
+  index median of 6 — SUGGESTION.
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 47 archived changes, 22 capabilities, checked back to 2026-01-10.
+
+### CRITICAL
+Finding 1: add-live-sync's stated budget constraint for sync/protocol may
+no longer hold, given adopt-notification-gateway's later message-broker
+adoption.
+  (a) Confirm — I'll ask which change stands, then update Status and
+      notify the relevant doc skill(s)
+  (b) Dismiss — Recorded permanently; this exact pair won't be flagged again
+  (c) Defer  — Left as-is; resurfaces next run
+
+### WARNING
+Finding 2: cache/layer's specs/INDEX.md row disagrees with its own
+spec.md — index says related: [cli-core], file currently says
+related: [cli-core, rule-engine].
+  (a) Confirm — I'll patch this row directly (Purpose + related:
+      only, last_touched_by stays as-is)
+  (b) Dismiss — Not persisted; will still be re-checked and may
+      resurface next run if still unresolved
+  (c) Defer  — Left as-is; resurfaces next run
+
+### SUGGESTION
+Finding 3: sync/protocol relates to 14 capabilities, over double the
+median of 6.
+  (a) Confirm — Routes to ARCHITECTURE.md's Known Technical Debt review
+  (b) Dismiss — Not persisted; will still be re-checked and may
+      resurface next run if still elevated
+  (c) Defer  — Left as-is; resurfaces next run
+
+User: Confirm all three findings.
+
+Skill: For Finding 1 — which change should Status reflect as the one
+that stands: add-live-sync's original budget constraint, or
+adopt-notification-gateway's later message-broker adoption?
+
+User: adopt-notification-gateway — the budget constraint's gone now.
+
+Skill:
+✓ archive/INDEX.md: add-live-sync row Status → "superseded by
+  adopt-notification-gateway (2026-06-18)"
+[invokes accelint-architecture-doc with findings: — sync/protocol budget
+  constraint may be stale]
+✓ Finding 2 confirmed.
+✓ specs/INDEX.md: cache/layer row patched — related: [cli-core] →
+  [cli-core, rule-engine] (Purpose unchanged, last_touched_by left
+  exactly as it was — this patch isn't an archived change, so
+  attribution doesn't move)
+✓ Finding 3 confirmed.
+[invokes accelint-architecture-doc with findings: — sync/protocol
+  structural coupling, routed to Known Technical Debt review]
+
+Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
+
+✅ Synthesis complete: 3 confirmed, 0 dismissed, 0 deferred.
+```
+
+**Scenario: first-ever run, small corpus, nothing to report**
+
+```
+User: Run archive synthesis on this repo, I don't think it's ever been done.
+
+Skill: Preflight —
+✓ Task B: both indexes present, 6 archived changes, 4 capabilities
+ℹ openspec/changes/archive/SYNTHESIS-LOG.md doesn't exist yet — this is the
+  first-ever run. Task A's cadence math needs a prior checkpoint, so it's
+  skipped this time rather than computed against nothing.
+⚠ 6 archived changes is a small corpus — cross-archive synthesis has little
+  to work with yet. Continue anyway with a low-signal run?
+
+User: Yes, go ahead.
+
+Skill: Scanning archive/INDEX.md and specs/INDEX.md...
+
+Decision drift — no candidate collisions found across 4 capabilities.
+Index reconciliation — 4/4 directories present; all 4 spec.md files match
+  their specs/INDEX.md rows.
+Structural coupling — only 4 specs/INDEX.md rows; Phase 4 needs at least 2
+  to compute a median, but a corpus this small has nothing meaningful to
+  flag either way.
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 6 archived changes, 4 capabilities, checked back to project start.
+
+No CRITICAL, WARNING, or SUGGESTION findings this run.
+
+Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md
+  (file created fresh)...
+
+✅ Synthesis complete: nothing to confirm. Re-run once more changes have
+   archived — this corpus is too small yet for the signal to be meaningful.
+```
+
+**Scenario: a previously dismissed pair stays suppressed on the next run**
+
+```
+[Run 1, three months earlier]
+Skill: Finding 1 [WARNING]: legacy-cache-warmer (2025-11-02) chose eager
+  cache warming for cache/layer, citing predictable traffic patterns.
+  adopt-lazy-init (2026-01-14) later chose lazy initialization for an
+  unrelated capability.
+  (a) Confirm — I'll ask which change stands, then update Status and
+      notify the relevant doc skill(s)
+  (b) Dismiss — Recorded permanently; this exact pair won't be
+      flagged again
+  (c) Defer  — Left as-is; resurfaces next run
+
+User: Dismiss — these two were never actually in tension, different
+teams, different constraints.
+
+Skill: ✓ Recorded as dismissed.
+Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
+  dismissed: [adopt-lazy-init|legacy-cache-warmer|cache/layer]
+
+[Run 2, today]
+Skill: Preflight —
+✓ Task A: reading SYNTHESIS-LOG.md — last run 2026-04-02, checked
+  through row 31; 1 dismissed pair on record
+✓ Task B: both indexes present, 53 archived changes, 24 capabilities
+
+Scanning archive/INDEX.md and specs/INDEX.md...
+Loading dismissed-pair history — 1 entry found.
+
+Decision drift —
+- legacy-cache-warmer / adopt-lazy-init / cache/layer: matches a
+  dismissed pair on record, skipped without re-verification.
+- [new candidates, if any, proceed through Steps 2-4 as normal]
+
+## Archive Synthesis Report — 2026-07-06
+Corpus: 53 archived changes, 24 capabilities, checked back to 2026-04-02.
+(cache/layer's legacy-cache-warmer/adopt-lazy-init pair previously
+dismissed — not re-surfaced this run)
+
+No new CRITICAL or WARNING findings.
+```

--- a/skills/accelint-onboard-agent/CHANGELOG.md
+++ b/skills/accelint-onboard-agent/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.4.0] - 2026-07-08
+
+### Added
+- **External findings support in refresh mode** — skill now accepts `findings:` list from invoking prompt
+  - Parses invoking prompt for a `findings:` section (bulleted list of factual statements)
+  - Each finding is phrased as something already known to be true, never as an instruction
+  - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+  - Findings are merged with drift detection and unresolved TODOs before presenting to user
+  - Allows upstream workflows (e.g., `accelint-qrspi-apply`) to pass change-specific context that should influence AGENTS.md updates
+  - If external findings exist, notes their source (e.g., "from completed OpenSpec change")
+  - Rationale: AGENTS.md refresh after completing OpenSpec changes should incorporate behavioral decisions made during that change. Without external findings, the skill would only detect drift via file/config changes but miss workflow or policy decisions that haven't yet manifested in tracked files.
+
+### Changed
+- **Refresh mode workflow expanded** — now includes 5-step process instead of 4-step
+  - Step 1: Extract external findings from invoking prompt (if any)
+  - Step 2: Drift detection (scan codebase for changes)
+  - Step 3: Unresolved TODOs (find placeholder markers)
+  - Step 4: Merge and announce all findings (external + drift + TODOs) before asking anything
+  - Step 5: After targeted interview, show diff-style preview before writing
+  - Rationale: Explicit merge step makes it clear that external findings, drift findings, and TODOs are treated equally, and announcing them together upfront gives the user full context before the interview begins
+
+### Version
+- Bumped from 1.3.0 → 1.4.0
+
 ## [1.3.0] - 2026-05-11
 
 ### Changed

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -4,7 +4,7 @@ description: Interactively onboard a project to agent-driven development by runn
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Onboard Agents
@@ -222,7 +222,13 @@ as (a) or (b) if the user is satisfied.
 The file matches the skill's expected shape — it was likely produced by a
 previous run. Run an abbreviated interview covering only:
 
-1. **Drift detection** — scan the codebase for changes since the file was
+1. **Extract external findings** — check if the invoking prompt includes a `findings:` list:
+   - Parse the prompt for a `findings:` section (a bulleted list of factual statements)
+   - Each finding is phrased as something already known to be true, never as an instruction
+   - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+   - Store these findings for merging in step 4
+
+2. **Drift detection** — scan the codebase for changes since the file was
    last updated:
 
    | Signal | Where to look |
@@ -235,14 +241,17 @@ previous run. Run an abbreviated interview covering only:
    | OpenSpec added/removed | `openspec/` directory presence |
    | New protected branches | `.github/branch-protection*`, README |
 
-2. **Unresolved TODOs** — find all `<!-- TODO: fill in -->` markers left
+3. **Unresolved TODOs** — find all `<!-- TODO: fill in -->` markers left
    from the previous run and surface them as targeted questions.
 
-3. **Announce findings** before asking anything:
-   > "I found [N] sections that may have drifted and [M] unresolved TODOs.
-   > I'll only ask about those — the rest looks current."
+4. **Merge and announce all findings** before asking anything:
+   - Combine external findings (from step 1) with drift findings (from step 2) and TODOs (from step 3)
+   - Present the merged list to the user:
+     > "I found [N] external findings, [M] sections that may have drifted, and [P] unresolved TODOs.
+     > I'll only ask about those — the rest looks current."
+   - If external findings exist, note their source (e.g., "from completed OpenSpec change")
 
-4. After the targeted interview, show a diff-style preview (changed sections
+5. After the targeted interview, show a diff-style preview (changed sections
    only) before writing. Do not re-emit sections that have not changed.
 
 ---
@@ -538,12 +547,10 @@ with placeholder text.
 | Uncertain about scope | [ask / proceed with stated assumption] |
 | Deleting files | [always ask first] |
 | Changing public API | [always ask first] |
+| Adding a new dependency | [ask, state rationale] |
+| Modifying shared utilities | [ask, list affected packages] |
 | Discovering scope creep mid-task | [pause and surface to user] |
 | Two equally valid approaches | [pick one and state choice / ask] |
-| Adding a new dependency | Check stdlib, native platform features, and already-installed deps first; if none cover it, ask and state rationale |
-| Modifying shared utilities | Check this repo's shared-utility location (config.yaml → Architecture Patterns → Shared code) before writing something new; if extending, ask and list affected packages |
-| Introducing a new abstraction (interface, factory, config) for one use case | Don't — implement directly; add the abstraction once a second concrete use case exists |
-| Taking a shortcut with a known ceiling (naive scan, global lock, hardcoded limit) | Take it, mark it with `// NOTE:` naming the ceiling and the upgrade trigger — use the existing comment convention, not a new tag |
 | *(TypeScript)* Adding JSDoc to exported code | Always add comprehensive docs |
 | *(TypeScript)* Adding JSDoc to internal code | Use judgment — document non-obvious behavior only |
 | *(TypeScript)* Writing tests for pure functions with invariants | Consider property-based testing with fast-check |
@@ -577,9 +584,6 @@ with placeholder text.
 ## Guardrails
 
 ### Never (hard stops — no exceptions)
-- [ ] Never simplify away trust-boundary input validation, error handling that
-      prevents data loss, security checks, or accessibility basics — the
-      minimalism heuristics above never override this
 - [ ] Never force-push to any branch
 - [ ] Never commit secrets, tokens, or credentials
 - [ ] Never break backward compatibility without explicit approval

--- a/skills/accelint-onboard-openspec/CHANGELOG.md
+++ b/skills/accelint-onboard-openspec/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.4.0] - 2026-07-08
+
+### Added
+- **External findings support in refresh mode** — skill now accepts `findings:` list from invoking prompt
+  - Parses invoking prompt for a `findings:` section (bulleted list of factual statements)
+  - Each finding is phrased as something already known to be true, never as an instruction
+  - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+  - Findings are merged with drift detection and unresolved TODOs before presenting to user
+  - Allows upstream workflows (e.g., `accelint-qrspi-apply`) to pass change-specific context that should influence config.yaml updates
+  - If external findings exist, notes their source (e.g., "from completed OpenSpec change")
+  - Rationale: config.yaml refresh after completing OpenSpec changes should incorporate architectural and pattern decisions made during that change. Without external findings, the skill would only detect drift via file changes but miss semantic decisions that haven't yet manifested in the codebase.
+
+### Changed
+- **Refresh mode workflow expanded** — now includes 5-step process instead of 4-step
+  - Step 1: Extract external findings from invoking prompt (if any)
+  - Step 2: Drift detection (scan codebase for changes)
+  - Step 3: Unresolved TODOs (find placeholder markers)
+  - Step 4: Merge and announce all findings (external + drift + TODOs) before asking anything
+  - Step 5: After targeted interview, show diff-style preview before writing
+  - Rationale: Explicit merge step makes it clear that external findings, drift findings, and TODOs are treated equally, and announcing them together upfront gives the user full context before the interview begins
+
+### Version
+- Bumped from 1.3.0 → 1.4.0
+
 ## [1.3.0] - 2026-05-11
 
 ### Changed

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -4,7 +4,7 @@ description: Interactively onboard a project to OpenSpec by running a structured
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Onboard OpenSpec
@@ -161,7 +161,13 @@ as (a) or (b) if the user is satisfied.
 The file matches the skill's expected schema — it was likely produced by a
 previous run. Run an abbreviated interview covering only:
 
-1. **Drift detection** — scan the codebase for changes since the file was
+1. **Extract external findings** — check if the invoking prompt includes a `findings:` list:
+   - Parse the prompt for a `findings:` section (a bulleted list of factual statements)
+   - Each finding is phrased as something already known to be true, never as an instruction
+   - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+   - Store these findings for merging in step 4
+
+2. **Drift detection** — scan the codebase for changes since the file was
    last updated:
 
    | Signal | Where to look |
@@ -175,14 +181,17 @@ previous run. Run an abbreviated interview covering only:
    | New domain concepts | New top-level directories, new entity types in source |
    | Anti-patterns deprecated | `@deprecated` tags, `// TODO: replace` comments added |
 
-2. **Unresolved TODOs** — find all `# TODO: fill in` markers left from the
+3. **Unresolved TODOs** — find all `# TODO: fill in` markers left from the
    previous run and surface them as targeted questions.
 
-3. **Announce findings** before asking anything:
-   > "I found [N] context sections that may have drifted and [M] unresolved
-   > TODOs. I'll only ask about those — the rest looks current."
+4. **Merge and announce all findings** before asking anything:
+   - Combine external findings (from step 1) with drift findings (from step 2) and TODOs (from step 3)
+   - Present the merged list to the user:
+     > "I found [N] external findings, [M] context sections that may have drifted, and [P] unresolved TODOs.
+     > I'll only ask about those — the rest looks current."
+   - If external findings exist, note their source (e.g., "from completed OpenSpec change")
 
-4. After the targeted interview, show only the changed sections in the
+5. After the targeted interview, show only the changed sections in the
    preview before writing. Do not re-emit unchanged sections.
 
 ---
@@ -637,7 +646,6 @@ rules:
     # Technical depth:
     - Use ASCII diagrams for data flows, state machines, architecture
     - Call out performance implications where relevant
-    - Any new abstraction, interface, or dependency introduced must have its "Alternatives Considered" entry explicitly rule out stdlib, an existing project utility (per config.yaml), and an installed dependency.
     [user-specific design rules]
 
     # Constraints:

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.4.0] - 2026-07-08
+
+### Changed
+- **Living document update invocations now pass change decisions as findings** — All documentation skill invocations (accelint-onboard-openspec, accelint-architecture-doc, accelint-onboard-agent, accelint-readme-writer) now extract decisions from design.md frontmatter and pass them as `findings:` list
+  - Step 3a of each living document update now includes:
+    1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+    2. For each decision, rephrase as a plain factual statement (not an instruction)
+    3. Invoke the skill with findings in the prompt
+  - Example finding: "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"
+  - Skills merge these findings with their own codebase scans before presenting to the human
+  - Rationale: Documentation skills need to know what decisions were made during the change to properly update project DNA, architecture, agent behavior, and user docs. Without this context, skills would only detect file-level drift and miss semantic decisions that haven't fully manifested in the codebase yet.
+  - Impact: Each documentation update now has richer context about *why* changes were made, not just *what* changed
+
+### Added
+- **Fallback documentation update instructions for missing skills** — When a documentation skill is not installed, the manual update instructions now include reading design.md frontmatter for decisions
+  - Ensures consistency whether using skills or manual updates
+  - Prevents documentation updates from missing change rationale when skills aren't available
+
+### Version
+- Bumped from 1.3.0 → 1.4.0
+
 ## [1.3.0] - 2026-06-25
 
 ### Changed

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
 metadata:
   author: accelint
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Accelint QRSPI Apply
@@ -365,11 +365,19 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
    **For OpenSpec config** (`<repo-root>/openspec/config.yaml`):
    - Check if `accelint-onboard-openspec` skill is installed
    - If skill is available:
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     2. For each decision, rephrase as a plain factual statement (not an instruction)
+     3. Invoke the skill with findings:
      ```
      /accelint-onboard-openspec
-     We have just completed the change spec openspec/changes/<change-name>. Given this change, we need to make sure that the openspec/config.yaml is current and up to date.
+     We have just completed the change spec openspec/changes/<change-name>.
+
+     findings:
+     - [Decision 1 rephrased as fact, e.g., "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"]
+     - [Decision 2 rephrased as fact]
+     ...
      ```
-     The skill will read the proposal and design from the change directory to understand what was implemented and update the config accordingly.
+     The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
      - `openspec/changes/<change-name>/proposal.md`
@@ -387,11 +395,19 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
    **For ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
    - Check if `accelint-architecture-doc` skill is installed
    - If skill is available:
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     2. For each decision, rephrase as a plain factual statement (not an instruction)
+     3. Invoke the skill with findings:
      ```
      /accelint-architecture-doc
-     We have just completed the change spec openspec/changes/<change-name>. Given this change, we need to make sure that the ARCHITECTURE.md is current and up to date.
+     We have just completed the change spec openspec/changes/<change-name>.
+
+     findings:
+     - [Decision 1 rephrased as fact]
+     - [Decision 2 rephrased as fact]
+     ...
      ```
-     The skill will read the proposal and design from the change directory to understand what was implemented and update ARCHITECTURE.md accordingly.
+     The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
      - `openspec/changes/<change-name>/proposal.md`
@@ -410,11 +426,19 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
    **For AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
    - Check if `accelint-onboard-agent` skill is installed
    - If skill is available:
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     2. For each decision, rephrase as a plain factual statement (not an instruction)
+     3. Invoke the skill with findings:
      ```
      /accelint-onboard-agent
-     We have just completed the change spec openspec/changes/<change-name>. Given this change, we need to make sure that the AGENTS.md is current and up to date.
+     We have just completed the change spec openspec/changes/<change-name>.
+
+     findings:
+     - [Decision 1 rephrased as fact]
+     - [Decision 2 rephrased as fact]
+     ...
      ```
-     The skill will read the proposal and design from the change directory to understand what was implemented and update AGENTS.md accordingly.
+     The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
      - `openspec/changes/<change-name>/proposal.md`
@@ -432,11 +456,19 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
    **For README.md** (`<repo-root>/README.md`) — IF it exists:
    - Check if `accelint-readme-writer` skill is installed
    - If skill is available:
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     2. For each decision, rephrase as a plain factual statement (not an instruction)
+     3. Invoke the skill with findings:
      ```
      /accelint-readme-writer
-     We have just completed the change spec openspec/changes/<change-name>. Given this change, we need to make sure that the README.md is current and up to date.
+     We have just completed the change spec openspec/changes/<change-name>.
+
+     findings:
+     - [Decision 1 rephrased as fact]
+     - [Decision 2 rephrased as fact]
+     ...
      ```
-     The skill will read the proposal and design from the change directory to understand what was implemented and update README.md accordingly.
+     The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
      - `openspec/changes/<change-name>/proposal.md`
@@ -659,7 +691,7 @@ All requirements implemented. No critical issues found.
 ### Next Steps
 1. Review the changes: `git diff`
 2. Run tests: `pnpm test`
-3. Archive this change: `/opsx:archive remove-security-ruleset`
+3. Archive this change: `/accelint-qrspi-archive remove-security-ruleset`
 
 Ready to archive!
 ```

--- a/skills/accelint-qrspi-archive/README.md
+++ b/skills/accelint-qrspi-archive/README.md
@@ -1,0 +1,340 @@
+# Accelint QRSPI Archive
+
+Archive OpenSpec changes with cross-capability linking and index maintenance. This skill orchestrates the complete archiving workflow, from invoking OpenSpec's native merge through updating cross-capability relationships and maintaining running indices.
+
+## What This Does
+
+Takes a completed OpenSpec change and archives it with full bookkeeping:
+
+- Invokes `/opsx:archive` or `/opsx:bulk-archive` to merge the change
+- Cross-links every capability pair the change touched
+- Updates `related:` frontmatter and regenerates `## Related Specs` sections
+- Rebuilds the complete specs index (`openspec/specs/INDEX.md`)
+- Appends to the archived-change changelog (`openspec/changes/archive/INDEX.md`)
+
+The skill runs the native archive command itself as Phase 1 — it's the entry point for archiving, not a post-merge hook. This ensures cross-linking happens after conflicts resolve, when specs have reached their final merged state.
+
+## When to Use This
+
+Invoke this skill when:
+
+- You've completed implementing an OpenSpec change and want to archive it
+- You want to bulk-archive multiple pending changes at once
+- You need cross-capability linking maintained automatically
+- The specs index or changelog needs updating after archival
+
+Trigger phrases:
+- "archive this change"
+- "bulk archive the pending changes"
+- "run opsx:archive with cross-linking"
+- "archive [change-name]"
+- "update specs index and archive"
+
+**Note**: This skill calls `/opsx:archive` or `/opsx:bulk-archive` itself. Don't run those commands manually first — let the skill orchestrate the entire workflow.
+
+## Prerequisites
+
+This skill requires:
+
+1. **OpenSpec CLI** - Installed and initialized
+2. **Sub-agent support** - Phase 1 (archive + extraction) and Phase 4 (per-capability writes) always run as subagents (hard requirement, not optional)
+3. **Frontmatter in design.md** - Each change must have:
+   - `specs_touched`: non-empty list of capability names
+   - `decisions`: list with `{id, choice, rationale, alternatives}` entries
+4. **Purpose heading in specs** - Every capability in `specs_touched` must have a `## Purpose` heading in its `openspec/specs/<capability>/spec.md`
+
+### Check prerequisites:
+
+```bash
+# Verify OpenSpec is initialized
+ls openspec/
+
+# Check a change's frontmatter
+cat openspec/changes/<change-name>/design.md | head -20
+
+# Verify Purpose headings exist
+grep "## Purpose" openspec/specs/*/spec.md
+```
+
+If any are missing, the skill reports the gap and guides you through resolution before proceeding.
+
+## How It Works
+
+### The Workflow
+
+The skill orchestrates seven phases:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Phase          Action                        Output           │
+├────────────────────────────────────────────────────────────────┤
+│  0 Preflight    Verify frontmatter + headings Go/no-go         │
+│  1 Archive      SUBAGENT: run native archive  Change records   │
+│  2 Validate     Confirm extracted completeness Checked records │
+│  3 Link         Compute co-touch pairs         New partners    │
+│  4 Write specs  SUBAGENT: merge & update       Updated specs   │
+│  5 Specs index  Rebuild INDEX.md wholesale     INDEX.md        │
+│  6 Change log   Append to archive INDEX.md     INDEX.md        │
+│  7 Report       Summarize what changed         Summary         │
+└────────────────────────────────────────────────────────────────┘
+
+Critical: for /opsx:bulk-archive, Phases 2-7 run exactly ONCE, after every
+merge in the batch has resolved — never once per intermediate merge.
+```
+
+### Phase 0: Preflight Checks
+
+1. Determines scope: single change (`/opsx:archive <name>`) or bulk archive (`/opsx:bulk-archive`)
+2. **Verifies frontmatter** — reads each change's `design.md` to confirm `specs_touched` and `decisions` exist and are well-formed
+3. **Verifies Purpose headings** — checks that every capability in `specs_touched` has a `## Purpose` heading in its spec
+4. Reports preflight summary and any gaps before proceeding
+
+If frontmatter is missing or malformed, stops before Phase 1 and reports exactly which field is missing. If Purpose headings are missing, asks whether to add placeholders or fix first.
+
+### Phase 1: Archive and Extract (Subagent)
+
+Always runs as a subagent, never inline — keeps raw `design.md` contents out of parent context.
+
+1. Spawns subagent with instructions to run `/opsx:archive` or `/opsx:bulk-archive`
+2. Subagent always answers "yes" to sync prompts (routine part of archive operation)
+3. Waits for all merges to fully resolve
+4. Extracts structured records: `{change, date, archivePath, specsTouched, decisions}`
+5. Returns only these fields — never full file contents
+
+If unresolved conflicts occur, subagent stops immediately and reports verbatim. Does not proceed to Phase 2.
+
+### Phase 2: Validate Extracted Records
+
+Confirms the subagent's returned records are structurally complete:
+- Every record has non-empty `specsTouched`
+- Every record has at least one `decisions` entry with `choice` populated
+- Records remain grouped by change (not flattened across batch)
+
+If validation fails, re-runs Phase 1 for that change rather than proceeding with partial data.
+
+### Phase 3: Compute Cross-Links (All-Pairs Union)
+
+Pure computation with no file I/O. For each change:
+
+1. Computes all 2-combinations within `specs_touched`: `[A, B, C]` → `(A,B)`, `(A,C)`, `(B,C)`
+2. Co-touch is symmetric — pairing `(A,B)` means A gains B **and** B gains A
+3. Combines pairs across all changes in the batch into one map: `capability → Set<new partners>`
+4. Hands this map to Phase 4 unsorted and unmerged (Phase 4 does the union with existing `related:`)
+
+**Example**: Change with `specs_touched: [sync/protocol, ui/status-indicator]` contributes the pair `(sync/protocol, ui/status-indicator)`.
+
+### Phase 4: Write Spec Frontmatter and Body (Subagent, Always)
+
+Always spawns one subagent per touched capability — never inline, regardless of batch size. Keeps spec contents out of parent context.
+
+Each subagent:
+1. Reads current `related:` from frontmatter (treats as empty if no frontmatter exists yet)
+2. Unions it with newly contributed partners from Phase 3 (never drops existing entries)
+3. Sorts the full set alphabetically, writes in flow style (one line for clean diffs)
+4. Updates `last_touched_by` and `last_touched_on` (overwrites previous values)
+5. Regenerates `## Related Specs` section from the sorted `related:` list (wholesale replacement)
+6. Reports back: file path, no-op vs. changed, final `related:` list (not full contents)
+
+For brand-new capabilities (no prior spec.md), creates frontmatter from scratch.
+
+### Phase 5: Rebuild openspec/specs/INDEX.md
+
+Regenerates the complete specs index wholesale (never patched):
+
+1. Lists every directory under `openspec/specs/`
+2. Reads three things from each spec: `## Purpose` heading body, `related:` frontmatter, `last_touched_by`
+3. Emits full table sorted by capability name:
+
+```markdown
+| Capability          | Purpose                         | Related              | Last touched by |
+| ------------------- | -------------------------------- | --------------------- | ---------------- |
+| sync/protocol        | Defines the live-sync wire proto | ui/status-indicator   | add-live-sync     |
+| ui/status-indicator  | Renders connection state in UI   | sync/protocol         | add-live-sync     |
+```
+
+4. Overwrites `openspec/specs/INDEX.md` entirely (preserves any preamble above the table)
+
+### Phase 6: Append to openspec/changes/archive/INDEX.md
+
+Logs one durable row per archived change. This file is history — append-only, never reordered.
+
+For each change from Phase 2:
+1. Constructs one row with: `Change | Date | Decision | Specs touched | Status`
+2. `Date` comes from archive folder's `YYYY-MM-DD` prefix (never from `design.md`)
+3. `Decision` is a one-line summary of `decisions[].choice` (concatenate with semicolons if multiple)
+4. `Status` written as `current` — this skill never touches that column again
+5. Appends to `openspec/changes/archive/INDEX.md` (creates with header if missing)
+
+Never re-sorts or reformats existing rows. Append-only discipline makes this a reliable audit trail.
+
+### Phase 7: Report
+
+Summarizes what changed:
+
+```
+✅ Archive complete: add-live-sync
+
+Specs updated:
+- sync/protocol        (+ui/status-indicator)
+- ui/status-indicator  (+sync/protocol)
+
+openspec/specs/INDEX.md rebuilt (14 capabilities)
+openspec/changes/archive/INDEX.md: 1 row appended
+
+Next steps:
+- Review the diff on touched specs before committing
+- related: entries are additive only — pruning is accelint-archive-synthesis's job
+```
+
+If any capability has a placeholder purpose or was skipped due to Phase 0 Task B, calls that out explicitly.
+
+## Key Concepts
+
+### Cross-Linking at Archive Time
+
+Delta specs in `openspec/changes/<slug>/specs/` are provisional. `/opsx:bulk-archive` may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing.
+
+This is why the skill runs the native command itself as Phase 1 — it needs to wait for the merge to fully resolve before computing cross-links.
+
+### Additive-Only Linking
+
+This skill only adds to `related:` lists, never removes. Pruning a stale entry requires cross-change judgment and human confirmation — that's `accelint-archive-synthesis`'s job, not this one.
+
+### Idempotent Writes
+
+Flow-style sorted `related:` and the wholesale-rebuilt specs index mean re-running against unchanged inputs produces byte-identical output. Retrying after a partial failure never duplicates entries or rows.
+
+### Two Index Strategies
+
+- `specs/INDEX.md` — regenerated wholesale every run (describes current state)
+- `changes/archive/INDEX.md` — append-only, never reordered (describes history)
+
+Treating either the other way corrupts history or lets the index drift.
+
+### Unconditional Subagent Delegation
+
+Phases 1 and 4 always delegate to subagents, never conditionally. This keeps the parent's context cost flat regardless of batch size — the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use.
+
+## Example Usage
+
+### Scenario 1: Single-change archive
+
+```
+User: Archive the add-live-sync change with cross-linking
+
+Skill: Running preflight checks...
+✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
+✓ Both capabilities have a ## Purpose heading
+
+[spawns subagent: archive + extract]
+✓ /opsx:archive add-live-sync merged
+✓ Extracted: specs_touched, decisions
+
+Computing new co-touch pairs...
+- sync/protocol ↔ ui/status-indicator (new pair)
+
+[spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
+✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
+✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
+
+Rebuilding openspec/specs/INDEX.md... (14 capabilities)
+Appending to openspec/changes/archive/INDEX.md... (1 row)
+
+✅ Archive complete: add-live-sync
+
+Next steps:
+- Review the diff on the two updated specs before committing
+- related: entries are additive only — pruning is accelint-archive-synthesis's job
+```
+
+### Scenario 2: Bulk archive with missing Purpose heading
+
+```
+User: Run bulk-archive on the pending changes
+
+Skill: Running preflight checks across 3 pending changes...
+✓ All design.md frontmatter valid
+⚠ auth/session-store is missing a ## Purpose heading
+
+How would you like to handle auth/session-store?
+(a) Add a placeholder purpose now and continue
+(b) Pause so you can add the heading yourself first
+
+User: (b)
+
+Skill: Paused. Add a ## Purpose heading to openspec/specs/auth/session-store/spec.md,
+then re-invoke this skill to continue.
+```
+
+## Error Handling
+
+**If design.md frontmatter is missing or malformed:**
+- Stops before Phase 1 for that change
+- Reports exactly which field is missing (`specs_touched` or `decisions`)
+- Does not infer `specs_touched` from delta spec directory contents
+
+**If a capability is missing its `## Purpose` heading:**
+- Doesn't block Phases 1–3 (they don't touch spec bodies)
+- Stops before Phase 4 reaches that capability
+- Asks whether to add a placeholder or fix the spec first
+
+**If a change touches only one capability:**
+- Produces zero pairs (expected, not an error)
+- Still runs Phase 4 for that capability (updates `last_touched_by`/`last_touched_on`)
+- Still adds a row to the changelog in Phase 6
+
+**If a change introduces a brand-new capability:**
+- Phase 0 notes it separately (no prior spec.md exists yet)
+- Phase 4 subagent creates frontmatter from scratch rather than editing existing file
+
+**If the native command reports unresolved conflicts:**
+- Phase 1 subagent stops immediately and reports verbatim
+- Does not proceed to Phase 2 (partial extraction is worse than none)
+
+**If no subagent support is available:**
+- Falls back to running Phase 1 and Phase 4 directly in parent context
+- Warns explicitly that full file contents will enter context (degraded fallback)
+- Always-answer-yes rule for sync prompts still applies
+
+**If `specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist:**
+- Expected on a project's first-ever archive
+- Phase 6 creates `changes/archive/INDEX.md` with header row
+- Phase 5 always writes `specs/INDEX.md` fresh (wholesale rebuild every run)
+
+## Configuration Requirements
+
+This skill assumes:
+
+1. OpenSpec installed and initialized (`openspec/` directory exists)
+2. Changes have `design.md` with `specs_touched` and `decisions` frontmatter
+3. Sub-agent support available (for parallel execution)
+4. Git initialized (for checking file changes in Phase 7 report)
+
+If any are missing, the skill reports the issue and guides you through setup.
+
+## Tips
+
+Review the preflight summary before proceeding. Make sure frontmatter is present and Purpose headings exist.
+
+Always answer "yes" to sync prompts during archive — this is routine, not a decision point.
+
+The skill is purely additive on `related:` entries. If you see a stale link, use `accelint-archive-synthesis` to prune it (with human confirmation).
+
+Trust the idempotent writes. Re-running against unchanged inputs produces byte-identical output — no duplicates, no drift.
+
+For bulk archives, remember that Phases 2–7 run once after all merges resolve. Don't expect incremental updates mid-batch.
+
+## Related Skills
+
+- `accelint-qrspi-propose` - Create QRSPI-planned changes (phase 1, generates the design.md this skill reads)
+- `accelint-qrspi-apply` - Implement QRSPI-planned changes with parallelization (phase 2, happens before archival)
+- `accelint-archive-synthesis` - Prune stale `related:` entries and update `Status` values with human confirmation
+
+## OpenSpec Commands
+
+This skill uses these OpenSpec CLI commands:
+
+- `/opsx:archive <change-name>` - Archive a single change (delegated to Phase 1 subagent)
+- `/opsx:bulk-archive` - Archive all pending changes (delegated to Phase 1 subagent)
+
+The skill invokes these commands itself in Phase 1. Don't run them manually before invoking the skill.

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -1,0 +1,558 @@
+---
+name: accelint-qrspi-archive
+description: Archive an OpenSpec change end-to-end. This skill invokes `/opsx:archive` or `/opsx:bulk-archive` itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run opsx:archive", "run opsx:bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
+license: Apache-2.0
+compatibility: Requires the OpenSpec CLI. Phase 4 (per-capability spec writes) requires sub-agent support — see the skill body for the degraded fallback if unavailable. Phase 1 (native archive) always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but Phase 0 Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose heading in its body.
+metadata:
+  author: accelint
+  version: "1.0.0"
+---
+
+# Accelint QRSPI Archive
+
+Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes `/opsx:archive` or `/opsx:bulk-archive` itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
+
+Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/<slug>/specs/` is still provisional — `/opsx:bulk-archive` may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
+
+## What This Skill Does
+
+**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking `/opsx:archive` or `/opsx:bulk-archive` itself, then immediately following up with cross-capability linking and index maintenance.
+**Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself in Phase 1; it does not wait for the merge to have happened some other way first.
+**Output**: the change(s) archived via OpenSpec's own merge, plus updated `related:` frontmatter and a regenerated `## Related Specs` section on every touched spec, an updated `openspec/specs/INDEX.md` (patched for the capabilities this batch touched, or built fresh project-wide the first time the file doesn't exist yet), and one appended row per archived change in `openspec/changes/archive/INDEX.md`.
+**Does NOT**: implement the merge or conflict-resolution logic itself (that's OpenSpec's own, which this skill invokes via the native command rather than reimplementing), prune any `related:` entry, change a change's `Status` column after its initial write, reorder existing changelog rows, or shell out to the OpenSpec CLI to read local spec files (plain file reads are sufficient — see Explicitly Out of Scope).
+
+## Prerequisites
+
+- OpenSpec CLI installed and initialized, with one or more changes ready to archive.
+- Sub-agent support, for Phase 4 (per-capability writes) only — Phase 4 always runs as subagents, unconditionally, and this is a hard requirement for normal operation there, not an optional speedup for large batches (see Error Handling for the degraded fallback if unavailable). Phase 1 (native archive + extraction) never uses a subagent, regardless of whether sub-agent support exists — see Phase 1 for why.
+- Each change's `openspec/changes/<slug>/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
+- Every capability named in any `specs_touched` list already has `openspec/specs/<capability>/spec.md` with a `## Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in Phase 0, Task B).
+
+If any of these are missing, report the gap and guide the user to resolve it before proceeding — do not silently substitute a guessed default for a missing field. This applies as-is to Phase 4's sub-agent support and a touched spec's missing `## Purpose` heading. A change's missing `specs_touched`/`decisions` frontmatter is handled differently: Phase 0 Task A derives a candidate from the change's own files and gets the author's explicit confirmation before writing it, rather than stopping outright — see Task A below for why a hard stop isn't actually necessary here, and why it still isn't a silent guess.
+
+## Workflow Overview
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  Phase              Action                              Output         │
+├────────────────────────────────────────────────────────────────────────┤
+│  0 Preflight        Verify frontmatter + Purpose         Go / no-go    │
+│                     headings before touching anything                  │
+│  1 Archive+Extract  Run /opsx:archive or /opsx:bulk-        Change     │
+│                     archive yourself, in this context      records     │
+│                     (never a subagent); stay with any                  │
+│                     internal sync branch until archive's               │
+│                     own steps finish, then read back                   │
+│                     specs_touched + decisions                          │
+│  2 Validate         Confirm Phase 1's records are          Checked     │
+│                     structurally complete                  records     │
+│  3 Link             Combine new co-touch pairs across         New      │
+│                     this batch's changes (no file I/O)     partners    │
+│  4 Write specs      SUBAGENT (one per capability,          Updated     │
+│                     always, never inline): merges new       specs      │
+│                     partners with existing related:,                   │
+│                     sorts, writes frontmatter + body                   │
+│  5 Specs index      Patch specs/INDEX.md for the           INDEX.md    │
+│                     capabilities this batch touched                    │
+│                     (full rebuild only if the index is                 │
+│                     missing)                                           │
+│  6 Change log       Append one row per archived change     INDEX.md    │
+│                     to changes/archive/INDEX.md (append-only)          │
+│  7 Report           Summarize what changed                 Summary     │
+└────────────────────────────────────────────────────────────────────────┘
+
+Critical: for /opsx:bulk-archive, Phases 2-7 run exactly ONCE, after every
+merge in the batch has resolved — never once per intermediate merge. Running
+early would compute pairs against a specs_touched set that hasn't finished
+accumulating cross-change conflicts, and would patch INDEX.md against a
+half-finished batch.
+
+Phase 4 always delegates to subagents, regardless of batch size — one
+capability or forty. This isn't a parallelization optimization that only
+kicks in for large batches; it's how this skill keeps raw spec.md contents
+out of the parent's context on every run, the same pattern
+accelint-qrspi-propose and accelint-qrspi-apply use.
+
+Phase 1 is the mirror image: it never delegates to a subagent, regardless of
+batch size or whether sub-agent support is even available. /opsx:archive and
+/opsx:bulk-archive are themselves agent-driven, multi-step skills — not a
+single deterministic CLI call — and a subagent handed "run /opsx:archive"
+has no reliable way to resume that skill's own remaining steps once it
+branches internally into something like a separate sync skill, and no way
+to surface an interactive prompt back to the user if one comes up. Both of
+those are failure modes this skill hit in practice, not hypothetical ones —
+see Phase 1 for the full account.
+```
+
+## Phase Breakdown
+
+### Phase 0: Preflight Checks
+
+**Goal**: confirm the archive operation's inputs are shaped the way Phases 2–6 assume, before any spec or index file is touched. Task A is a narrow exception: once the author has explicitly confirmed a derived `specs_touched`/`decisions` candidate (see below), it writes that confirmed value back into the change's own `design.md` — that's filling in an input Phase 1 expects to already be there, not touching a spec or an index.
+
+**Steps**:
+
+1. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
+
+2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/<slug>/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
+
+   ```yaml
+   ---
+   change: add-live-sync
+   specs_touched: [sync/protocol, ui/status-indicator]
+   decisions:
+     - id: D1
+       choice: polling with 5s interval
+       rationale: no infra budget for a message broker this quarter
+       alternatives: [websocket push, long polling]
+   ---
+   ```
+
+   If frontmatter is present and well-formed, proceed as-is — this is the expected case for any change that went through `accelint-qrspi-propose`, which is where `specs_touched`/`decisions` are supposed to get written at design time in the first place. If changes are consistently arriving here without this frontmatter, that's a signal to go fix `accelint-qrspi-propose` (or `accelint-qrspi-apply`) so it writes this block as part of its own normal workflow — that closes the gap at the source instead of leaning on the recovery path below run after run.
+
+   If frontmatter is missing or malformed for a change, this skill still does not silently substitute a guessed value — the change's author has to make that call explicitly, not this skill. But a hard stop with no path forward isn't the only way to get that explicit confirmation, and most of the time the missing field is recoverable from material the change's own author already wrote:
+
+   - **Derive a candidate.** For `specs_touched`, look at the change's `proposal.md` capability declarations and the delta spec directories under `openspec/changes/<slug>/specs/`. For `decisions`, look at any Decisions section in `proposal.md` or decision prose already present in `design.md`.
+   - **Present it for confirmation — don't write it yet.** Show the derived candidate to the user and ask them to (a) confirm it as written, (b) edit it first, or (c) pause so they can fix `design.md` themselves and re-invoke this skill later. Only once the user picks (a) or (b) does the candidate become the value this skill writes into `design.md`'s frontmatter — at that point it's the same explicit author confirmation the well-formed case gets for free, just captured one step later than at propose time.
+   - **Stop outright, with no candidate offered**, only when there's nothing in the change's own files to derive from — e.g. an empty delta specs directory and no capability declarations anywhere in `proposal.md`. In that case, report exactly which change and which field is missing, the same as before.
+
+   This is evaluated per change in a bulk-archive batch — one change needing confirmation doesn't block preflight for the others.
+
+3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, confirm `openspec/specs/<capability>/spec.md` contains a `## Purpose` heading. Phase 5 reads this heading directly for the index's Purpose column, and Phase 4 relies on it existing so it can decide where a `## Related Specs` section belongs. If a spec is missing the heading, do not invent placeholder purpose text — ask the user whether to (a) add a placeholder like `_purpose not yet documented_` for now, or (b) fix the spec first. Fixing first is almost always better: a guessed purpose written into the index by this skill becomes content nobody actually authored, and it will look authoritative to the next reader.
+
+4. For any capability in `specs_touched` that has no `openspec/specs/<capability>/` directory yet — a brand-new capability introduced by this change — note it separately. Phase 4 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and Phase 5's Purpose column will need the user to supply a value manually since nothing exists yet to read.
+
+5. Report the preflight summary before proceeding: changes in scope, capabilities touched, and any Task A or Task B outcomes. If Task A ends in a stop for any change — the user chose to pause and fix `design.md` themselves, or no candidate could be derived at all — do not proceed to Phase 1 for that change. A Task A candidate the user confirmed counts as passing, the same as frontmatter that was already well-formed. If Task B fails for some capability, that's fine to resolve later — Phases 1 through 3 don't touch spec bodies, so only flag it as blocking once Phase 4 is about to reach that capability.
+
+**Output**: a go/no-go decision per change, plus the list of capabilities needing manual attention before Phase 4.
+
+### Phase 1: Archive and Extract (Runs Inline — Never a Subagent)
+
+**Goal**: let OpenSpec do the actual merge, then read back the data Phase 3 and Phase 6 need — done directly in this context, not handed to a subagent.
+
+This phase never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
+
+- **`/opsx:archive` and `/opsx:bulk-archive` are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent hand-fed the instruction "run `/opsx:archive`" has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running Phase 1 directly in this context means the same agent that issued "run `/opsx:archive`" is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
+- **A subagent can't surface an interactive prompt to the user.** `/opsx:archive` and `/opsx:bulk-archive` may raise more than the routine sync y/n — `/opsx:bulk-archive` in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running Phase 1 inline means any such prompt lands in the same conversation the user is already in.
+
+This does give something up: `/opsx:archive`'s own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; Phase 4 still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to Phase 1's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the `/opsx:archive`/`/opsx:bulk-archive` skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
+
+**Steps**:
+
+1. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
+
+2. **Known interactive prompt — always sync.** `/opsx:archive` and `/opsx:bulk-archive` will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
+
+3. Run `/opsx:archive <change-name>` (single change) or `/opsx:bulk-archive` (all pending changes) directly, exactly as if the user had typed the slash command themselves.
+
+4. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of Phase 1.
+
+5. **If any other interactive prompt comes up** — most commonly `/opsx:bulk-archive` asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 2. Surface it to the user directly and wait for their answer before continuing.
+
+6. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
+
+7. If ANY merge reports unresolved conflicts, STOP immediately. Do not attempt to resolve it, and do not proceed to step 8 for ANY change in this batch — a partial extraction is worse than none, since there's no way to tell a stalled batch from a clean one otherwise. Report the conflict verbatim to the user and stop. Do not proceed to Phase 2 — parsing anything out of a partially-merged batch would propagate garbage into every capability the batch touches.
+
+8. For each change that archived successfully, read its `design.md` frontmatter from its new archived path (e.g. `openspec/changes/archive/2026-03-02-add-live-sync/design.md`) and build one record:
+
+   ```
+   {
+     change: "add-live-sync",
+     date: "2026-03-02",           // from the archive folder's own
+                                    // YYYY-MM-DD prefix, NEVER from
+                                    // anything inside design.md
+     archivePath: "openspec/changes/archive/2026-03-02-add-live-sync/",
+     specsTouched: ["sync/protocol", "ui/status-indicator"],
+     decisions: [{ id: "D1", choice: "polling with 5s interval", ... }]
+   }
+   ```
+
+9. Keep the list of records from step 8, grouped by change, for Phase 2 — plus an explicit note to yourself that no unresolved conflicts remain.
+
+**Output**: one record per archived change (`change`, `date`, `archivePath`, `specsTouched`, `decisions`), held in this context and passed straight to Phase 2.
+
+### Phase 2: Validate Extracted Records
+
+**Goal**: confirm Phase 1's records are structurally sound before Phase 3 depends on them — a sanity check on what Phase 1 produced, not a re-verification of the source data (Phase 0 Task A already confirmed the source `design.md` frontmatter was well-formed before Phase 1 ran).
+
+**Steps**:
+
+1. Confirm every record has a non-empty `specsTouched` and at least one `decisions` entry with `choice` populated. If a record is missing either, something went wrong building it in Phase 1 (not in the original data, which Task A already validated) — re-run Phase 1 for that change rather than proceeding with a partial record.
+
+2. Keep records grouped **by change**, exactly as returned. Phase 3 computes pairs within a single change's own `specsTouched` — two unrelated changes archived in the same bulk-archive batch don't imply their capabilities co-touch each other, even though they landed at the same moment.
+
+**Output**: the same record set from Phase 1, confirmed structurally complete and ready for Phases 3 and 6.
+
+### Phase 3: Compute Cross-Links (All-Pairs Union)
+
+**Goal**: for each change, compute the symmetric co-touch pairs within its own `specs_touched`, and combine those pairs across every change in this archive operation into one set of newly-contributed partners per capability. This step touches zero files — it only combines the `specsTouched` lists already sitting in the Phase 2 records. Merging those new partners with whatever `related:` entries a spec already has (never dropping any of them) happens in Phase 4, inside the subagent that's already opening that file — there's no reason for the parent to read spec frontmatter just to seed a union that Phase 4 can do in the same breath as its own file read.
+
+**Steps**:
+
+1. For a change with `specs_touched: [A, B, C]`, the contributed pairs are all 2-combinations excluding self: `(A,B)`, `(A,C)`, `(B,C)`. Co-touch has no direction — pairing `(A,B)` means A gains B as a related partner **and** B gains A in the same step.
+
+2. This is a pure computation with no dependency on file I/O, so it's worth writing as a small pure function rather than eyeballing it per capability:
+
+   ```typescript
+   type ChangeLink = {
+     readonly change: string;
+     readonly specsTouched: readonly string[];
+   };
+
+   // All 2-combinations within one change's specs_touched. Pure, no self-pairs,
+   // no directionality — a co-touch relationship reads the same both ways.
+   const pairsFromChange = (
+     link: ChangeLink,
+   ): ReadonlyArray<readonly [string, string]> =>
+     link.specsTouched.flatMap((a, i) =>
+       link.specsTouched.slice(i + 1).map((b) => [a, b] as const),
+     );
+
+   // Fold every change's pairs into one partner-set-per-capability map. This
+   // starts from an empty map every time — it combines pairs ACROSS the
+   // changes in this batch, not against a spec's on-disk related: list. That
+   // merge is deliberately left to Phase 4, which is the one opening the file.
+   const accumulateNewPartners = (
+     pairsByChange: ReadonlyArray<ReadonlyArray<readonly [string, string]>>,
+   ): ReadonlyMap<string, ReadonlySet<string>> => {
+     const next = new Map<string, Set<string>>();
+     for (const pairs of pairsByChange) {
+       for (const [a, b] of pairs) {
+         next.set(a, (next.get(a) ?? new Set()).add(b));
+         next.set(b, (next.get(b) ?? new Set()).add(a));
+       }
+     }
+     return next;
+   };
+   ```
+
+3. Fold every change's pairs into the same accumulating map, starting from empty — a bulk-archive batch of three changes touching overlapping capabilities should have all three changes' pairs combined before Phase 4 ever touches a file, so each capability's subagent is invoked once with a complete new-partner list rather than three times with partial data.
+
+4. Hand this map to Phase 4 as-is — unsorted and unmerged with any spec's existing `related:` list. Phase 4's subagent is responsible for both the merge (union with whatever's already in the file) and the final alphabetical sort, since it's the one that actually reads the file this all depends on.
+
+**Output**: a map of `capability -> newly contributed partner names`, not yet merged with any spec's existing `related:` list and not yet sorted — both of those happen in Phase 4.
+
+### Phase 4: Write Spec Frontmatter and Body (Subagent, Always)
+
+**Goal**: merge Phase 3's newly contributed partners into each touched spec's existing `related:` list, persist that plus provenance into frontmatter, and regenerate the `## Related Specs` section to match.
+
+Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once Phase 3's new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in Phase 3.
+
+**Steps**:
+
+1. For each touched capability, spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from Phase 3 — not a final list; the subagent is the one that merges those against whatever the file already has):
+
+   ```
+   Update openspec/specs/<capability>/spec.md only. Do not touch any other file.
+
+   Read this file's current related: value from its frontmatter (treat it as
+   empty if the file has no frontmatter yet — this may be a brand-new
+   capability). Union it with these newly contributed partners:
+   [<partner>, <partner>, ...]. Never drop an entry that was already there.
+   Sort the resulting full set alphabetically and write it in flow style on
+   one line — that's what keeps a no-op run byte-identical and a genuine
+   addition a clean one-line diff.
+
+   Also set:
+     last_touched_by: <change-name>
+     last_touched_on: <date>
+   as plain overwrites of whatever was there before, not an accumulated
+   history.
+
+   Do NOT add capability or purpose fields. The capability name is this
+   file's own path; purpose already lives in its ## Purpose heading.
+
+   Then regenerate the ## Related Specs section in the body from the same
+   final, sorted related: list (replace any existing ## Related Specs
+   content entirely — this section is never hand-maintained):
+
+     ## Related Specs
+
+     - <partner>
+     - <partner>
+
+   If no ## Related Specs heading exists, insert one directly after
+   ## Purpose, or at the end of the file if there's no clear insertion point.
+
+   Report back ONLY: the file path, whether the write was a no-op
+   (byte-identical to what was already there) or an actual change, the
+   final related: list you wrote, and the capability's current ## Purpose
+   heading text (a sentence or short paragraph — you're not writing this,
+   just reading it back so the parent doesn't have to reopen this file in
+   Phase 5). Do not return the file's full contents.
+   ```
+
+2. If the capability has no prior `spec.md` (a brand-new capability per Phase 0 step 4), the subagent starts from an empty frontmatter block instead of reading an existing one — same prompt otherwise.
+
+3. Collect each subagent's short report (file, no-op vs. changed, final `related:` list, and Purpose heading text) for Phase 5 and Phase 7. Phase 5 reuses the `related:` and Purpose values directly from this report instead of reopening the file; Phase 7's summary draws only on the no-op/changed status. Nothing else about the write needs to enter the parent's context — a reported no-op is the expected signal that this capability wasn't actually affected by this batch, not something to double-check by re-reading the file.
+
+**Output**: every touched capability's `spec.md` updated in place (existing `related:` entries preserved, new ones unioned in and sorted), or confirmed unchanged, with only a short status line plus its `related:`/Purpose values — the small payload Phase 5 needs — entering the parent's context.
+
+### Phase 5: Update openspec/specs/INDEX.md
+
+**Goal**: keep `openspec/specs/INDEX.md` in sync with what Phase 4 just wrote, at the cost of touching only the lines that actually changed — not a re-scan of every capability's `spec.md`, and not even a full read of `specs/INDEX.md` itself. Phase 4's subagents already read each touched capability's current `related:`, `last_touched_by`, and `## Purpose` heading as part of doing their own write, and report those values back — Phase 5 reuses that data directly instead of paying for a second full scan of `openspec/specs/`. The only time this phase looks at capabilities beyond the ones this batch touched, or reads more than a single targeted line of `specs/INDEX.md`, is when the file doesn't exist yet at all — there's no existing state to patch, and a one-time full build is the right move, not a routine one.
+
+**Steps**:
+
+1. **The common case — `specs/INDEX.md` already exists.** Don't read the whole file into context to do this — locate and edit only the lines that actually change:
+
+   - **Existing capability**: grep for the line whose first cell exactly matches the capability name (anchored between the leading `| ` and the next `|`, not a loose substring match — `sync/protocol` must not match `sync/protocol-v2`). Replace that single line with the row built from Phase 4's report for that capability (`Purpose`, `related:`, `last_touched_by`). Nothing else in the file is read or touched.
+   - **Brand-new capability** (per Phase 0 step 4): grep for capability-name cells to find the first existing row that sorts after the new one alphabetically, and insert the new row immediately before it (or append at the end if it sorts last). This still only touches one new line — locating the insertion point doesn't require loading row content, just the capability-name column.
+   - Every row for every untouched capability is never opened, matched, or rewritten — not just "left identical" as an outcome of a full rebuild, but literally never touched by this operation.
+
+2. Build each row without cross-row padding — single-space cell separation (`| sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |`), not aligned to the widest value in each column:
+
+   ```markdown
+   | Capability | Purpose | Related | Last touched by |
+   | --- | --- | --- | --- |
+   | sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |
+   | ui/status-indicator | Renders connection state in UI | sync/protocol | add-live-sync |
+   ```
+
+   Markdown tables render correctly regardless of padding — only the header separator's dash count matters, not whitespace consistency across data rows. Keeping cross-row alignment would mean every row's padding depends on every other row's content length, which forces a full-table rewrite the instant any single row's text changes length — exactly the cost this design exists to avoid. A patched row and its untouched neighbors will look slightly ragged in a raw diff; that's the trade for the diff actually being one line.
+
+3. **The bootstrap case — `specs/INDEX.md` doesn't exist yet.** There's no prior state to patch, and patching only the touched rows would permanently omit every untouched capability until each happens to be touched by some future change. List every directory under `openspec/specs/`, and for each one, read its `## Purpose` heading, `related:` frontmatter, and `last_touched_by` directly — the full scan Phase 5 used to do unconditionally. This runs at most once per project, the first time this skill archives anything against it; every archive after that goes through step 1 instead.
+
+4. **Bootstrap case only**: write `openspec/specs/INDEX.md` from the full scan gathered in step 3, using the row format from step 2. If the file already carries a project-specific title or preamble above the table, preserve it. The common case (step 1) has already written its edit directly — there's no separate write step for it.
+
+**Output**: `openspec/specs/INDEX.md`, with one line changed or inserted per capability this batch touched and every other line untouched, or built once from every capability project-wide if the file didn't exist yet.
+
+A patched `specs/INDEX.md` can still drift from reality for reasons outside this skill's control — a `spec.md` hand-edited outside the archive workflow, a capability directory renamed or deleted directly. This skill doesn't re-derive the whole index every run to catch that. Nothing else currently does either: `accelint-archive-synthesis`'s two checks (decision-drift, structural-coupling) both read `specs/INDEX.md` as ground truth rather than auditing it against the `spec.md` files it summarizes. Catching this kind of drift would mean adding an index-reconciliation check to `accelint-archive-synthesis` — a natural fit for a skill that already exists to do periodic, corpus-wide checks — but that check doesn't exist yet. Until it does, this is an accepted, narrow gap rather than a covered one.
+
+### Phase 6: Append to openspec/changes/archive/INDEX.md
+
+**Goal**: log one durable row per archived change, inserted at the end of the table's existing data rows — never blindly at the end of the file. Unlike Phase 5, this file is history, and history is append-only — never regenerated, never reordered.
+
+**Steps**:
+
+1. For each change from Phase 2, construct one row:
+
+   ```markdown
+   | Change | Date | Decision | Specs touched | Status |
+   | --- | --- | --- | --- | --- |
+   | add-live-sync | 2026-03-02 | polling with 5s interval | sync/protocol, ui/status-indicator | current |
+   ```
+
+   - `Date` is the archive folder's `YYYY-MM-DD` prefix — the same source used in Phase 2, never anything read out of `design.md`.
+   - `Decision` is a one-line summary of `decisions[].choice`. If a change recorded more than one decision, concatenate the choices with semicolons (e.g. `polling with 5s interval; client-side dedup on reconnect`) rather than picking just one — every decision the design phase made deserves to survive into the permanent record, even compressed to a phrase.
+   - `Status` is written as `current` and this skill never touches that column again after this initial write, for this row or any other. Transitions like `current` → `superseded` belong to `accelint-archive-synthesis`, which has the cross-change context needed to know when a decision has actually been superseded — this skill only ever sees one archive operation at a time and can't safely make that call.
+
+2. **Locate the insertion point — the end of the table, not the end of the file.** Find the header row (`| Change | Date | ... |`), its separator (`| --- | --- | ... |`), and the contiguous block of data rows that follows. Insert the new row(s) immediately after the last of those data rows. This file may carry content after the table — a summary block with a total row count, a `Generated:` date stamp, a status legend, or similar — and that content is not part of the table; do not read past it, move it, or edit it. Appending past it instead of before it is exactly how a data row ends up sitting in prose after a `Status Legend` line instead of inside the table, which is what happened before this step existed: treat any such trailing block as preserved-but-unowned, the same way Phase 5 preserves a project-specific preamble above `specs/INDEX.md`'s table without editing it.
+
+3. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row (and no trailing content) if missing.
+
+4. Do not re-sort, reformat, or otherwise touch any existing row. The append-only discipline here is what makes this file a reliable audit trail; reordering past rows would make it impossible for anyone to use git blame to see when a decision was recorded relative to the others around it.
+
+5. If the file's trailing content (per step 2) states a total row count, leave it as written even though it will now be stale by however many rows this run just added. Reconciling that count isn't this skill's job any more than pruning `related:` entries or flipping `Status` values is — it's corpus-wide bookkeeping, the same category of accepted gap Phase 5 already lives with for `specs/INDEX.md` drift (see the note at the end of Phase 5), and a reasonable additional check for `accelint-archive-synthesis` to pick up if it doesn't already.
+
+**Output**: `openspec/changes/archive/INDEX.md`, with one new row per archived change inserted at the end of the table's data rows, every prior row untouched, and any trailing content after the table preserved exactly as it was — including any count within it that's now stale.
+
+### Phase 7: Report
+
+**Steps**:
+
+1. Summarize what changed:
+
+   ```
+   ✅ Archive complete: add-live-sync
+
+   Specs updated:
+   - sync/protocol        (+ui/status-indicator)
+   - ui/status-indicator  (+sync/protocol)
+
+   openspec/specs/INDEX.md updated (2 rows patched)
+   openspec/changes/archive/INDEX.md: 1 row appended
+
+   Next steps:
+   - Review the diff on touched specs before committing
+   - related: entries are additive only here — if one looks wrong,
+     pruning is accelint-archive-synthesis's job, not this skill's
+   ```
+
+2. If any capability was left with a placeholder purpose or skipped entirely because Phase 0 Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
+
+**Output**: a human-readable summary of every file this skill touched.
+
+## Key Principles
+
+A quick-reference summary — each of these is explained in full where it's actually applied (Phase Breakdown) or enforced (NEVER Do This); this is just the index.
+
+- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until `/opsx:bulk-archive` resolves conflicts in order; only the merged, archived spec is worth indexing.
+- **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
+- **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
+- **Every write is idempotent.** Flow-style sorted `related:` and Phase 5's row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
+- **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
+- **Phase 4 always delegates to subagents, never conditionally; Phase 1 never does, unconditionally.** Phase 4's unconditional delegation keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching phase. Phase 1 runs inline for the opposite reason: `/opsx:archive`/`/opsx:bulk-archive` are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
+
+## Explicitly Out of Scope
+
+- **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/<capability>/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
+- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the `/opsx:archive`/`/opsx:bulk-archive` skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Phase 1 always goes through the skill, never the raw CLI, even though running it inline (see Phase 1) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
+- **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
+- **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
+- **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
+- **No corpus-wide drift detection in `specs/INDEX.md`.** Phase 5 only ever patches the rows for capabilities this batch's changes declared in `specs_touched`. If some capability's `spec.md` was edited outside this skill and its `INDEX.md` row has gone stale as a result, this skill's hot path doesn't catch that — and neither, currently, does `accelint-archive-synthesis`: its decision-drift and structural-coupling checks both read `specs/INDEX.md` as ground truth rather than verifying it against `spec.md`. This is a real, accepted gap, not a job this skill should absorb into its own per-archive cost.
+- **No reconciling summary stats trailing `changes/archive/INDEX.md`.** If that file carries a total row count or similar after the table, Phase 6 preserves it untouched (see Phase 6 step 2) rather than incrementing it — updating summary stats is corpus-wide bookkeeping in the same family as `specs/INDEX.md` drift above, not a per-archive job.
+
+## Error Handling
+
+**Missing or malformed design.md frontmatter (Task A)**: derive a candidate `specs_touched`/`decisions` from the change's own `proposal.md` and delta spec directories, present it to the user for explicit confirmation, and write the confirmed value back into `design.md` before Phase 1 runs for that change. Stop before Phase 1 for that change, with the field named, only if the user chooses to pause and fix it themselves, or if nothing in the change's own files supports a candidate at all.
+
+**Missing `## Purpose` heading (Task B)**: don't block Phases 1–3 (they don't touch spec bodies), but stop before Phase 4 reaches that capability and ask the user to either add a placeholder or fix the spec first.
+
+**A change touches only one capability**: `specs_touched` with a single entry produces zero pairs — that's expected, not an error. Still run Phase 4 for that capability (write `last_touched_by`/`last_touched_on`, regenerate `## Related Specs` even if its list is unchanged) and still add its row to `changes/archive/INDEX.md` in Phase 6.
+
+**Brand-new capability with no prior spec.md**: handled explicitly in Phase 0 step 4 and Phase 4 step 2 — the subagent starts from an empty frontmatter block rather than treating the missing file as an error.
+
+**Native command reports unresolved conflicts**: Phase 1 stops and reports the conflict verbatim to the user immediately without proceeding to extraction (its own step 8); do not proceed to Phase 2.
+
+**`/opsx:archive` or `/opsx:bulk-archive` branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see Phase 1 steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
+
+**No subagent support available for Phase 4** (e.g. an environment without sub-agent support): fall back to performing Phase 4's steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for Phase 4 only, not the intended default there, and normal operation should always prefer subagents for Phase 4. This has no bearing on Phase 1, which already runs in this context unconditionally by design regardless of sub-agent availability — see Phase 1.
+
+**`specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist yet**: expected on a project's first-ever archive. Create `changes/archive/INDEX.md` fresh with a header row (Phase 6 step 3); `specs/INDEX.md` is built fresh from every capability in Phase 5's bootstrap case, and patched row-by-row on every archive after that.
+
+**`changes/archive/INDEX.md` has content after the table** (a total row count, a `Generated:` date, a status legend, or similar): insert new rows at the end of the table's existing data rows, immediately before that content — never after it. See Phase 6 step 2. Do not edit the trailing content itself, and do not treat a stale count within it as something this run needs to fix.
+
+## NEVER Do This
+
+**NEVER run Phases 2–7 once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
+
+**NEVER prune a `related:` entry** — this skill only unions. Removing an entry that looks stale is `accelint-archive-synthesis`'s job, and it requires human confirmation even there.
+
+**NEVER write a derived `specs_touched` or `decisions` candidate into a change's `design.md` without the author's explicit confirmation** — deriving a candidate from `proposal.md` and delta specs (Task A's recovery path) is a convenience for getting unblocked, not a substitute for the author's own call on which capabilities a change actually touched.
+
+**NEVER re-pad or realign existing rows in `specs/INDEX.md` when patching one row** — cell padding is per-row, not aligned to the table's widest value. Touching every row's whitespace to keep columns visually lined up defeats the entire point of a targeted line edit and turns a one-line diff back into a full-file rewrite.
+
+**NEVER change an existing `Status` value in `changes/archive/INDEX.md`** — write `current` once, at creation, and never touch that column again for that row. Transitions belong to `accelint-archive-synthesis`.
+
+**NEVER read `Date` from `design.md`** — always use the archive folder's own `YYYY-MM-DD` prefix. A change can sit in review for weeks before it's archived, so anything `design.md` says about dates will be stale by the time this skill runs.
+
+**NEVER duplicate `capability` or `purpose` into a spec's frontmatter** — both already exist as the file's own path and its `## Purpose` heading. Restating either creates a second source of truth that will eventually disagree with the first.
+
+**NEVER hand-maintain `## Related Specs`** — always regenerate it wholesale from the `related:` frontmatter that was just written. Treating it as independently editable content invites drift between what the frontmatter says and what the body shows.
+
+**NEVER reorder or rewrite existing rows in `changes/archive/INDEX.md`** — append only. This file's value as an audit trail depends entirely on past rows staying exactly as they were written.
+
+**NEVER append a new row to `changes/archive/INDEX.md` by writing to the end of the file** — locate the end of the table's existing data rows (Phase 6 step 2) and insert there. The file may carry content after the table — a total row count, a `Generated:` date, a status legend — and writing to end-of-file instead of end-of-table lands a data row in prose after that content instead of inside the table, corrupting it.
+
+**NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
+
+**NEVER decline, skip, or second-guess a sync prompt during `/opsx:archive` or `/opsx:bulk-archive`** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
+
+**NEVER spawn a subagent for Phase 1, even when sub-agent support is available** — always run `/opsx:archive` or `/opsx:bulk-archive` directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See Phase 1 for the full account.
+
+**NEVER run Phase 4 directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
+
+**NEVER treat a mid-run branch in `/opsx:archive`/`/opsx:bulk-archive` (most commonly its own sync skill) as the end of Phase 1** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running Phase 1 inline in the first place.
+
+## Example Usage
+
+**Scenario 1: Single-change archive**
+
+```
+User: Archive the add-live-sync change with cross-linking
+
+Skill: Running preflight checks...
+✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
+✓ Both capabilities have a ## Purpose heading
+
+Running /opsx:archive add-live-sync directly (Phase 1 never uses a subagent)...
+Sync now? (y/n) → yes
+✓ Synced delta specs, resuming /opsx:archive's remaining steps...
+✓ /opsx:archive add-live-sync merged, archived to
+  openspec/changes/archive/2026-03-02-add-live-sync/
+✓ Extracted: specs_touched, decisions from design.md frontmatter
+
+Computing new co-touch pairs...
+- sync/protocol ↔ ui/status-indicator (new pair)
+
+[spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
+✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
+✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
+
+Updating openspec/specs/INDEX.md... (2 rows patched, 12 rows untouched)
+Appending to openspec/changes/archive/INDEX.md... (1 row)
+
+✅ Archive complete: add-live-sync
+
+Next steps:
+- Review the diff on the two updated specs before committing
+- related: entries are additive only — pruning is accelint-archive-synthesis's job
+```
+
+**Scenario 2: Bulk archive touching an already-linked capability**
+
+```
+User: Run bulk-archive on the pending changes
+
+Skill: Running preflight checks across 3 pending changes...
+✓ All design.md frontmatter valid
+⚠ auth/session-store is missing a ## Purpose heading
+
+How would you like to handle auth/session-store?
+(a) Add a placeholder purpose now and continue
+(b) Pause so you can add the heading yourself first
+
+User: (b)
+
+Skill: Paused. Add a ## Purpose heading to openspec/specs/auth/session-store/spec.md,
+then re-invoke this skill to continue.
+```
+
+**Scenario 3: Missing design.md frontmatter, recovered from the change's own files**
+
+```
+User: Archive the enhance-mock-consistency-rule change
+
+Skill: Running preflight checks...
+⚠ design.md has no specs_touched or decisions frontmatter
+
+Checking proposal.md and openspec/changes/enhance-mock-consistency-rule/specs/
+for a derivable candidate...
+
+Derived from this change's own files:
+  specs_touched: [testing/mock-consistency]
+  decisions:
+    - id: D1
+      choice: enforce consistency at lint time, not runtime
+      rationale: catches drift before merge instead of in CI
+      alternatives: [runtime assertion, manual review checklist]
+
+(a) Confirm this as written
+(b) Edit it first
+(c) Pause so I can fix design.md myself
+
+User: (a)
+
+Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
+Running /opsx:archive enhance-mock-consistency-rule directly...
+✓ /opsx:archive enhance-mock-consistency-rule merged, archived to
+  openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
+...
+```
+
+**Scenario 4: Bulk archive raises a non-routine prompt (surfaced to the user, not answered by the skill)**
+
+```
+User: Run bulk-archive on the pending changes
+
+Skill: Running preflight checks across 2 pending changes...
+✓ All design.md frontmatter valid
+
+Running /opsx:bulk-archive directly (Phase 1 never uses a subagent)...
+Sync now? (y/n) → yes
+⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,
+  merging in chronological order? (y/n)
+
+This isn't the routine sync prompt, so I'm not answering it myself —
+add-dark-mode and update-footer both touch specs/ui/. Archive both,
+merging in chronological order (add-dark-mode, then update-footer)?
+
+User: Yes
+
+Skill: ✓ Archived add-dark-mode, then update-footer, specs/ui/ merged in that order
+...
+```
+
+This is the scenario Phase 1 running inline actually unlocks: a subagent handed `/opsx:bulk-archive` has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running Phase 1 in this context means the question reaches the person who can actually answer it.

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [1.3.0] - 2026-07-08
+
+### Added
+- **Frontmatter capture for specs_touched and decisions** — Phase 4 now captures structured metadata in design.md YAML frontmatter after user approval
+  - Runs only after design.md is approved (checkpoint 1a) or manual edits are confirmed (checkpoint 1c), never before
+  - Captures `specs_touched`: capability names declared in design.md/proposal.md as affected or introduced
+  - Captures `decisions`: design.md's decision content restructured as list of `{id, choice, rationale, alternatives}` entries
+  - Written to design.md YAML frontmatter (or merged if frontmatter block already exists)
+  - Rationale: `accelint-qrspi-archive` needs this structured metadata for cross-capability linking. Capturing it at approval time (not earlier) ensures it reflects the final approved design, not a draft that might be edited during the checkpoint.
+  - If `specs_touched` or decisions can't be confidently read from approved design.md/proposal.md, asks user to add them rather than guessing
+  - Does not block Phase 5 — changes can proceed to specs/tasks without this frontmatter, though archive workflow will need to derive it later
+
+### Changed
+- **Phase 4 checkpoint expanded to 5 steps** — added frontmatter capture as step 4, before proceeding to Phase 5
+  - Previous flow: approve → proceed to Phase 5
+  - New flow: approve → capture frontmatter → proceed to Phase 5
+  - Rationale: Frontmatter capture happens after approval but before continuing, ensuring design.md is complete for downstream workflows
+- **Phase 2: Research now includes existing specs** — research sub-agent now scans `openspec/specs/INDEX.md` for relevant capabilities and reads their specs
+  - Sub-agent observes what current specs say alongside what the codebase does
+  - Includes spec requirements and scenarios directly in research findings, not just references
+  - Rationale: Research should be objective about *both* current implementation *and* current specs of record. Without reading specs, research would miss documented requirements that haven't been implemented yet or have drifted.
+- **Workflow diagram updated** — added frontmatter capture notation at Checkpoint 1: "(frontmatter capture: specs_touched/decisions -> design.md)"
+- **Updated NEVER Do section** — added two new anti-patterns:
+  - NEVER capture specs_touched/decisions frontmatter before design.md is in its final, approved state
+  - NEVER guess specs_touched or decisions when they can't be confidently read from approved design.md/proposal.md
+- **Error Handling section expanded** — added guidance for missing specs_touched/decisions in approved design.md
+
+### Fixed
+- **Frontmatter capture timing** — design.md frontmatter is now only captured *after* user approval/confirmation, not during draft/edit cycles
+  - Issue: Capturing frontmatter speculatively before approval could write metadata against content the user is about to change
+  - Fix: Step 4 of Phase 4 explicitly runs only after approval (1a) or confirmed edits (1c)
+  - Impact: `accelint-qrspi-archive` now receives frontmatter that's guaranteed to reflect the final approved design
+
+### Version
+- Bumped from 1.2.1 → 1.3.0
+
 ## [1.2.1] - 2026-05-07
 
 ### Fixed

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Automate the QRSPI + OpenSpec planning workflow (Questions → Rese
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.1"
+  version: "1.3.0"
 ---
 
 # Accelint QRSPI
@@ -51,6 +51,7 @@ openspec update
 │                                      design.md       —          │
 │                                      [STOP HERE]                │
 │  ⚠️  CHECKPOINT 1: Review design.md - MUST approve to continue  │
+│  (frontmatter capture: specs_touched/decisions -> design.md)    │
 │                                                                 │
 │  Specs/Tasks    Q+R+design           specs/*         —          │
 │                                      tasks.md        —          │
@@ -63,6 +64,11 @@ Note: Ticket is kept OUT of context after Phase 1 to prevent completion bleed.
 
 Critical: Phase 3 generates ONLY proposal.md and design.md, then STOPS for review.
 Phase 5 generates specs/* and tasks.md separately after design approval.
+
+Frontmatter capture happens after Checkpoint 1 approval, not before — design.md
+is only in its final form once the user has approved it or confirmed a manual
+edit, so capturing specs_touched/decisions any earlier risks writing frontmatter
+against content the user is about to change.
 
 ⚠️  MANDATORY CHECKPOINTS: The agent MUST pause and wait for explicit user approval
 at both checkpoints. Proceeding without approval bypasses QRSPI's core value.
@@ -138,7 +144,7 @@ Before starting, verify the user provided input and OpenSpec has the required wo
 
 ### Phase 2: Research (Questions Only → Research Doc)
 
-**Goal**: Answer the questions with objective facts from the codebase, without the ticket bleeding into research.
+**Goal**: Answer the questions with objective facts from the codebase AND existing specs, without the ticket bleeding into research.
 
 **Context isolation**: The agent answering questions should see ONLY the questions, not the original ticket. This is the core QRSPI insight — research is objective, ticket-agnostic.
 
@@ -151,14 +157,13 @@ Before starting, verify the user provided input and OpenSpec has the required wo
 
    [paste ONLY the research questions from Phase 1]
 
-   Answer each question with facts only. Observe what the codebase does today.
-   Do not suggest changes or implementation approaches.
+   Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
    ```
 
 2. Wait for the sub-agent to complete and return the research document
 3. Store the research answers — they will inform the design phase
 
-**Output**: A research document with objective answers to all questions
+**Output**: A research document with objective answers to all questions, including relevant current spec content
 
 ### Phase 3: Design Scaffolding
 
@@ -255,7 +260,7 @@ purpose of QRSPI's separation of design from implementation planning.
    ```
 
 3. Wait for user input:
-   - **(a) Approve**: Proceed to Phase 5
+   - **(a) Approve**: Proceed to step 4 below
    - **(b) Request edits**:
      - User describes changes
      - Make edits to design.md in place
@@ -264,7 +269,33 @@ purpose of QRSPI's separation of design from implementation planning.
    - **(c) Manual edit**:
      - Wait for user confirmation that edits are complete
      - Re-read design.md
-     - Proceed to Phase 5
+     - Proceed to step 4 below
+
+4. **Capture specs_touched/decisions frontmatter.** Once the user has approved (a) or confirmed their manual edits are complete (c), design.md is in its final form for this planning pass — capture its `specs_touched` and `decisions` as structured YAML frontmatter now, not any earlier, so an edit made during this same checkpoint can't leave the frontmatter stale against content that changed after it was written.
+
+   - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (Phase 5 generates those), so there's nothing else to derive it from.
+   - **`decisions`**: design.md's own decision content — the choices, rationale, and alternatives the design phase already worked through — restructured into a list of `{id, choice, rationale, alternatives}` entries. This is structuring content that's already there, not writing new design content.
+   - Write both into design.md's YAML frontmatter:
+
+     ```yaml
+     ---
+     change: <change-name-from-phase-3>
+     specs_touched: [capability-a, capability-b]
+     decisions:
+       - id: D1
+         choice: <short decision summary>
+         rationale: <why this over the alternatives>
+         alternatives: [<option>, <option>]
+     ---
+     ```
+
+   - If design.md already starts with a frontmatter block (e.g. OpenSpec's own metadata), merge into it rather than writing a second block.
+   - If `specs_touched` or a clear decisions list can't be confidently read out of the approved design.md/proposal.md, don't guess at either — tell the user what's missing and ask them to add it to design.md directly. A design doc without a clear decisions trail is worth flagging on its own terms, and `accelint-qrspi-archive` needs this frontmatter later to do its cross-capability linking.
+   - This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content `/opsx:continue` generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
+
+5. Proceed to Phase 5.
+
+**Output**: An approved `design.md` with `specs_touched`/`decisions` captured in its YAML frontmatter, ready for `accelint-qrspi-archive` to read at archive time.
 
 **CRITICAL: DO NOT PROCEED TO PHASE 5 WITHOUT EXPLICIT USER APPROVAL.**
 
@@ -499,13 +530,13 @@ After tasks.md is approved:
    Next steps:
    1. Review the artifacts one more time if needed
    2. Run `/clear` to start fresh context for implementation
-   3. Run `/opsx:apply <change-name>` to begin implementation
+   3. Run `/accelint-qrspi-apply <change-name>` to begin implementation
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.
    ```
 
-2. Exit the skill — do NOT automatically invoke `/opsx:apply`
+2. Exit the skill — do NOT automatically invoke `/accelint-qrspi-apply`
 
 ## Key Principles
 
@@ -533,7 +564,7 @@ The skill should actively check for and discourage horizontal (layer-by-layer) s
 
 ### No Automatic Implementation
 
-The skill stops after planning. The user explicitly runs `/opsx:apply` when ready. This allows:
+The skill stops after planning. The user explicitly runs `/accelint-qrspi-apply` when ready. This allows:
 
 - Multiple specs to be created before any implementation starts
 - Context clearing between planning and implementation
@@ -550,6 +581,11 @@ The skill stops after planning. The user explicitly runs `/opsx:apply` when read
 - Show the error from the sub-agent
 - Ask user if they want to retry that phase or provide manual input
 - Allow manual fallback (user provides questions/research directly)
+
+**If `specs_touched` or `decisions` can't be confidently read out of approved design.md/proposal.md (Phase 4 step 4)**:
+- Do not guess. Show the user what's missing (e.g. "no capability declarations found" or "no decisions with a stated rationale")
+- Ask them to add it to design.md directly, then re-run step 4
+- Do not block Phase 5 on this — a change can proceed to specs/tasks without this frontmatter, it just means `accelint-qrspi-archive` will need to derive it later from proposal.md and the by-then-existing delta specs instead of reading it straight from frontmatter
 
 **If design.md or tasks.md is missing after generation**:
 - Check if the file exists at expected path
@@ -569,7 +605,7 @@ If any of these are missing, guide the user to set them up before running this s
 
 ## NEVER Do This
 
-**NEVER generate artifacts yourself** — Always use /opsx commands (new, continue) to create proposal.md, design.md, specs/*, and tasks.md. The /opsx workflow handles artifact generation following OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design/spec/task rules and create inconsistent outputs.
+**NEVER generate artifacts yourself** — Always use /opsx commands (new, continue) to create proposal.md, design.md, specs/*, and tasks.md. The /opsx workflow handles artifact generation following OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design/spec/task rules and create inconsistent outputs. The one narrow exception is Phase 4 step 4's `specs_touched`/`decisions` frontmatter block: that's cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content `/opsx:continue` already generated and the user already approved — not new design content. Even there, only the YAML frontmatter block is written; the design.md body is never touched by this step.
 
 **NEVER generate tasks.md from scratch** — Always use /opsx:continue to create the initial tasks.md. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If /opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) following the validation guidance in Phase 5 Step 10. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert to numbered lists or plain bullets.
 
@@ -578,6 +614,10 @@ If any of these are missing, guide the user to set them up before running this s
 **NEVER overcomplicate Parallelization Strategy** — Keep it simple: list which slices can run in parallel, which have sequential dependencies, and recommended implementation order. Don't add excessive detail about every possible edge case or coordination mechanism. The example in this skill shows the right level of detail.
 
 **NEVER continue to specs/tasks without design approval** — Phase 4 checkpoint is mandatory. If you skip the design review and generate tasks immediately, you miss the "brain surgery" moment where corrections are cheap. Fixing design issues after code is written costs review cycles and rework.
+
+**NEVER capture specs_touched/decisions frontmatter before design.md is in its final, approved state** — Phase 4 step 4 runs only after (a) approval or (c) confirmed manual edits, never during a (b) request-edits loop or speculatively ahead of approval. Capturing it against a draft that's still being revised is exactly the kind of stale metadata `accelint-qrspi-archive` depends on this skill not producing.
+
+**NEVER guess specs_touched or decisions when they can't be confidently read out of the approved design.md/proposal.md** — ask the user to add what's missing to design.md directly instead. A silently invented capability list is worse than a visible gap, since `accelint-qrspi-archive` will trust this frontmatter as the author's explicit statement of scope.
 
 **NEVER let the ticket leak into research/design context** — Questions are generated WITH ticket context, but research and design must see ONLY questions + research answers. If the ticket stays in context during research, the agent will propose solutions instead of gathering objective facts about the current codebase.
 

--- a/skills/accelint-readme-writer/CHANGELOG.md
+++ b/skills/accelint-readme-writer/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.2.0] - 2026-07-08
+
+### Added
+- **External findings support** — skill now accepts `findings:` list from invoking prompt
+  - Parses invoking prompt for a `findings:` section (bulleted list of factual statements)
+  - Each finding is phrased as something already known to be true, never as an instruction
+  - Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+  - Findings are merged with codebase gap analysis before presenting to user
+  - Allows upstream workflows (e.g., `accelint-qrspi-apply`) to pass change-specific context that should influence README updates
+  - If external findings exist, notes their source (e.g., "from completed OpenSpec change")
+  - Rationale: README updates after completing OpenSpec changes should incorporate user-facing feature decisions made during that change. Without external findings, the skill would only detect documentation gaps via code analysis but miss semantic decisions about features, usage patterns, or configuration that haven't yet fully manifested in exported APIs.
+
+### Changed
+- **Step 3 expanded to include external findings extraction** — README comparison workflow now starts with external findings check
+  - New Step 3a: Extract external findings from invoking prompt (if any)
+  - Existing Step 3b: Compare against existing README (identify gaps from codebase scan)
+  - New Step 3c: Merge and present all findings (external + codebase gaps) before generating updates
+  - Rationale: Explicit merge step makes it clear that external findings and codebase gaps are treated equally, and presenting them together upfront gives the user full context about what needs updating
+
+### Version
+- Bumped from 1.1.0 → 1.2.0
+
 ## [1.1.0] - 2026-05-11
 
 ### Changed

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -4,7 +4,7 @@ description: Use when creating or editing a README.md file in any project or pac
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # README Writer
@@ -117,12 +117,23 @@ Spawn these discovery agents in parallel (if sub-agents available):
 
 ### Step 3: Compare Against Existing README
 
-If a README exists, identify gaps:
+**Extract external findings first** — check if the invoking prompt includes a `findings:` list:
+- Parse the prompt for a `findings:` section (a bulleted list of factual statements)
+- Each finding is phrased as something already known to be true, never as an instruction
+- Example: "config.yaml's Anti-Patterns section says to avoid polling, but two archived changes chose polling for stated reasons"
+- Store these findings for merging with codebase scan findings below
+
+If a README exists, identify gaps from codebase scan:
 
 - **Missing exports**: Public API not documented
 - **Stale examples**: Code samples using deprecated patterns
 - **Missing sections**: No installation, no quick start, no API reference
 - **Outdated commands**: Wrong package manager, missing scripts
+
+**Merge and present all findings**:
+- Combine external findings (if any) with codebase scan findings
+- Present the merged list to the user before generating updates
+- If external findings exist, note their source (e.g., "from completed OpenSpec change")
 
 ### Step 4: Generate or Update README
 


### PR DESCRIPTION
### New Skills

**accelint-qrspi-archive**: Wraps the archive operation and handles all the structured indexing work. After a change merges, it:
- Writes `related:`, `last_touched_by:`, and `last_touched_on:` frontmatter to affected spec files
- (Re)builds `openspec/specs/INDEX.md` (one row per capability)
- Appends one row to `openspec/changes/archive/INDEX.md` (one row per archived change, with columns for date, decisions, specs touched, and status)
- Renders a "## Related Specs" section in each spec's body so you can navigate the graph

**accelint-archive-synthesis**: A periodic lint pass (suggested every 15 archived changes) that reads the two indexes and produces a drift/contradiction report. It looks for:
- **Decision drift**: Did we say X in March but then Y in November for conflicting reasons?
- **Structural coupling**: Is one capability related to way more things than normal? (Flags candidates for refactoring)
- **Stale cross-references**: Are specs still referencing things that got superseded?


### Update Current Skills

**accelint-qrspi-propose Phase 2**: The research phase now scans `openspec/specs/INDEX.md` and inlines any relevant existing spec content directly into research findings. So when you're designing a change, the agent already knows what current specs say instead of starting from zero.

**accelint-qrspi-propose Phase 4**: After design approval, the skill now captures `specs_touched` (capability names) and `decisions` (choice/rationale/alternatives) as structured YAML frontmatter in `design.md`. This happens only after user approval, ensuring the metadata reflects the final approved design. This structured metadata enables `accelint-qrspi-archive` to perform cross-capability linking without re-parsing the entire design document.

**accelint-qrspi-apply Phase 4**: Instead of invoking writer skills with a vague "we just completed a change, please update yourself" prompt, it now extracts the `decisions` field from `design.md` frontmatter, rephrases each as a factual statement, and passes them as explicit findings. The writer skills get the context they need without having to re-read and re-parse the entire change.

`accelint-onboard-openspec`, `accelint-architecture-doc`, `accelint-onboard-agent`, `accelint-readme-writer`: **New `findings:` interface**: Each skill's refresh mode now accepts an explicit list of factual observations from the invoking prompt (like "config.yaml says avoid polling, but this change chose polling for stated reasons"). These external findings are merged with the skill's own codebase scan before any questions are presented to the user. The skills don't blindly apply findings; they combine external context with their own drift detection.