### PR TITLE
refactor: change "Phase N" prose to numbered steps

### DIFF
--- a/skills/accelint-archive-synthesis/CHANGELOG.md
+++ b/skills/accelint-archive-synthesis/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [1.1.0] - 2026-07-10
+
+### Changed
+- **Remove phase boundaries to prevent premature stopping:** Refactored from phase-based structure to continuous numbered steps
+  - Rationale: Phase headers like "### Phase 0: Preflight Checks" create natural stopping points where agents might pause and check with the user mid-workflow, breaking the intended continuous execution flow
+  - Changed structure from:
+    - "### Phase 0: Preflight Checks" / "### Phase 1: Archive" / etc.
+    - To: Continuous numbered steps (1, 2, 3...) under a single "Implementation Steps" section with instruction "Execute these steps in order without stopping between them"
+  - Updated workflow diagram: "Phase" column → "Step" column (or "Stage" for higher-level groupings)
+  - Updated all cross-references throughout (e.g., "Phase 7" → "Step 8", "Phase 4's hub-doc refresh" → "Step 5's hub-doc refresh")
+  - Why: Agents tend to treat phase headers as checkpoint boundaries even when not intended. Continuous numbered steps signal that the workflow should execute atomically unless an error occurs
+
+### Version
+- Bumped from 1.0.0 → 1.1.0

--- a/skills/accelint-archive-synthesis/SKILL.md
+++ b/skills/accelint-archive-synthesis/SKILL.md
@@ -5,12 +5,12 @@ license: Apache-2.0
 compatibility: Requires the OpenSpec CLI, sub-agent support, and a project already onboarded with accelint-qrspi-archive so that openspec/changes/archive/INDEX.md and openspec/specs/INDEX.md exist and are populated. Routing confirmed findings requires the shared findings: interface (Mode 3 Refresh support) in whichever writer skill(s) a given finding targets; without it, this skill still produces its report but degrades to manual guidance for that step.
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Accelint Archive Synthesis
 
-Read backward across the entire archived-change history to check whether it still agrees with itself, check the running index itself against the live files it claims to summarize, and surface any capability whose accumulated relationships suggest it has outgrown its own boundaries. This is the "lint" operation in Karpathy's LLM Wiki pattern: `ingest` already exists as `accelint-qrspi-archive`, `query` already exists as artifact loading at propose/apply time, but nothing periodically re-reads the whole corpus to check it is still internally consistent. Every existing drift check in this stack, including `accelint-qrspi-apply` Phase 4's own hub-doc refresh, is forward-looking and scoped to one change's own proposal and design. This skill is the only one that looks the other direction — and, since `accelint-qrspi-archive` moved to row-level index patching for its own efficiency, the only one that ever re-checks `specs/INDEX.md` against the `spec.md` files it summarizes at all.
+Read backward across the entire archived-change history to check whether it still agrees with itself, check the running index itself against the live files it claims to summarize, and surface any capability whose accumulated relationships suggest it has outgrown its own boundaries. This is the "lint" operation in Karpathy's LLM Wiki pattern: `ingest` already exists as `accelint-qrspi-archive`, `query` already exists as artifact loading at propose/apply time, but nothing periodically re-reads the whole corpus to check it is still internally consistent. Every existing drift check in this stack, including `accelint-qrspi-apply` Step 5's own hub-doc refresh, is forward-looking and scoped to one change's own proposal and design. This skill is the only one that looks the other direction — and, since `accelint-qrspi-archive` moved to row-level index patching for its own efficiency, the only one that ever re-checks `specs/INDEX.md` against the `spec.md` files it summarizes at all.
 
 That backward-looking scope is also what keeps this skill's footprint small and deliberate. It reads two indexes and, for genuine candidates only, a handful of `design.md` files and, for the reconciliation check, a lightweight top-of-file read of every `spec.md`. It never rewrites a hub doc directly, and every write it does make — on either index — is a single targeted line, gated behind an explicit human confirmation of that specific finding, and never runs on its own initiative. A human always decides which findings get acted on.
 
@@ -18,30 +18,30 @@ That backward-looking scope is also what keeps this skill's footprint small and 
 
 **Automates**: a periodic, corpus-wide consistency check across every archived OpenSpec change, surfacing contradictions between past decisions, flagging capabilities that have become structurally over-coupled, and flagging `specs/INDEX.md` rows that have drifted from the `spec.md` files they summarize.
 **Scope**: `openspec/changes/archive/INDEX.md`, `openspec/specs/INDEX.md`, and — for the reconciliation check only — a lightweight read of each `spec.md`'s `## Purpose` heading and `related:` frontmatter. This skill never originates a change, never implements a fix, and never edits a hub doc itself.
-**Output**: a CRITICAL / WARNING / SUGGESTION report in the same register as `/opsx:verify`, plus, only after a human confirms a specific finding, a `Status` column update on the relevant archive row, a single-row patch or removal on `specs/INDEX.md`, and/or an independent invocation of the affected writer skill(s) via the shared `findings:` interface — see Phase 7 for which finding types get which.
+**Output**: a CRITICAL / WARNING / SUGGESTION report in the same register as `/opsx:verify`, plus, only after a human confirms a specific finding, a `Status` column update on the relevant archive row, a single-row patch or removal on `specs/INDEX.md`, and/or an independent invocation of the affected writer skill(s) via the shared `findings:` interface — see Step 8 for which finding types get which.
 **Does NOT**: run automatically, run as a blocking step inside any other skill's workflow, rewrite any document directly, write any `archive/INDEX.md` column other than `Status`, write to `specs/INDEX.md` beyond a single confirmed row's patch or removal, introduce any severity or status state beyond CRITICAL/WARNING/SUGGESTION and current/superseded, or reconcile a contradiction on its own judgment without a human confirming which side of it stands.
 
 ## Prerequisites
 
 - OpenSpec CLI installed and initialized, with `accelint-qrspi-archive` already in regular use — this skill is a consumer of the indexes that skill produces, not a replacement for it.
 - `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` both exist and contain at least one row. See Verification Task B.
-- Sub-agent support, for the same reason `accelint-qrspi-archive`'s Phases 1 and 4 require it: opening a candidate change's `design.md`, or a capability's `spec.md` for reconciliation, should return a structured extract to the parent, not the raw file contents. This skill's Phase 2 and Phase 3 both always delegate those targeted reads to subagents.
-- Read access to every capability directory under `openspec/specs/` — plain file reads are sufficient, no OpenSpec CLI shellout needed, the same reasoning `accelint-qrspi-archive` already applies to its own local spec reads. Phase 3 is the only phase that needs this beyond the two index files.
-- For routing to actually land anywhere beyond the report itself, the four writer skills' Mode 3 Refresh path needs to accept a `findings:` list (the same shared interface `accelint-qrspi-apply` Phase 4 uses). If a targeted writer skill doesn't yet support this, this skill still produces the finding — it just can't hand it off automatically (see Error Handling).
+- Sub-agent support, for the same reason `accelint-qrspi-archive`'s Steps 2 and 5 require it: opening a candidate change's `design.md`, or a capability's `spec.md` for reconciliation, should return a structured extract to the parent, not the raw file contents. This skill's Step 3 and Step 4 both always delegate those targeted reads to subagents.
+- Read access to every capability directory under `openspec/specs/` — plain file reads are sufficient, no OpenSpec CLI shellout needed, the same reasoning `accelint-qrspi-archive` already applies to its own local spec reads. Step 4 is the only step that needs this beyond the two index files.
+- For routing to actually land anywhere beyond the report itself, the four writer skills' Mode 3 Refresh path needs to accept a `findings:` list (the same shared interface `accelint-qrspi-apply` Step 5 uses). If a targeted writer skill doesn't yet support this, this skill still produces the finding — it just can't hand it off automatically (see Error Handling).
 
 ## Build Order Context
 
 This skill is deliberately the last of four pieces to exist, and each of the other three is a hard dependency, not a nice-to-have:
 
-1. **`accelint-qrspi-archive`** has to already be in regular use. It's what produces both indexes this skill reads and the `related:`/frontmatter fields Phase 2, Phase 3, and Phase 4 depend on — without it, there is no corpus here at all.
+1. **`accelint-qrspi-archive`** has to already be in regular use. It's what produces both indexes this skill reads and the `related:`/frontmatter fields Steps 3, 4, and 5 depend on — without it, there is no corpus here at all.
 2. **`accelint-qrspi-propose`'s Phase 2 extension** (reading `specs/INDEX.md` at propose time) needs to exist so that `specs/INDEX.md` is actually a load-bearing artifact in the workflow, not just a side effect of archiving — otherwise nothing downstream would notice or care if this skill's structural-coupling flags ever pointed at stale data.
-3. **The shared `findings:` interface** — the Mode 3 Refresh extension across the four writer skills, paired with `accelint-qrspi-apply` Phase 4's matching prompt change — has to land before this skill has anywhere to route a confirmed decision-drift or structural-coupling finding at all. Without it, Phase 7 has a report and a human decision but no destination for those two finding types. Index reconciliation findings (Phase 3) don't depend on this at all — they never route anywhere, confirmed or not, so that check works the same regardless of whether this interface exists yet.
+3. **The shared `findings:` interface** — the Mode 3 Refresh extension across the four writer skills, paired with `accelint-qrspi-apply` Step 5's matching prompt change — has to land before this skill has anywhere to route a confirmed decision-drift or structural-coupling finding at all. Without it, Step 8 has a report and a human decision but no destination for those two finding types. Index reconciliation findings (Step 4) don't depend on this at all — they never route anywhere, confirmed or not, so that check works the same regardless of whether this interface exists yet.
 
-The practical consequence: if any of these three aren't in place yet, this skill can still run Phases 0 through 6 (scan, detect, report) and produce a valid report, but Phase 7 degrades to "tell the human what to do manually" for whichever half of the interface is missing, on decision-drift and structural-coupling findings only. It is never a reason to refuse the run outright.
+The practical consequence: if any of these three aren't in place yet, this skill can still run Steps 1 through 7 (scan, detect, report) and produce a valid report, but Step 8 degrades to "tell the human what to do manually" for whichever half of the interface is missing, on decision-drift and structural-coupling findings only. It is never a reason to refuse the run outright.
 
 ## The Two Indexes This Skill Reads (Owned Elsewhere)
 
-Neither index below is written by this skill in the general case. Both are written and maintained by `accelint-qrspi-archive`; this skill only ever reads them, with two narrow exceptions, both spelled out under Phase 7: a `Status` column update on `archive/INDEX.md`, and a single-row patch or removal on `specs/INDEX.md`.
+Neither index below is written by this skill in the general case. Both are written and maintained by `accelint-qrspi-archive`; this skill only ever reads them, with two narrow exceptions, both spelled out under Step 8: a `Status` column update on `archive/INDEX.md`, and a single-row patch or removal on `specs/INDEX.md`.
 
 ```
 openspec/changes/archive/INDEX.md, one row per archived change:
@@ -57,19 +57,19 @@ openspec/specs/INDEX.md, one row per capability, rebuilt on every archive:
 | sync/protocol | Defines how client and server exchange live state       | ui/status-indicator   | add-live-sync (2026-03-02)  |
 ```
 
-The `Decision` column is a condensed one-line summary of that change's `design.md` frontmatter (`choice` + `rationale`). This skill's Phase 2 works off that summary first, cheaply, and only opens the full `design.md` — for its `alternatives:` field and any nuance the one-liner compresses away — for the specific candidates flagged as plausibly contradictory. This mirrors the same cost-control discipline `accelint-qrspi-archive` uses when it defers opening a change's folder until its own index flags it as relevant.
+The `Decision` column is a condensed one-line summary of that change's `design.md` frontmatter (`choice` + `rationale`). This skill's Step 3 works off that summary first, cheaply, and only opens the full `design.md` — for its `alternatives:` field and any nuance the one-liner compresses away — for the specific candidates flagged as plausibly contradictory. This mirrors the same cost-control discipline `accelint-qrspi-archive` uses when it defers opening a change's folder until its own index flags it as relevant.
 
 ## The Log This Skill Owns
 
 Neither index above records a synthesis checkpoint — that's expected, since both are owned entirely by `accelint-qrspi-archive` and neither has a reason to know this skill exists. So this skill maintains one small file of its own, `openspec/changes/archive/SYNTHESIS-LOG.md`, purely to answer two questions neither index can: "how many changes have archived since I last ran," and "has a human already looked at this specific decision-drift pair and judged it not real." It's a plain append-only list of one line per completed run, date plus the `archive/INDEX.md` row count checked through, plus an optional `dismissed:` sub-list of decision-drift pairs a human explicitly dismissed that run.
 
-This file is not a column of either index and is never touched by `accelint-qrspi-archive` — it exists solely so **Phase 1** and **Phase 0, Task A** below can read it, and **Phase 2** can filter against its accumulated `dismissed:` history. Phase 8 is the only phase that ever appends to it, and it only ever appends — a dismissal recorded on one run is never later removed by this skill itself; if a human wants to reconsider a dismissed pair, that's a manual edit to the log file, outside this skill's own write path. The exact line format, including the `dismissed:` sub-list, is shown where Phase 8 writes it.
+This file is not a column of either index and is never touched by `accelint-qrspi-archive` — it exists solely so **Step 2** and **Step 1, Task A** below can read it, and **Step 3** can filter against its accumulated `dismissed:` history. Step 9 is the only step that ever appends to it, and it only ever appends — a dismissal recorded on one run is never later removed by this skill itself; if a human wants to reconsider a dismissed pair, that's a manual edit to the log file, outside this skill's own write path. The exact line format, including the `dismissed:` sub-list, is shown where Step 9 writes it.
 
 **Only decision-drift dismissals get this treatment — structural coupling dismissals don't, on purpose.** A decision-drift pair is anchored to two specific, immutable archived changes; a human's judgment that a specific pair isn't a real contradiction stays true forever, since the underlying `design.md` files never change. A structural coupling finding is a live snapshot of a `related:` count that moves every time `accelint-qrspi-archive` runs — permanently silencing "sync/protocol is over-coupled" would blind this skill to sync/protocol's count climbing further, which is exactly the trend this signal exists to catch. So structural coupling findings always resurface every run regardless of a prior dismissal; only decision-drift dismissals are ever written to the log.
 
 ## Findings Interface (Shared Contract, Not New)
 
-Routing a confirmed finding to a writer skill uses the exact same `findings:` shape `accelint-qrspi-apply` Phase 4 already uses — this skill is the interface's second caller, not a new one:
+Routing a confirmed finding to a writer skill uses the exact same `findings:` shape `accelint-qrspi-apply` Step 5 already uses — this skill is the interface's second caller, not a new one:
 
 ```
 /accelint-architecture-doc
@@ -84,9 +84,9 @@ findings:
   budget constraint still holds before sync/protocol's spec is next touched"]
 ```
 
-The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Phase 3) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Phase 7 for what happens to those instead.
+The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Step 4) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Step 8 for what happens to those instead.
 
-**Rephrasing discipline.** Every line inside `findings:` is a plain factual statement about what the archive shows, never an instruction and never a conclusion the writer skill hasn't reached itself yet. "sync/protocol's stated budget constraint may no longer hold, given a later change's message-broker adoption" is correctly phrased; "update sync/protocol's spec to remove the budget constraint" is not — that second phrasing pre-empts the writer skill's own Mode 3 interview, which is exactly the judgment call this skill's Phase 6/7 split exists to keep with a human, not hand to a downstream skill as a foregone conclusion.
+**Rephrasing discipline.** Every line inside `findings:` is a plain factual statement about what the archive shows, never an instruction and never a conclusion the writer skill hasn't reached itself yet. "sync/protocol's stated budget constraint may no longer hold, given a later change's message-broker adoption" is correctly phrased; "update sync/protocol's spec to remove the budget constraint" is not — that second phrasing pre-empts the writer skill's own Mode 3 interview, which is exactly the judgment call this skill's Steps 7/8 split exists to keep with a human, not hand to a downstream skill as a foregone conclusion.
 
 ## Relationship to `/opsx:verify`
 
@@ -96,68 +96,64 @@ This skill borrows `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register deliber
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────────┐
-│  Phase            Action                                            Output    │
+│  Step             Action                                            Output    │
 ├───────────────────────────────────────────────────────────────────────────────┤
-│  0 Preflight      Read SYNTHESIS-LOG.md, verify dependencies        Go / no-go│
+│  1 Preflight      Read SYNTHESIS-LOG.md, verify dependencies        Go / no-go│
 │                   exist, sanity-check the two reasoned-default      + notes   │
 │                   thresholds (Tasks A, B, C)                                  │
-│  1 Scan indexes   Read archive/INDEX.md + specs/INDEX.md, load      In-memory │
+│  2 Scan indexes   Read archive/INDEX.md + specs/INDEX.md, load      In-memory │
 │                   prior dismissed: pairs from the log               model     │
-│  2 Decision drift Coarse-scan Decision column for same/related-     Candidate │
+│  3 Decision drift Coarse-scan Decision column for same/related-     Candidate │
 │                   capability collisions, skipping already-dismissed findings  │
 │                   pairs; SUBAGENT opens design.md for the rest                │
-│  3 Reconciliation Confirm every spec.md still exists; read Purpose  Candidate │
+│  4 Reconciliation Confirm every spec.md still exists; read Purpose  Candidate │
 │                   + related: from each and diff against its         findings  │
 │                   specs/INDEX.md row                                          │
-│  4 Structural     Median related-count across specs/INDEX.md,       Candidate │
+│  5 Structural     Median related-count across specs/INDEX.md,       Candidate │
 │    coupling       flag outliers ≥5 and ≥2× median                   findings  │
-│  5 Compile report Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
+│  6 Compile report Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
 │                   findings, /opsx:verify register                   report    │
-│  6 Human review   Present report; human confirms, dismisses, or     Confirmed │
+│  7 Human review   Present report; human confirms, dismisses, or     Confirmed │
 │                   defers each finding                               findings  │
-│  7 Route          Update Status, or patch/remove a specs/INDEX.md   Docs +    │
+│  8 Route          Update Status, or patch/remove a specs/INDEX.md   Docs +    │
 │                   row (confirmed findings only) + invoke affected   Status +  │
 │                   writer skill(s) via findings:                     specs row │
-│  8 Log + report   Append run checkpoint + any new dismissed:        Summary   │
+│  9 Log + report   Append run checkpoint + any new dismissed:        Summary   │
 │                   pairs to SYNTHESIS-LOG.md, summarize                        │
 └───────────────────────────────────────────────────────────────────────────────┘
 
-Phase 2's design.md reads and Phase 3's spec.md reads both always delegate to
+Step 3's design.md reads and Step 4's spec.md reads both always delegate to
 a subagent, one per candidate, regardless of how many candidates surface. This
 keeps raw design.md and spec.md contents out of the parent's context on every
-run, the same discipline accelint-qrspi-archive applies to its own Phase 1
-and Phase 4.
+run, the same discipline accelint-qrspi-archive applies to its own Step 2
+and Step 5.
 ```
 
-## Phase Breakdown
+## Implementation Steps
 
-### Phase 0: Preflight
+Execute these steps in order without stopping between them unless an error occurs:
 
-**Goal**: confirm this run has something to check and that its two reasoned-default thresholds still look reasonable, before reading anything else.
+1. **Preflight — confirm this run has something to check and that its two reasoned-default thresholds still look reasonable, before reading anything else.**
 
-**Verification Task A — trigger cadence sanity-check.** Read `openspec/changes/archive/SYNTHESIS-LOG.md` (introduced above, under "The Log This Skill Owns") to find the last completed run's date and the archive row count it checked through. If the file doesn't exist yet, this is the first-ever run — skip the cadence math entirely rather than dividing by a history that doesn't exist yet, and note in the report that no prior checkpoint exists. Otherwise, take the `Date` column across every `archive/INDEX.md` row appended since that checkpoint and derive an average time-between-archives. The 15-archived-changes-since-last-run trigger is a reasoned starting point, not a measured one, so if the actual cadence implies 15 changes would mean checking twice a year or checking every few days, surface this as an informational note in the final report — never adjust the threshold automatically. Changing it is a decision for the human reading the report, not this skill. This task never blocks a run: if a human manually invokes this skill the day after the last run, with zero new rows since the checkpoint, proceed anyway — say so plainly ("0 changes since the last run, proceeding at your request"), since freshness is informational, not a gate.
+   **Verification Task A — trigger cadence sanity-check.** Read `openspec/changes/archive/SYNTHESIS-LOG.md` (introduced above, under "The Log This Skill Owns") to find the last completed run's date and the archive row count it checked through. If the file doesn't exist yet, this is the first-ever run — skip the cadence math entirely rather than dividing by a history that doesn't exist yet, and note in the report that no prior checkpoint exists. Otherwise, take the `Date` column across every `archive/INDEX.md` row appended since that checkpoint and derive an average time-between-archives. The 15-archived-changes-since-last-run trigger is a reasoned starting point, not a measured one, so if the actual cadence implies 15 changes would mean checking twice a year or checking every few days, surface this as an informational note in the final report — never adjust the threshold automatically. Changing it is a decision for the human reading the report, not this skill. This task never blocks a run: if a human manually invokes this skill the day after the last run, with zero new rows since the checkpoint, proceed anyway — say so plainly ("0 changes since the last run, proceeding at your request"), since freshness is informational, not a gate.
 
 **Verification Task B — dependency check.** Confirm both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` exist and contain at least one row each. If either is missing or empty, stop and report that `accelint-qrspi-archive` needs to run first — this skill has nothing to read yet, and guessing at index content would be worse than declining. If the archive has fewer than roughly 10 rows total, proceed only if the human explicitly wants a low-signal run anyway; note plainly in the report that a corpus this small has little for cross-archive synthesis to find, per the same reasoning that put this skill last in the build order.
 
 **Verification Task C — structural coupling threshold sanity-check.** "At least 5 and at least double the index median" is the same kind of reasoned-not-measured default as Task A's trigger count. Compute the actual median `related:` count across every row in `specs/INDEX.md` and note, informationally only, whether the fixed floor of 5 or the 2× multiplier look like they'd flag either far too many capabilities or none at all against this project's real distribution. Same rule as Task A: report the observation, never silently change the threshold.
 
-If Tasks A and C surface nothing unusual, say so briefly and move on — these are sanity checks, not a mandatory finding every run.
+   If Tasks A and C surface nothing unusual, say so briefly and move on — these are sanity checks, not a mandatory finding every run.
 
-### Phase 1: Scan Indexes
-
-**Goal**: build an in-memory model of the archive without opening a single change folder yet.
+2. **Scan Indexes — build an in-memory model of the archive without opening a single change folder yet.**
 
 Read `archive/INDEX.md` in full: every row's `Change`, `Date`, `Decision` summary, `Specs touched` list, and current `Status`. Read `specs/INDEX.md` in full: every row's `Capability`, `Purpose`, `Related` list, and `Last touched by`/date. Both files stay cheap regardless of how large the archive has grown — that is the entire point of maintaining them — so this phase never needs to look past them.
 
-Also read every `dismissed:` sub-list across `SYNTHESIS-LOG.md`'s full history (not just the most recent run — a pair dismissed three runs ago still needs to stay suppressed) and build one flat set of dismissed-pair identities, each in the form `<change-A slug>|<change-B slug>|<capability>` with the two slugs alphabetically sorted so the same pair always produces the same identity regardless of which run or which order they were first compared in. If the log doesn't exist yet, this set starts empty — same first-run handling as Task A.
+   Also read every `dismissed:` sub-list across `SYNTHESIS-LOG.md`'s full history (not just the most recent run — a pair dismissed three runs ago still needs to stay suppressed) and build one flat set of dismissed-pair identities, each in the form `<change-A slug>|<change-B slug>|<capability>` with the two slugs alphabetically sorted so the same pair always produces the same identity regardless of which run or which order they were first compared in. If the log doesn't exist yet, this set starts empty — same first-run handling as Task A.
 
-### Phase 2: Decision Drift Detection
-
-**Goal**: find archived decisions that no longer cohere with each other, without opening every `design.md` in the corpus to do it.
+3. **Decision Drift Detection — find archived decisions that no longer cohere with each other, without opening every `design.md` in the corpus to do it.**
 
 **Step 1 — group by shared or related capability.** Using `Specs touched` from `archive/INDEX.md` and `related:` from `specs/INDEX.md`, cluster archived changes that touched the same capability directly, or touched capabilities each other's `related:` lists connect.
 
-**Step 2 — coarse scan.** Before comparing anything, drop any pair already present in Phase 1's dismissed-pair set — a human already looked at that exact pair and judged it not real, and that judgment doesn't expire. For everything else, within each cluster, compare `Decision` one-liners for signals of tension. A starter list of opposing-choice pairs worth pattern-matching on (extend it as a project's own vocabulary reveals its own oppositions — this isn't exhaustive):
+**Step 2 — coarse scan.** Before comparing anything, drop any pair already present in Step 2's dismissed-pair set (loaded during the Scan Indexes step) — a human already looked at that exact pair and judged it not real, and that judgment doesn't expire. For everything else, within each cluster, compare `Decision` one-liners for signals of tension. A starter list of opposing-choice pairs worth pattern-matching on (extend it as a project's own vocabulary reveals its own oppositions — this isn't exhaustive):
 
 - polling vs. push/websocket
 - synchronous vs. asynchronous
@@ -199,31 +195,25 @@ decisions:
 
 the subagent reads both `choice`/`rationale` pairs directly and confirms a genuine contradiction candidate: `add-live-sync`'s stated constraint ("no infra budget for a message broker") is now in tension with a later change clearing exactly that obstacle for a different capability. Whether this actually rises to a finding, and at what severity, is settled by the rule below — not by this step alone. Return only a structured verdict (confirmed / dismissed, plus a supporting quote-free summary) to the parent — never the raw `design.md` contents.
 
-**Step 4 — staleness flag.** Separately, flag any capability where `specs/INDEX.md`'s `Last touched by` date is old relative to a cluster of recent, related activity nearby (per Step 1's grouping) — this doesn't require opening any `design.md`, since it's a pure date comparison already available from Phase 1's index scan.
+**Step 4 — staleness flag.** Separately, flag any capability where `specs/INDEX.md`'s `Last touched by` date is old relative to a cluster of recent, related activity nearby (per Step 1's grouping) — this doesn't require opening any `design.md`, since it's a pure date comparison already available from the index data already loaded in Step 2.
 
-**Classification rule.** A confirmed contradiction is CRITICAL if the affected capability's `specs/INDEX.md` `Last touched by` date falls *after* the earlier of the two contradicting changes' dates — meaning something was built or touched on top of a decision that may no longer hold. Otherwise it's WARNING: the contradiction is real, but nothing has actively depended on the resolved version since. Both halves of this comparison come straight from the index model Phase 1 already built, so the rule needs no new lookup and produces the same classification on a re-run given the same data. Staleness flags (Step 4) are always SUGGESTION-level, since they're a signal to look, not a confirmed contradiction.
+   **Classification rule.** A confirmed contradiction is CRITICAL if the affected capability's `specs/INDEX.md` `Last touched by` date falls *after* the earlier of the two contradicting changes' dates — meaning something was built or touched on top of a decision that may no longer hold. Otherwise it's WARNING: the contradiction is real, but nothing has actively depended on the resolved version since. Both halves of this comparison come straight from the index model Step 2 already built, so the rule needs no new lookup and produces the same classification on a re-run given the same data. Staleness flags (Step 4) are always SUGGESTION-level, since they're a signal to look, not a confirmed contradiction.
 
-### Phase 3: Index Reconciliation
+4. **Index Reconciliation — check whether `specs/INDEX.md` still matches the actual `spec.md` files it claims to summarize — the one thing nothing else in this pipeline verifies. `accelint-qrspi-archive`'s Step 6 patches only the rows for capabilities the current batch's changes declared in `specs_touched`, and only performs a full corpus-wide scan once, at bootstrap, when the index doesn't exist yet. Every archive after that leaves every untouched row exactly as it was, indefinitely — a `spec.md` hand-edited outside the archive workflow, or a capability directory renamed or deleted directly, has no mechanism anywhere in this stack that would ever notice unless that specific capability happens to be touched by some future change. `accelint-qrspi-archive`'s own SKILL.md names this gap explicitly and names this skill as the natural place to close it, since periodic, corpus-wide checking is exactly this skill's charter.**
 
-**Goal**: check whether `specs/INDEX.md` still matches the actual `spec.md` files it claims to summarize — the one thing nothing else in this pipeline verifies. `accelint-qrspi-archive`'s Phase 5 patches only the rows for capabilities the current batch's changes declared in `specs_touched`, and only performs a full corpus-wide scan once, at bootstrap, when the index doesn't exist yet. Every archive after that leaves every untouched row exactly as it was, indefinitely — a `spec.md` hand-edited outside the archive workflow, or a capability directory renamed or deleted directly, has no mechanism anywhere in this stack that would ever notice unless that specific capability happens to be touched by some future change. `accelint-qrspi-archive`'s own SKILL.md names this gap explicitly and names this skill as the natural place to close it, since periodic, corpus-wide checking is exactly this skill's charter.
+**Step 1 — existence check (every row, no content read).** For every row in `specs/INDEX.md`, confirm `openspec/specs/<capability>/spec.md` still exists on disk. This is a file-existence check, not a content read, so it costs nothing meaningful even against a large corpus. A missing file or directory is an immediate CRITICAL finding — every other step in this workflow that touches this row (Step 3's clustering, Step 5's median) is working from a reference that no longer resolves to anything.
 
-**Step 1 — existence check (every row, no content read).** For every row in `specs/INDEX.md`, confirm `openspec/specs/<capability>/spec.md` still exists on disk. This is a file-existence check, not a content read, so it costs nothing meaningful even against a large corpus. A missing file or directory is an immediate CRITICAL finding — every other phase in this pipeline that touches this row (Phase 2's clustering, Phase 4's median) is working from a reference that no longer resolves to anything.
+**Step 2 — content check (every row whose file exists).** Read just the top of each `spec.md` — its `## Purpose` heading body and `related:` frontmatter list, not the full spec body — and compare against that row's `Purpose` and `Related` columns. A mismatch on either is a WARNING finding: "specs/INDEX.md row for `<capability>` disagrees with its own spec.md — index says `<X>`, file currently says `<Y>`." This is a small, bounded read (frontmatter plus one heading, the same shape of read Step 3's detailed verification already does against `design.md`), not a full-corpus content scan — it stays proportionate to corpus size the same way Step 5's median calculation does, just with a per-row cost instead of a zero cost.
 
-**Step 2 — content check (every row whose file exists).** Read just the top of each `spec.md` — its `## Purpose` heading body and `related:` frontmatter list, not the full spec body — and compare against that row's `Purpose` and `Related` columns. A mismatch on either is a WARNING finding: "specs/INDEX.md row for `<capability>` disagrees with its own spec.md — index says `<X>`, file currently says `<Y>`." This is a small, bounded read (frontmatter plus one heading, the same shape of read Phase 2 Step 3 already does against `design.md`), not a full-corpus content scan — it stays proportionate to corpus size the same way Phase 4's median calculation does, just with a per-row cost instead of a zero cost.
+   **What this step does not do.** It never writes anything itself — Step 4 is detection only. It never routes a confirmed finding to a writer skill either, since this isn't a hub-doc content gap — it's the index itself being wrong. What happens after a human confirms a reconciliation finding is Step 8's job, not this one; see Step 8 for the narrow, confirmation-gated write permission this skill has on `specs/INDEX.md` for exactly this case.
 
-**What this phase does not do.** It never writes anything itself — Phase 3 is detection only. It never routes a confirmed finding to a writer skill either, since this isn't a hub-doc content gap — it's the index itself being wrong. What happens after a human confirms a reconciliation finding is Phase 7's job, not this one; see Phase 7 for the narrow, confirmation-gated write permission this skill has on `specs/INDEX.md` for exactly this case.
+5. **Structural Coupling Signal — surface capabilities whose `related:` count suggests they may have outgrown their own boundary — at zero extra cost, since the counts already exist in `specs/INDEX.md` for other reasons.**
 
-### Phase 4: Structural Coupling Signal
+Compute the median `related:` list length across every row loaded in Step 2. Flag any capability whose count is both at least 5 and at least double that median as a SUGGESTION-level finding, phrased as a plain fact: for example, "sync/protocol relates to 14 other capabilities, more than double the index median of 6." This is a second reading of data the pipeline was already maintaining, not new bookkeeping, and it never requires opening any `design.md`.
 
-**Goal**: surface capabilities whose `related:` count suggests they may have outgrown their own boundary — at zero extra cost, since the counts already exist in `specs/INDEX.md` for other reasons.
+   Worked example: across 22 capability rows, related-counts of `[1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8, 9, 10, 11, 14, 14]` sort to a median of 6 (the 11th and 12th of 22 values, both 6). The floor is `max(5, 2 × 6) = 12`, so only the two rows at 14 clear it — everything from 11 down, including the two rows already at 6, stays unflagged. This is exactly the kind of distribution Verification Task C checks against: if every project's median clustered near 1 or 2 instead, the fixed floor of 5 alone would already flag most of the corpus regardless of the 2× multiplier, which is precisely the mismatch Task C exists to surface.
 
-Compute the median `related:` list length across every row read in Phase 1. Flag any capability whose count is both at least 5 and at least double that median as a SUGGESTION-level finding, phrased as a plain fact: for example, "sync/protocol relates to 14 other capabilities, more than double the index median of 6." This is a second reading of data the pipeline was already maintaining, not new bookkeeping, and it never requires opening any `design.md`.
-
-Worked example: across 22 capability rows, related-counts of `[1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8, 9, 10, 11, 14, 14]` sort to a median of 6 (the 11th and 12th of 22 values, both 6). The floor is `max(5, 2 × 6) = 12`, so only the two rows at 14 clear it — everything from 11 down, including the two rows already at 6, stays unflagged. This is exactly the kind of distribution Verification Task C checks against: if every project's median clustered near 1 or 2 instead, the fixed floor of 5 alone would already flag most of the corpus regardless of the 2× multiplier, which is precisely the mismatch Task C exists to surface.
-
-### Phase 5: Compile Report
-
-**Goal**: assemble everything Phases 2, 3, and 4 found into one report, in the same CRITICAL / WARNING / SUGGESTION register `/opsx:verify` already uses, so it reads as a familiar artifact rather than a new report format to learn.
+6. **Compile Report — assemble everything Steps 3, 4, and 5 found into one report, in the same CRITICAL / WARNING / SUGGESTION register `/opsx:verify` already uses, so it reads as a familiar artifact rather than a new report format to learn.**
 
 ```
 ## Archive Synthesis Report — <date>
@@ -249,11 +239,9 @@ checkpoint or "project start">.
 - [Any cadence or median mismatch worth a human's attention]
 ```
 
-Never present a finding here as already-resolved — every CRITICAL/WARNING item is a candidate for Phase 6, not a conclusion.
+   Never present a finding here as already-resolved — every CRITICAL/WARNING item is a candidate for Step 7, not a conclusion.
 
-### Phase 6: Human Review
-
-**Goal**: let a human decide what actually happens with each finding — this skill never resolves a contradiction on its own authority.
+7. **Human Review — let a human decide what actually happens with each finding — this skill never resolves a contradiction on its own authority.**
 
 Present each finding individually, in severity order. The three options are always Confirm / Dismiss / Defer, but "Confirm" and "Dismiss" don't do the same thing for a decision-drift finding as they do for a structural coupling or index reconciliation finding, and the label has to say so — a person choosing between them shouldn't have to already know this skill's internals to know what they're picking:
 
@@ -283,40 +271,36 @@ openspec/specs/cache/layer/spec.md, which no longer exists.
   (c) Defer  — Left as-is; resurfaces next run
 ```
 
-Only confirmed findings proceed to Phase 7, and for a decision-drift finding, "Confirm" is the start of a decision, not the end of one — it only tells this skill the contradiction is real; Phase 7 still has to ask which side of it stands before anything gets written (see Phase 7 and Error Handling). Defer never writes anything — a deferred finding resurfaces on the next run exactly as before, since nothing about the underlying index data changed to stop Phase 2, Phase 3, or Phase 4 from re-detecting the same pattern. Dismiss behaves differently depending on the finding type, which is exactly why its label above isn't the same across all three: dismissing a **decision-drift finding** persists — Phase 8 records that specific pair's identity to `SYNTHESIS-LOG.md`, and Phase 2 Step 2 will skip it on every future run. Dismissing a **structural coupling** or **index reconciliation finding** does not persist — either resurfaces next run like a defer would, because both are live snapshots of current state (a `related:` count, or whether a `spec.md` still matches its index row) rather than fixed historical facts (see "The Log This Skill Owns" for the full reasoning).
+   Only confirmed findings proceed to Step 8, and for a decision-drift finding, "Confirm" is the start of a decision, not the end of one — it only tells this skill the contradiction is real; Step 8 still has to ask which side of it stands before anything gets written (see Step 8 and Error Handling). Defer never writes anything — a deferred finding resurfaces on the next run exactly as before, since nothing about the underlying index data changed to stop Step 3, Step 4, or Step 5 from re-detecting the same pattern. Dismiss behaves differently depending on the finding type, which is exactly why its label above isn't the same across all three: dismissing a **decision-drift finding** persists — Step 9 records that specific pair's identity to `SYNTHESIS-LOG.md`, and Step 3 will skip it on every future run. Dismissing a **structural coupling** or **index reconciliation finding** does not persist — either resurfaces next run like a defer would, because both are live snapshots of current state (a `related:` count, or whether a `spec.md` still matches its index row) rather than fixed historical facts (see "The Log This Skill Owns" for the full reasoning).
 
-If the human stops reviewing partway through the list — ends the session, or moves on without responding to every finding — treat every unaddressed finding as deferred by default, never as confirmed. Phase 8 still logs the run and reports what was confirmed so far; whatever wasn't reached simply resurfaces next time, same as an explicit defer.
+   If the human stops reviewing partway through the list — ends the session, or moves on without responding to every finding — treat every unaddressed finding as deferred by default, never as confirmed. Step 9 still logs the run and reports what was confirmed so far; whatever wasn't reached simply resurfaces next time, same as an explicit defer.
 
-### Phase 7: Route Confirmed Findings
-
-**Goal**: hand off confirmed findings to wherever they can actually change something, using the shared `findings:` interface, and, for the narrow set of writes this skill is ever allowed to make, make them.
+8. **Route Confirmed Findings — hand off confirmed findings to wherever they can actually change something, using the shared `findings:` interface, and, for the narrow set of writes this skill is ever allowed to make, make them.**
 
 **For a confirmed decision contradiction**: confirming doesn't specify which side of the contradiction stands, so ask that directly first — never infer it from recency alone, even though "the later change" is often the reasonable guess (see Error Handling for why a wrong guess here is worse than a wrong guess almost anywhere else in this skill). Once the human names it, update that row's `Status` column in `archive/INDEX.md` to `superseded by <slug> (<date>)`, where `<slug>` and `<date>` identify the change that stands. This is the only write this skill ever makes to that file, and it only happens after both the initial confirmation and this follow-up answer — never automatically, never speculatively, never guessed. Then invoke the writer skill(s) whose hub doc covers the affected capability, using the Findings Interface format above.
 
-**Which writer skill a finding targets** follows the same purpose split `accelint-qrspi-apply` Phase 4 already uses to decide between the four hub docs — a decision-drift finding rarely belongs to exactly one, so route to whichever actually covers what the contradiction is about:
+**Which writer skill a finding targets** follows the same purpose split `accelint-qrspi-apply` Step 5 already uses to decide between the four hub docs — a decision-drift finding rarely belongs to exactly one, so route to whichever actually covers what the contradiction is about:
 
 - A contradiction over **tech stack, dependencies, or coding/architecture patterns** → `accelint-onboard-openspec` (`openspec/config.yaml`).
 - A contradiction over **system structure, components, or data flow** → `accelint-architecture-doc` (`ARCHITECTURE.md`). This is also always the target for structural coupling findings, landing in that skill's existing Known Technical Debt interview slot.
 - A contradiction over **agent workflow or behavior** → `accelint-onboard-agent` (`AGENTS.md`).
 - A contradiction over **user-facing setup or usage** → `accelint-readme-writer` (`README.md`).
 
-A single finding can legitimately target more than one — invoke each relevant writer skill separately, with the same finding rephrased once per invocation to fit that doc's own focus, exactly as `accelint-qrspi-apply` Phase 4 already treats each hub doc as an independent target rather than a single combined update. Each invocation succeeds or fails on its own — one writer skill being unavailable or erroring never blocks or rolls back a separate, successful invocation of another (see Error Handling for the specific case of a routing failure after `Status` has already been written).
+A single finding can legitimately target more than one — invoke each relevant writer skill separately, with the same finding rephrased once per invocation to fit that doc's own focus, exactly as `accelint-qrspi-apply` Step 5 already treats each hub doc as an independent target rather than a single combined update. Each invocation succeeds or fails on its own — one writer skill being unavailable or erroring never blocks or rolls back a separate, successful invocation of another (see Error Handling for the specific case of a routing failure after `Status` has already been written).
 
 **For a confirmed staleness flag or structural coupling flag**: no `Status` update applies — these aren't contradictions between two specific rows, so there is nothing to mark superseded. Route the finding to `accelint-architecture-doc`'s existing Known Technical Debt interview slot via the same `findings:` interface.
 
-**For a confirmed index reconciliation finding — content mismatch (WARNING)**: unlike a decision-drift finding, this needs no disambiguating question — `spec.md` is the source of truth by construction, so once a human confirms the discrepancy is real, the correct value isn't a judgment call. Patch that single row in `specs/INDEX.md`: locate the line whose first cell exactly matches the capability name — anchored between the leading `| ` and the next `|`, the same precise match `accelint-qrspi-archive`'s own Phase 5 uses, so `cache/layer` never matches `cache/layer-v2` — and replace only the `Purpose` and `related:` cells with `spec.md`'s current values. Leave `last_touched_by` exactly as it reads. That field records which *archived change* last touched this capability, and a reconciliation patch isn't an archived change — overwriting it would misattribute a hand-edit fix to a change that never happened. Build the replacement row with `accelint-qrspi-archive`'s own formatting rules: single-space cell separation, no cross-row padding, every other row in the file untouched. Report the before/after diff once written.
+   **For a confirmed index reconciliation finding — content mismatch (WARNING)**: unlike a decision-drift finding, this needs no disambiguating question — `spec.md` is the source of truth by construction, so once a human confirms the discrepancy is real, the correct value isn't a judgment call. Patch that single row in `specs/INDEX.md`: locate the line whose first cell exactly matches the capability name — anchored between the leading `| ` and the next `|`, the same precise match `accelint-qrspi-archive`'s own Step 6 uses, so `cache/layer` never matches `cache/layer-v2` — and replace only the `Purpose` and `related:` cells with `spec.md`'s current values. Leave `last_touched_by` exactly as it reads. That field records which *archived change* last touched this capability, and a reconciliation patch isn't an archived change — overwriting it would misattribute a hand-edit fix to a change that never happened. Build the replacement row with `accelint-qrspi-archive`'s own formatting rules: single-space cell separation, no cross-row padding, every other row in the file untouched. Report the before/after diff once written.
 
-**For a confirmed index reconciliation finding — missing directory or file (CRITICAL)**: also unambiguous once confirmed — the row points at something that no longer exists, so the correct action is removing that row, regardless of whether the capability was renamed or genuinely retired. Locate the line by the same anchored match and delete it; every other row stays untouched. If it turns out this was a rename rather than a removal, this skill doesn't attempt to guess the new name or insert a row for it — Phase 3 never verified that new capability's content, so writing a row for it here would be a guess dressed up as a finding. The new capability picks up its own row the ordinary way, the next time `accelint-qrspi-archive` archives a change that touches it.
+   **For a confirmed index reconciliation finding — missing directory or file (CRITICAL)**: also unambiguous once confirmed — the row points at something that no longer exists, so the correct action is removing that row, regardless of whether the capability was renamed or genuinely retired. Locate the line by the same anchored match and delete it; every other row stays untouched. If it turns out this was a rename rather than a removal, this skill doesn't attempt to guess the new name or insert a row for it — Step 4 never verified that new capability's content, so writing a row for it here would be a guess dressed up as a finding. The new capability picks up its own row the ordinary way, the next time `accelint-qrspi-archive` archives a change that touches it.
 
-**This skill's write permission on `specs/INDEX.md`** is exactly these two operations — patch or delete a single row — and only ever fires after Phase 6's explicit human confirmation of that specific discrepancy. It reuses `accelint-qrspi-archive`'s own row-patch mechanics rather than inventing separate logic that could drift from it over time; the two skills write the same file the same way, they just fire from different triggers.
+   **This skill's write permission on `specs/INDEX.md`** is exactly these two operations — patch or delete a single row — and only ever fires after Step 7's explicit human confirmation of that specific discrepancy. It reuses `accelint-qrspi-archive`'s own row-patch mechanics rather than inventing separate logic that could drift from it over time; the two skills write the same file the same way, they just fire from different triggers.
 
-**For a dismissed decision-drift finding**: no `Status` write, but Phase 8 does record the pair's identity to `SYNTHESIS-LOG.md`'s `dismissed:` sub-list, so Phase 2 Step 2 skips it on every future run. This is the one case where a dismissal actually changes what happens next time.
+   **For a dismissed decision-drift finding**: no `Status` write, but Step 9 does record the pair's identity to `SYNTHESIS-LOG.md`'s `dismissed:` sub-list, so Step 3 skips it on every future run. This is the one case where a dismissal actually changes what happens next time.
 
-**For a dismissed structural coupling or index reconciliation finding, or any deferred finding**: no write anywhere. All resurface identically on the next synthesis run — a deferred finding because nothing about the underlying index changed, a dismissed coupling or reconciliation finding because both are live snapshots that deserve re-checking every run regardless of a prior dismissal (see "The Log This Skill Owns").
+   **For a dismissed structural coupling or index reconciliation finding, or any deferred finding**: no write anywhere. All resurface identically on the next synthesis run — a deferred finding because nothing about the underlying index changed, a dismissed coupling or reconciliation finding because both are live snapshots that deserve re-checking every run regardless of a prior dismissal (see "The Log This Skill Owns").
 
-### Phase 8: Log and Report
-
-**Goal**: leave a checkpoint for Task A's cadence math next time, persist any newly dismissed decision-drift pairs, and summarize the run.
+9. **Log and Report — leave a checkpoint for Task A's cadence math next time, persist any newly dismissed decision-drift pairs, and summarize the run.**
 
 Append one line to `openspec/changes/archive/SYNTHESIS-LOG.md` (created fresh on first run) recording the date and the `archive/INDEX.md` row count this run checked through, followed by an indented `dismissed:` sub-list if any decision-drift finding was dismissed this run (omit the sub-list entirely if none were):
 
@@ -325,9 +309,9 @@ Append one line to `openspec/changes/archive/SYNTHESIS-LOG.md` (created fresh on
   dismissed: [add-live-sync|adopt-notification-gateway|sync/protocol]
 ```
 
-This log is a new, standalone file this skill owns entirely — it is not a column of either index, so writing it never conflicts with the single-write-permission rule on `archive/INDEX.md`. It exists purely so Phase 0's next run can compute "changes since last run" without guessing, and so Phase 2 can skip pairs a human has already ruled out, since neither index records either of those things on its own. Every run only ever appends a new line — an existing `dismissed:` entry is never edited or removed by this skill; a human wanting to reconsider a dismissed pair does so by editing the log file directly, not through this skill.
+   This log is a new, standalone file this skill owns entirely — it is not a column of either index, so writing it never conflicts with the single-write-permission rule on `archive/INDEX.md`. It exists purely so Step 1's next run can compute "changes since last run" without guessing, and so Step 3 can skip pairs a human has already ruled out, since neither index records either of those things on its own. Every run only ever appends a new line — an existing `dismissed:` entry is never edited or removed by this skill; a human wanting to reconsider a dismissed pair does so by editing the log file directly, not through this skill.
 
-Close with a short summary: how many findings of each type, how many confirmed/dismissed/deferred, and which writer skill(s) were invoked as a result.
+   Close with a short summary: how many findings of each type, how many confirmed/dismissed/deferred, and which writer skill(s) were invoked as a result.
 
 ## Explicitly Out of Scope
 
@@ -337,36 +321,36 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 - **No automatic threshold adjustment.** Verification Tasks A and C report mismatches; they never change the 15-change trigger or the 5-and-2×-median coupling floor on their own.
 - **No running on its own initiative.** Always either a direct human invocation or an offered suggestion from `accelint-qrspi-archive` that the human separately accepts.
 - **No cross-repository synthesis.** This skill operates only on the local project's `openspec/changes/archive/` and `openspec/specs/`. OpenSpec's separate stores feature, for cross-repo spec references, is untouched by anything here — extending synthesis across repositories is a different, larger problem this skill doesn't attempt.
-- **No writes to any `design.md`, ever.** Phase 2 opens archived `design.md` files strictly to read `choice`/`rationale`/`alternatives` for verification — never to annotate, correct, or append anything back to them. An archived change's own record of its own reasoning stays exactly as it was written, even after a later synthesis run confirms it's now superseded.
+- **No writes to any `design.md`, ever.** Step 3 opens archived `design.md` files strictly to read `choice`/`rationale`/`alternatives` for verification — never to annotate, correct, or append anything back to them. An archived change's own record of its own reasoning stays exactly as it was written, even after a later synthesis run confirms it's now superseded.
 - **No writes to `specs/INDEX.md` beyond a single confirmed row's patch or removal.** This mirrors the `archive/INDEX.md` rule exactly: one narrow, confirmation-gated exception, using `accelint-qrspi-archive`'s own row-format logic rather than separate logic that could drift from it. No bulk edits, no full-file rewrites, no speculative inserts for a renamed capability this skill never verified.
-- **No writes to any `spec.md`, ever.** Phase 3 reads `## Purpose` and `related:` to compare against the index — it never corrects, annotates, or touches the file it's checking.
-- **No full-body reads of `spec.md` during reconciliation.** Phase 3 reads only the `## Purpose` heading and `related:` frontmatter — the same bounded, top-of-file read Phase 4's own source data already assumes, not a full spec review.
+- **No writes to any `spec.md`, ever.** Step 4 reads `## Purpose` and `related:` to compare against the index — it never corrects, annotates, or touches the file it's checking.
+- **No full-body reads of `spec.md` during reconciliation.** Step 4 reads only the `## Purpose` heading and `related:` frontmatter — the same bounded, top-of-file read Step 5's own source data already assumes, not a full spec review.
 
 ## Error Handling
 
-**Either index missing or empty (Task B)**: stop before Phase 1; tell the user to run `accelint-qrspi-archive` first.
+**Either index missing or empty (Task B)**: stop before Step 2; tell the user to run `accelint-qrspi-archive` first.
 
-**`SYNTHESIS-LOG.md` doesn't exist yet**: not an error, and not the same condition as the one above — this is the expected state on this skill's first-ever run. Task A skips its cadence math and proceeds; Phase 8 creates the file fresh.
+**`SYNTHESIS-LOG.md` doesn't exist yet**: not an error, and not the same condition as the one above — this is the expected state on this skill's first-ever run. Task A skips its cadence math and proceeds; Step 9 creates the file fresh.
 
 **Corpus smaller than ~10 archived changes**: don't block, but say plainly that a corpus this size has little for cross-archive synthesis to find, and ask before proceeding with a low-signal run.
 
-**A flagged writer skill isn't installed, or doesn't yet support `findings:` in its Mode 3 path**: don't fail the whole run. Still produce and present the finding in the report; for Phase 7 routing, tell the user this specific handoff needs to happen manually and summarize what the finding was so they can paste it in themselves.
+**A flagged writer skill isn't installed, or doesn't yet support `findings:` in its Mode 3 path**: don't fail the whole run. Still produce and present the finding in the report; for Step 8 routing, tell the user this specific handoff needs to happen manually and summarize what the finding was so they can paste it in themselves.
 
-**No subagent support available**: fall back to opening flagged `design.md` candidates directly in the parent context for Phase 2 Step 3. Warn the user explicitly that this run's raw design.md contents will sit in context as a result — a degraded fallback, not the default.
+**No subagent support available**: fall back to opening flagged `design.md` candidates directly in the parent context for Step 3 Step 3. Warn the user explicitly that this run's raw design.md contents will sit in context as a result — a degraded fallback, not the default.
 
-**A `design.md` referenced by an index row no longer exists** (moved, renamed, or the archive folder was otherwise disturbed outside this skill's own writes): skip that row for Phase 2's targeted verification, note it in the report as unverifiable, and do not treat its absence as itself a finding.
+**A `design.md` referenced by an index row no longer exists** (moved, renamed, or the archive folder was otherwise disturbed outside this skill's own writes): skip that row for Step 3's targeted verification, note it in the report as unverifiable, and do not treat its absence as itself a finding.
 
 **A row in either index is malformed** (a `Specs touched` or `Related` list that fails to parse, a missing `Date`, or similar): skip that single row for whatever phase needs the missing field, note it plainly in the report as unparseable, and continue with every other row. One bad row is a data-quality note for the human, not a reason to abandon the run.
 
 **A `dismissed:` entry in `SYNTHESIS-LOG.md` references a slug that no longer appears in `archive/INDEX.md`** (the log was hand-edited, or the archive was altered outside this skill's own flow): drop that one identity from the in-memory dismissed-pair set for this run and note it once in the report — it can't suppress anything if one of its two slugs no longer resolves to a real row, and guessing at what it originally meant would be worse than treating it as inert.
 
-**Fewer than 2 rows in `specs/INDEX.md`**: skip Phase 4 entirely — a median needs enough rows to mean anything, and this mirrors the same low-corpus reasoning as the archive-size check above.
+**Fewer than 2 rows in `specs/INDEX.md`**: skip Step 5 entirely — a median needs enough rows to mean anything, and this mirrors the same low-corpus reasoning as the archive-size check above.
 
-**Phase 2 Step 1 clustering produces an unreasonably large candidate set** (a capability with a very long `related:` list, or a corpus with many changes touching it): don't spawn one subagent per pair unconditionally. Prioritize the most recently archived pairs first, verify those, and note in the report how many older candidates in the same cluster weren't checked this run due to volume — they remain candidates and will resurface next run, same as any other unconfirmed finding. This is a volume cap for cost control, not a correctness shortcut: nothing here is dismissed on the skill's own authority.
+**Step 3 Step 1 clustering produces an unreasonably large candidate set** (a capability with a very long `related:` list, or a corpus with many changes touching it): don't spawn one subagent per pair unconditionally. Prioritize the most recently archived pairs first, verify those, and note in the report how many older candidates in the same cluster weren't checked this run due to volume — they remain candidates and will resurface next run, same as any other unconfirmed finding. This is a volume cap for cost control, not a correctness shortcut: nothing here is dismissed on the skill's own authority.
 
 **A confirmed finding's routing invocation to a writer skill fails or times out**: this doesn't undo a `Status` update already made for that same finding — the two writes are independent, and `Status` reflects the human's confirmation, not whether the handoff succeeded. Tell the user plainly that the `Status` update landed but the writer-skill handoff didn't, and give them the same `findings:`-formatted text so they can invoke it manually.
 
-**The human answers Phase 7's "which change stands" follow-up ambiguously, or doesn't answer at all**: never infer it from recency alone, even though "the later change" is often the reasonable guess. Ask again rather than proceeding — a wrong guess here writes a permanent, human-facing claim into an audit-trail file, which is exactly the kind of write this skill's single-write-permission rule exists to keep deliberate. Leave the finding unresolved (equivalent to deferred) until the answer is unambiguous.
+**The human answers Step 8's "which change stands" follow-up ambiguously, or doesn't answer at all**: never infer it from recency alone, even though "the later change" is often the reasonable guess. Ask again rather than proceeding — a wrong guess here writes a permanent, human-facing claim into an audit-trail file, which is exactly the kind of write this skill's single-write-permission rule exists to keep deliberate. Leave the finding unresolved (equivalent to deferred) until the answer is unambiguous.
 
 **A human names a slug for `Status`'s `superseded by` value that doesn't actually appear in `archive/INDEX.md`**: stop and ask for the correct slug rather than writing an unverifiable reference — this field's entire value depends on it always resolving to a real row.
 
@@ -374,7 +358,7 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 
 **The corpus has far more capabilities than is reasonable to content-check in one run**: prioritize capabilities whose `Last touched by` change is oldest relative to the archive's own history first — those are the rows that have gone longest without any patch at all, and so carry the highest risk of undetected drift. Note in the report how many capabilities' content checks were skipped this run due to volume; the existence check in Step 1 still runs against every row regardless, since that check is nearly free.
 
-**A confirmed reconciliation finding's target row changed between Phase 3's detection and Phase 7's write** (a rare race — `accelint-qrspi-archive` ran in between, or a human hand-edited the row during the review session): re-check the row immediately before writing. If it already matches `spec.md` (something else already fixed it), skip the write and report it as resolved rather than confirmed-and-patched. If it still needs the same fix, proceed. Never write based on what Phase 3 saw if that's no longer what's actually there.
+**A confirmed reconciliation finding's target row changed between Step 4's detection and Step 8's write** (a rare race — `accelint-qrspi-archive` ran in between, or a human hand-edited the row during the review session): re-check the row immediately before writing. If it already matches `spec.md` (something else already fixed it), skip the write and report it as resolved rather than confirmed-and-patched. If it still needs the same fix, proceed. Never write based on what Step 4 saw if that's no longer what's actually there.
 
 **The `specs/INDEX.md` patch or removal write itself fails**: report it plainly, the same way a failed writer-skill handoff is reported — this finding stays unresolved (equivalent to deferred) and resurfaces next run, since nothing was actually written.
 
@@ -386,11 +370,11 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 
 **NEVER introduce a third state to `Status`** — it is always `current` or `superseded by <slug> (<date>)`, never anything else.
 
-**NEVER update `Status` without an explicit human confirmation of that specific contradiction** — a candidate surfacing in Phase 2 is not the same thing as a human agreeing it's real.
+**NEVER update `Status` without an explicit human confirmation of that specific contradiction** — a candidate surfacing in Step 3 is not the same thing as a human agreeing it's real.
 
-**NEVER rewrite a hub doc directly** — always route a confirmed finding through the relevant writer skill's own Mode 3 Refresh path via the `findings:` interface, exactly like `accelint-qrspi-apply` Phase 4 already does.
+**NEVER rewrite a hub doc directly** — always route a confirmed finding through the relevant writer skill's own Mode 3 Refresh path via the `findings:` interface, exactly like `accelint-qrspi-apply` Step 5 already does.
 
-**NEVER open every `design.md` in the corpus wholesale** — Phase 2 only opens the specific candidates the cheap index-only scan in Step 2 flagged, one subagent per candidate.
+**NEVER open every `design.md` in the corpus wholesale** — Step 3 only opens the specific candidates the cheap index-only scan in Step 2 flagged, one subagent per candidate.
 
 **NEVER silently adjust the 15-change trigger or the 5-and-2×-median coupling floor** — Tasks A and C only report a mismatch; changing either number is a human's call.
 
@@ -398,7 +382,7 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 
 **NEVER tell a human a dismissed structural coupling finding is permanently suppressed** — only decision-drift dismissals persist to `SYNTHESIS-LOG.md`; a dismissed coupling finding resurfaces next run exactly like a deferred one, since its underlying count is a moving snapshot. Say this plainly rather than implying a guarantee this skill doesn't keep.
 
-**NEVER let this skill itself edit or remove an existing `dismissed:` entry** — Phase 8 only ever appends. Reconsidering a previously dismissed pair is a manual edit to `SYNTHESIS-LOG.md`, deliberately outside this skill's own write path.
+**NEVER let this skill itself edit or remove an existing `dismissed:` entry** — Step 9 only ever appends. Reconsidering a previously dismissed pair is a manual edit to `SYNTHESIS-LOG.md`, deliberately outside this skill's own write path.
 
 **NEVER roll back a `Status` update because a routing invocation afterward failed** — the two writes are independent. A confirmed finding's `Status` change reflects the human's confirmation, not whether the writer-skill handoff succeeded; a failed handoff gets reported and handed to the human manually, it never reverses a write that already landed.
 
@@ -406,7 +390,7 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 
 **NEVER touch `last_touched_by` when patching a reconciliation finding** — that field records which archived change last touched the capability; a reconciliation patch isn't an archived change, and overwriting it would misattribute a hand-edit fix to a change that never happened.
 
-**NEVER guess a renamed capability's new name or insert a speculative row for it** — a missing-file CRITICAL finding only ever removes the stale row. Phase 3 never verified the new capability's content, so writing a row for it would be a guess dressed up as a finding.
+**NEVER guess a renamed capability's new name or insert a speculative row for it** — a missing-file CRITICAL finding only ever removes the stale row. Step 4 never verified the new capability's content, so writing a row for it would be a guess dressed up as a finding.
 
 **NEVER re-pad or realign existing rows in `specs/INDEX.md` when patching or removing one row** — same rule `accelint-qrspi-archive` follows for its own row-level writes. Cell padding is per-row, not aligned to the table's widest value; touching every row's whitespace to keep columns visually lined up turns a one-line diff back into a full-file rewrite.
 
@@ -418,15 +402,15 @@ Close with a short summary: how many findings of each type, how many confirmed/d
 
 This skill uses several terms precisely and doesn't mix them — worth pinning down once rather than re-explaining in every phase:
 
-- **Candidate**: a possible contradiction, drift, or coupling signal the coarse scan (Phase 2 Step 2), the existence/content check (Phase 3), or the median check (Phase 4) has flagged, before any verification has happened. Not yet a finding.
-- **Confirmed**: a candidate that Phase 2 Step 3's targeted subagent verified against full `design.md` content, a Phase 3 discrepancy that simply is what the direct comparison against `spec.md` shows (no separate verification step needed, since it's already a direct read), or a Phase 4 structural signal that simply is what the index says it is (same reasoning).
-- **Finding**: a confirmed candidate, phrased as a plain fact, ready for Phase 5's report and Phase 6's human review. Only findings appear in the report — raw candidates that Step 3 dismissed never do.
-- **Confirmed (human)**: distinct from the verification-step "confirmed" above — this is the human's Phase 6 decision that a given finding warrants action. Context disambiguates which sense is meant; where it doesn't, this document says "human-confirmed" explicitly.
-- **Dismissed**: a Phase 6 human decision that a finding isn't real or doesn't need action. Persists for decision-drift findings (the pair is logged and never re-flagged); does not persist for structural coupling or index reconciliation findings (both are re-checked every run regardless, since both read a live, moving snapshot of current state rather than a fixed historical fact). See Phase 6 and "The Log This Skill Owns" for why they differ.
-- **Deferred**: a Phase 6 human decision that a finding is real but not ready to act on. Never persists, for any finding type — a deferred finding resurfaces next run exactly as before.
+- **Candidate**: a possible contradiction, drift, or coupling signal the coarse scan (Step 3 Step 2), the existence/content check (Step 4), or the median check (Step 5) has flagged, before any verification has happened. Not yet a finding.
+- **Confirmed**: a candidate that Step 3 Step 3's targeted subagent verified against full `design.md` content, a Step 4 discrepancy that simply is what the direct comparison against `spec.md` shows (no separate verification step needed, since it's already a direct read), or a Step 5 structural signal that simply is what the index says it is (same reasoning).
+- **Finding**: a confirmed candidate, phrased as a plain fact, ready for Step 5's report and Step 6's human review. Only findings appear in the report — raw candidates that Step 3 dismissed never do.
+- **Confirmed (human)**: distinct from the verification-step "confirmed" above — this is the human's Step 6 decision that a given finding warrants action. Context disambiguates which sense is meant; where it doesn't, this document says "human-confirmed" explicitly.
+- **Dismissed**: a Step 6 human decision that a finding isn't real or doesn't need action. Persists for decision-drift findings (the pair is logged and never re-flagged); does not persist for structural coupling or index reconciliation findings (both are re-checked every run regardless, since both read a live, moving snapshot of current state rather than a fixed historical fact). See Step 6 and "The Log This Skill Owns" for why they differ.
+- **Deferred**: a Step 6 human decision that a finding is real but not ready to act on. Never persists, for any finding type — a deferred finding resurfaces next run exactly as before.
 - **`Status` = `current`**: the default state `accelint-qrspi-archive` writes for every row — not an assertion that the row is definitely correct, only that no synthesis run has yet confirmed a contradiction affecting it.
-- **`Status` = `superseded by <slug> (<date>)`**: the only other state this field ever holds, written exclusively by this skill's Phase 7, exclusively after a human-confirmed decision contradiction. Index reconciliation findings never produce a `Status` write — see Phase 7.
-- **`specs/INDEX.md` row patch or removal**: this skill's other write permission, exclusively on Phase 7, exclusively after a human-confirmed index reconciliation finding. A patch touches only `Purpose` and `related:`; a removal deletes the whole row. Neither ever touches `last_touched_by`, and neither is a `Status`-style state — the row is either present and current, or it's gone.
+- **`Status` = `superseded by <slug> (<date>)`**: the only other state this field ever holds, written exclusively by this skill's Step 8, exclusively after a human-confirmed decision contradiction. Index reconciliation findings never produce a `Status` write — see Step 8.
+- **`specs/INDEX.md` row patch or removal**: this skill's other write permission, exclusively on Step 8, exclusively after a human-confirmed index reconciliation finding. A patch touches only `Purpose` and `related:`; a removal deletes the whole row. Neither ever touches `last_touched_by`, and neither is a `Status`-style state — the row is either present and current, or it's gone.
 
 ## Example Usage
 
@@ -544,7 +528,7 @@ Skill: Scanning archive/INDEX.md and specs/INDEX.md...
 Decision drift — no candidate collisions found across 4 capabilities.
 Index reconciliation — 4/4 directories present; all 4 spec.md files match
   their specs/INDEX.md rows.
-Structural coupling — only 4 specs/INDEX.md rows; Phase 4 needs at least 2
+Structural coupling — only 4 specs/INDEX.md rows; Step 5 needs at least 2
   to compute a median, but a corpus this small has nothing meaningful to
   flag either way.
 

--- a/skills/accelint-onboard-openspec/CHANGELOG.md
+++ b/skills/accelint-onboard-openspec/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.5.0] - 2026-07-10
+
+### Added
+- **Leaf function purity guidance** — added explicit coding standard for leaf functions (bottom of call stack)
+  - Guidance: "Leaf functions (bottom of call stack) should be pure — same inputs produce same outputs, no side effects. Centralize state manipulation in parent/orchestrator functions."
+  - Added to TypeScript best practices section in default `config.yaml` template
+  - Rationale: Pushes side effects and state management to higher-level orchestration code, making leaf functions easier to test, reason about, and reuse. Pure leaf functions are deterministic and safe to parallelize.
+
+### Version
+- Bumped from 1.4.0 → 1.5.0
+
 ## [1.4.0] - 2026-07-08
 
 ### Added

--- a/skills/accelint-onboard-openspec/SKILL.md
+++ b/skills/accelint-onboard-openspec/SKILL.md
@@ -4,7 +4,7 @@ description: Interactively onboard a project to OpenSpec by running a structured
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Onboard OpenSpec
@@ -551,7 +551,8 @@ context: |
   - Validation:      [approach and library]
   - Constants:       Use `as const` objects, never `enum`
   - Classes:         Prefer functions over classes unless state management required or extending existing class
-  - Return values:   Return zero values (empty array, empty string, 0) instead of null/undefined
+  - Return values:   Return zero values (empty array, empty string, 0, false) instead of null/undefined
+  - Leaf functions:  Leaf functions (bottom of call stack) should be pure — same inputs produce same outputs, no side effects. Centralize state manipulation in parent/orchestrator functions.
   - Type safety:     Avoid `any` (use `unknown` or generics); avoid `enum` (use `as const` objects); use `type` over `interface`
   - Immutability:    Prefer `const`, immutable data structures, pure functions
   - Documentation:   Comprehensive JSDoc for all exported code (@param, @returns, @template, @example)

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.5.0] - 2026-07-10
+
+### Changed
+- **Remove phase boundaries to prevent premature stopping:** Refactored from phase-based structure to continuous numbered steps
+  - Rationale: Phase headers like "### Phase 0: Preflight and Change Selection", "### Phase 1: Parse Tasks and Parallelization Strategy" create natural stopping points where agents might pause and check with the user mid-workflow, breaking the intended continuous execution flow
+  - Changed structure from:
+    - "### Phase 0: Preflight", "### Phase 1: Parse", "### Phase 2: Load Context", etc.
+    - To: Single "Implementation Steps" section with continuous numbering (steps 1-N) and instruction "Execute these steps in order without stopping between them unless an error occurs"
+  - Updated workflow diagram: "Phase" column → "Stage" column (higher-level groupings like "Preflight", "Parse", "Execute")
+  - Updated all cross-references throughout the skill
+  - Removed all `**Steps:**` sub-headers that created additional stopping points within phases
+  - Why: Agents tend to treat phase headers and "Steps:" sub-headers as checkpoint boundaries even when not intended. Continuous numbered steps signal that the workflow should execute atomically unless an error occurs
+
+### Version
+- Bumped from 1.4.0 → 1.5.0
+
 ## [1.4.0] - 2026-07-08
 
 ### Changed

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
 metadata:
   author: accelint
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Accelint QRSPI Apply
@@ -33,8 +33,9 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Phase          Action                        Output            │
+│  Stage          Action                        Output            │
 ├─────────────────────────────────────────────────────────────────┤
+│  Preflight      Select and validate change    Ready to proceed  │
 │  Parse          Extract parallelization       Dependency graph  │
 │  Dependencies   Identify blocking tasks       Execution plan    │
 │  Load Context   Read config.yaml context      Project context   │
@@ -44,11 +45,9 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-## Phase Breakdown
+## Implementation Steps
 
-### Phase 0: Preflight and Change Selection
-
-**Steps**:
+### Preflight and Change Selection
 
 1. If a change name is provided in the skill arguments, use it
 2. Otherwise, try to infer from conversation context (recent mentions of change names)
@@ -64,15 +63,13 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    ```
    If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `/opsx:continue` to generate tasks before applying."
 
-### Phase 1: Parse Tasks and Parallelization Strategy
+### Parse Tasks and Parallelization Strategy
 
 **Goal**: Extract task structure and identify parallel vs sequential execution opportunities. Detect if work has already started and resume from the correct level.
 
-**Steps**:
+6. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
 
-1. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
-
-2. **Validate checklist format** (CRITICAL for progress tracking):
+7. **Validate checklist format** (CRITICAL for progress tracking):
    - Check that tasks use markdown checklist format: `- [ ] task` or `- [x] task`
    - If tasks use numbered lists (1. 2. 3.) or plain bullets (- without [ ]):
      ```
@@ -88,14 +85,15 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
      ```
    - Exit if format is invalid — do not proceed with invalid task format
 
-3. **Check for partial completion** (resumption detection):
+8. **Check for partial completion** (resumption detection):
    - Count completed tasks (marked `- [x]`) vs total tasks
    - Parse which slices have all their tasks marked complete
    - If any slices are complete, announce: "Detected partial completion. Resuming from Slice N."
    - Adjust the execution plan to skip completed slices
 
-4. Look for the "Parallelization Strategy" section (usually at the end of the file)
-5. Parse the strategy to build a dependency graph:
+9. Look for the "Parallelization Strategy" section (usually at the end of the file)
+
+10. Parse the strategy to build a dependency graph:
 
    **Example strategy:**
    ```md
@@ -120,11 +118,11 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
      - Final integration
    ```
 
-6. If no "Parallelization Strategy" section exists:
+11. If no "Parallelization Strategy" section exists:
    - Assume all tasks must run sequentially (safe default)
    - Inform user: "No parallelization strategy found. Running tasks sequentially."
 
-7. Build an execution plan showing:
+12. Build an execution plan showing:
    - Which slices run in which order
    - Which slices can run in parallel (and which are already complete)
    - Total estimated parallelization speedup
@@ -132,34 +130,32 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 
 **Output**: Dependency graph, execution plan, and resumption point if applicable
 
-### Phase 2: Load Project Context
+### Load Project Context
 
 **Goal**: Load project context from `openspec/config.yaml` to inject into sub-agent prompts. This compensates for OpenSpec CLI's limitation where the `apply` command doesn't automatically load project context (unlike artifact creation commands).
 
 **Background**: OpenSpec's `openspec instructions apply` command does NOT inject the `context` field from `config.yaml` (confirmed via code inspection and testing). This means sub-agents implementing tasks don't receive Stack Facts, coding patterns, testing conventions, or anti-patterns that should guide implementation. We work around this limitation by manually loading and injecting the context.
 
-**Steps**:
-
-1. Check if `openspec/config.yaml` exists:
+13. Check if `openspec/config.yaml` exists:
    ```bash
    test -f openspec/config.yaml && echo "exists" || echo "missing"
    ```
 
-2. If the file exists, read it:
+14. If the file exists, read it:
    ```bash
    cat openspec/config.yaml
    ```
 
-3. Parse and extract the `context` section (YAML block under `context: |`):
+15. Parse and extract the `context` section (YAML block under `context: |`):
    - The context starts after the line `context: |`
    - The context continues until the next top-level YAML key (e.g., `rules:`, `schema:`)
    - Lines in the context block are indented (usually 2 spaces)
    - Preserve all whitespace and newlines in the context block
    - You MUST inform the user that you found and loaded the config.
 
-4. Store the extracted context for injection into sub-agent prompts in Phase 3
+16. Store the extracted context for injection into sub-agent prompts in the next steps
 
-5. If no `context` field exists or the file is missing:
+17. If no `context` field exists or the file is missing:
    - Set context to empty string
    - Proceed without context injection (sub-agents will rely on OpenSpec's default behavior)
    - You MUST inform the user that you could NOT find and load the config.
@@ -194,7 +190,7 @@ rules:
 
 **Output**: Extracted project context string (may be empty if not present)
 
-### Phase 3: Execute Tasks (Sequential + Parallel)
+### Execute Tasks (Sequential + Parallel)
 
 **Goal**: Implement tasks following the dependency graph, spawning parallel sub-agents where possible.
 
@@ -202,8 +198,8 @@ rules:
 
 For each level in the dependency graph (starting from level 0):
 
-1. If the level has only one slice:
-   - Spawn a single sub-agent with this prompt (inject project context from Phase 2):
+18. If the level has only one slice:
+   - Spawn a single sub-agent with this prompt (inject project context loaded in step 16):
      ```
      <project_context>
      <!-- Background constraints for your implementation. Do NOT copy into code. -->
@@ -237,15 +233,15 @@ For each level in the dependency graph (starting from level 0):
      Focus exclusively on Slice N. Leave other slice tasks unchecked.
      ```
 
-     Note: If no project context was loaded in Phase 2, omit the `<project_context>` block entirely
+     Note: If no project context was loaded earlier, omit the `<project_context>` block entirely
 
-2. Wait for completion before proceeding to the next level
+19. Wait for completion before proceeding to the next level
 
 **Parallel execution** (when multiple slices are independent):
 
 For each level with multiple independent slices:
 
-1. Spawn all sub-agents in parallel in a single turn (one per slice, inject project context from Phase 2):
+20. Spawn all sub-agents in parallel in a single turn (one per slice, inject project context from earlier steps):
    ```
    <project_context>
    <!-- Background constraints for your implementation. Do NOT copy into code. -->
@@ -280,10 +276,11 @@ For each level with multiple independent slices:
    Your work is independent and should not block or depend on other slices.
    ```
 
-   Note: If no project context was loaded in Phase 2, omit the `<project_context>` block entirely
+   Note: If no project context was loaded earlier, omit the `<project_context>` block entirely
 
-2. Track completion as each sub-agent finishes
-3. When all slices in the level are done, **pause and offer context management**:
+21. Track completion as each sub-agent finishes
+
+22. **Context management decision point** - When all slices in the level are done, pause and offer context management:
    ```
    ✅ Level N complete
 
@@ -299,13 +296,13 @@ For each level with multiple independent slices:
    (c) Pause here — you can resume later with this skill
    ```
 
-4. If user chooses (b), instruct them:
+23. If user chooses (b), instruct them:
    ```
    Run `/clear` to reset context, then re-invoke this skill.
    I'll detect that Level N is complete and resume from Level N+1.
    ```
 
-5. If user chooses (c), exit and remind them how to resume:
+24. If user chooses (c), exit and remind them how to resume:
    ```
    Paused at Level N+1. To resume, re-invoke this skill.
    Progress is tracked in tasks.md checkboxes.
@@ -333,19 +330,19 @@ For each level with multiple independent slices:
 
 The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove CLI Surface", "## Slice 2: Remove Implementation"), making it straightforward for sub-agents to identify their scope.
 
-### Phase 4: Update Living Documents
+### Update Living Documents
 
 **Goal**: Update project documentation to reflect the implemented changes before running verification.
 
 **Why this matters**: OpenSpec changes represent significant architectural decisions and feature additions. Living documents (ARCHITECTURE.md, AGENTS.md, openspec/config.yaml) provide context for agents working in the codebase, while README.md serves human users. Keeping them synchronized prevents documentation drift and ensures future agents and developers have accurate, up-to-date context about the system's current state.
 
-**IMPORTANT**: Run this phase BEFORE verification so the verification step can check documentation completeness.
+**IMPORTANT**: Run this step BEFORE verification so the verification step can check documentation completeness.
 
-**Steps**:
+25. Check if the change is in a repository or package root by looking for `.git/` or `package.json`
 
-1. Check if the change is in a repository or package root by looking for `.git/` or `package.json`
-2. Determine the repo/package root (may be current directory or a parent)
-3. **Process ALL living documents** in this order (do not stop after the first one):
+26. Determine the repo/package root (may be current directory or a parent)
+
+27. **Process ALL living documents** in this order (do not stop after the first one):
    - OpenSpec config (`openspec/config.yaml`)
    - ARCHITECTURE.md (if exists)
    - AGENTS.md (if exists)
@@ -493,11 +490,11 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 - Document doesn't exist
 - Change content doesn't introduce anything requiring updates to that document
 
-**Important**: Process all 4 documents sequentially, one after another, without stopping. Do not pause between documents or wait for user input unless there's an error. After finishing all 4 documents, immediately proceed to Phase 5 (Verify Implementation).
+**Important**: Process all 4 documents sequentially, one after another, without stopping. Do not pause between documents or wait for user input unless there's an error. After finishing all 4 documents, immediately proceed to the next step (Verify Implementation).
 
-4. After checking all 4 documents, run `git status` to show which docs were modified
+28. After checking all 4 documents, run `git status` to show which docs were modified
 
-5. Present summary (then immediately continue to Phase 5):
+29. Present summary (then immediately continue to verification):
 
    - If no updates were needed:
      ```
@@ -509,7 +506,7 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - AGENTS.md [no changes needed]
      - README.md [no changes needed]
 
-     Proceeding to Phase 5: Verify Implementation...
+     Proceeding to verification...
      ```
 
    - If updates were made:
@@ -524,25 +521,23 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
      These changes ensure documentation stays synchronized with implementation.
 
-     Proceeding to Phase 5: Verify Implementation...
+     Proceeding to verification...
      ```
 
-**Output**: Summary of updated documents and methods used (skill vs manual), or confirmation that no updates were needed, then **MANDATORY automatic transition to Phase 5 without waiting for user input**
+**Output**: Summary of updated documents and methods used (skill vs manual), or confirmation that no updates were needed, then **MANDATORY automatic transition to verification without waiting for user input**
 
-### Phase 5: Verify Implementation
+### Verify Implementation
 
 **Goal**: Verify that the implementation matches the change artifacts (specs, tasks, design).
 
-**CRITICAL**: This is the FINAL phase. Verification is MANDATORY and produces a comprehensive report as the final output. Do NOT add additional reporting after this phase.
+**CRITICAL**: This is the FINAL step. Verification is MANDATORY and produces a comprehensive report as the final output. Do NOT add additional reporting after this step.
 
-**Steps**:
-
-1. Call the verify command:
+30. Call the verify command:
    ```
    /opsx:verify <change-name>
    ```
 
-2. The verify command will:
+31. The verify command will:
    - Check task completion (all checkboxes marked)
    - Verify spec coverage (requirements implemented)
    - Validate design adherence (decisions followed)
@@ -550,16 +545,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
    - Generate a comprehensive verification report with CRITICAL/WARNING/SUGGESTION issues
    - Include next steps (archive if passed, fix issues if failed)
 
-3. Present the verification report to the user
+32. Present the verification report to the user
 
-4. The verification report IS the completion report. It includes:
+33. The verification report IS the completion report. It includes:
    - Overall status (passed/failed)
    - Issue breakdown by severity
    - List of changed files
    - Next steps based on status
    - Archive guidance if ready
 
-5. Exit the skill after presenting the verification report. The report already tells the user what to do next.
+34. Exit the skill after presenting the verification report. The report already tells the user what to do next.
 
 **Output**: Comprehensive verification report with status, issues, changed files, and next steps
 
@@ -569,8 +564,8 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
 The skill supports pause/clear/resume workflow at dependency level boundaries:
 
-- **Pause points**: After each level completes, the skill offers to continue or let the user clear context
-- **Resumption detection**: When re-invoked, the skill reads tasks.md checkboxes to detect completed slices and resumes from the next incomplete level
+- **Pause points**: After each dependency level completes, the skill offers to continue or let the user clear context (Step 22)
+- **Resumption detection**: When re-invoked, the skill reads tasks.md checkboxes to detect completed slices and resumes from the next incomplete level (Step 8)
 - **Progress tracking**: Task completion is tracked in tasks.md via checkboxes, making progress durable across context clears
 - **Rationale**: Sub-agents can accumulate significant context. Between dependency levels, the orchestrating agent can clear context while preserving work progress via task checkboxes.
 
@@ -628,15 +623,17 @@ If the environment doesn't support sub-agents (e.g., Claude.ai):
 
 ## NEVER Do This
 
+**NEVER stop between living document updates and verification waiting for user confirmation** — Once living document updates (Steps 25-29) complete successfully, immediately proceed to verification (Step 30). These steps are a continuous workflow. The only legitimate stopping points are: (1) an error that requires user input to resolve, (2) preflight failing (Steps 1-5), or (3) the user-controlled context management decision points between dependency levels (Step 22). Do not treat completion of living document updates as a signal to stop and wait — it's a signal to continue to verification.
+
 **NEVER implement tasks directly** — Always delegate to `/opsx:apply` command via sub-agents. The /opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
 
-**NEVER skip verification** — Phase 5 verification using `/opsx:verify` is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
+**NEVER skip verification** — Verification using `/opsx:verify` (Step 30) is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
 
 **NEVER proceed with invalid task format** — This skill depends on markdown checklist format (`- [ ] task`) for progress tracking and resumption detection. If tasks.md uses numbered lists or plain bullets, exit early with an error. Do not attempt to work around the format issue — the user must fix tasks.md first.
 
 **NEVER skip dependency levels** — If Slice A blocks Slice B, Slice B cannot start until Slice A completes successfully. Do not spawn dependent slices before their blockers finish, even if it would speed up implementation. The dependency graph in the Parallelization Strategy must be respected.
 
-**NEVER skip living document updates** — Phase 4 updates living documents (ARCHITECTURE.md, AGENTS.md, README.md, config.yaml) to keep documentation synchronized with implementation. This phase runs BEFORE verification so the verification step can check documentation completeness. Do not skip to verification without updating living documents first.
+**NEVER skip living document updates** — Living document updates (Steps 25-29) keep ARCHITECTURE.md, AGENTS.md, README.md, and config.yaml synchronized with implementation. These steps run BEFORE verification so the verification step can check documentation completeness. Do not skip to verification without updating living documents first.
 
 ## Configuration Requirements
 

--- a/skills/accelint-qrspi-archive/CHANGELOG.md
+++ b/skills/accelint-qrspi-archive/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [1.1.0] - 2026-07-10
+
+### Changed
+- **Remove phase boundaries to prevent premature stopping:** Refactored from phase-based structure to continuous numbered steps
+  - Rationale: Phase headers like "### Phase 0: Preflight Checks", "### Phase 1: Archive and Extract", "### Phase 2: Validate" create natural stopping points where agents might pause and check with the user mid-workflow, breaking the intended continuous execution flow
+  - Changed structure from:
+    - "### Phase 0: Preflight Checks" / "### Phase 1: Archive and Extract" / etc.
+    - To: Single section with instruction "Execute these steps in order without stopping between them unless an error occurs" followed by continuous numbered steps
+  - Updated workflow diagram: "Phase" column → "Stage" column (higher-level groupings like "Preflight", "Archive", "Validate")
+  - Updated all cross-references throughout (e.g., "Phase 4 always delegates" → "Spec writing always delegates", "Phase 1 is the mirror image" → "Archive and extraction is the mirror image")
+  - Removed all `**Steps:**` sub-headers that created additional stopping points within phases
+  - Updated compatibility note to use plain language instead of phase references (e.g., "Phase 4 (per-capability spec writes)" → "Per-capability spec writes", "Phase 0 Task A" → "preflight Task A")
+  - Why: Agents tend to treat phase headers and "Steps:" sub-headers as checkpoint boundaries even when not intended. Continuous numbered steps signal that the workflow should execute atomically unless an error occurs
+
+### Version
+- Bumped from 1.0.0 → 1.1.0

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -2,10 +2,10 @@
 name: accelint-qrspi-archive
 description: Archive an OpenSpec change end-to-end. This skill invokes `/opsx:archive` or `/opsx:bulk-archive` itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run opsx:archive", "run opsx:bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
 license: Apache-2.0
-compatibility: Requires the OpenSpec CLI. Phase 4 (per-capability spec writes) requires sub-agent support — see the skill body for the degraded fallback if unavailable. Phase 1 (native archive) always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but Phase 0 Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose heading in its body.
+compatibility: Requires the OpenSpec CLI. Per-capability spec writes require sub-agent support — see the skill body for the degraded fallback if unavailable. Native archive always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but preflight Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose heading in its body.
 metadata:
   author: accelint
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Accelint QRSPI Archive
@@ -17,24 +17,24 @@ Cross-linking has to happen after the merge resolves, not before it, which is ex
 ## What This Skill Does
 
 **Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking `/opsx:archive` or `/opsx:bulk-archive` itself, then immediately following up with cross-capability linking and index maintenance.
-**Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself in Phase 1; it does not wait for the merge to have happened some other way first.
+**Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself during archive and extraction; it does not wait for the merge to have happened some other way first.
 **Output**: the change(s) archived via OpenSpec's own merge, plus updated `related:` frontmatter and a regenerated `## Related Specs` section on every touched spec, an updated `openspec/specs/INDEX.md` (patched for the capabilities this batch touched, or built fresh project-wide the first time the file doesn't exist yet), and one appended row per archived change in `openspec/changes/archive/INDEX.md`.
 **Does NOT**: implement the merge or conflict-resolution logic itself (that's OpenSpec's own, which this skill invokes via the native command rather than reimplementing), prune any `related:` entry, change a change's `Status` column after its initial write, reorder existing changelog rows, or shell out to the OpenSpec CLI to read local spec files (plain file reads are sufficient — see Explicitly Out of Scope).
 
 ## Prerequisites
 
 - OpenSpec CLI installed and initialized, with one or more changes ready to archive.
-- Sub-agent support, for Phase 4 (per-capability writes) only — Phase 4 always runs as subagents, unconditionally, and this is a hard requirement for normal operation there, not an optional speedup for large batches (see Error Handling for the degraded fallback if unavailable). Phase 1 (native archive + extraction) never uses a subagent, regardless of whether sub-agent support exists — see Phase 1 for why.
+- Sub-agent support, for per-capability spec writes only — those always run as subagents, unconditionally, and this is a hard requirement for normal operation there, not an optional speedup for large batches (see Error Handling for the degraded fallback if unavailable). Archive and extraction never uses a subagent, regardless of whether sub-agent support exists — see the Archive and Extract section for why.
 - Each change's `openspec/changes/<slug>/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
-- Every capability named in any `specs_touched` list already has `openspec/specs/<capability>/spec.md` with a `## Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in Phase 0, Task B).
+- Every capability named in any `specs_touched` list already has `openspec/specs/<capability>/spec.md` with a `## Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in preflight checks, Task B).
 
-If any of these are missing, report the gap and guide the user to resolve it before proceeding — do not silently substitute a guessed default for a missing field. This applies as-is to Phase 4's sub-agent support and a touched spec's missing `## Purpose` heading. A change's missing `specs_touched`/`decisions` frontmatter is handled differently: Phase 0 Task A derives a candidate from the change's own files and gets the author's explicit confirmation before writing it, rather than stopping outright — see Task A below for why a hard stop isn't actually necessary here, and why it still isn't a silent guess.
+If any of these are missing, report the gap and guide the user to resolve it before proceeding — do not silently substitute a guessed default for a missing field. This applies as-is to spec writing's sub-agent support and a touched spec's missing `## Purpose` heading. A change's missing `specs_touched`/`decisions` frontmatter is handled differently: preflight Task A derives a candidate from the change's own files and gets the author's explicit confirmation before writing it, rather than stopping outright — see Task A below for why a hard stop isn't actually necessary here, and why it still isn't a silent guess.
 
 ## Workflow Overview
 
 ```
 ┌────────────────────────────────────────────────────────────────────────┐
-│  Phase              Action                              Output         │
+│  Stage              Action                              Output         │
 ├────────────────────────────────────────────────────────────────────────┤
 │  0 Preflight        Verify frontmatter + Purpose         Go / no-go    │
 │                     headings before touching anything                  │
@@ -44,7 +44,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 │                     internal sync branch until archive's               │
 │                     own steps finish, then read back                   │
 │                     specs_touched + decisions                          │
-│  2 Validate         Confirm Phase 1's records are          Checked     │
+│  2 Validate         Confirm archive records are             Checked    │
 │                     structurally complete                  records     │
 │  3 Link             Combine new co-touch pairs across         New      │
 │                     this batch's changes (no file I/O)     partners    │
@@ -61,19 +61,19 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 │  7 Report           Summarize what changed                 Summary     │
 └────────────────────────────────────────────────────────────────────────┘
 
-Critical: for /opsx:bulk-archive, Phases 2-7 run exactly ONCE, after every
+Critical: for /opsx:bulk-archive, validation through reporting run exactly ONCE, after every
 merge in the batch has resolved — never once per intermediate merge. Running
 early would compute pairs against a specs_touched set that hasn't finished
 accumulating cross-change conflicts, and would patch INDEX.md against a
 half-finished batch.
 
-Phase 4 always delegates to subagents, regardless of batch size — one
+Spec writing always delegates to subagents, regardless of batch size — one
 capability or forty. This isn't a parallelization optimization that only
 kicks in for large batches; it's how this skill keeps raw spec.md contents
 out of the parent's context on every run, the same pattern
 accelint-qrspi-propose and accelint-qrspi-apply use.
 
-Phase 1 is the mirror image: it never delegates to a subagent, regardless of
+Archive and extraction is the mirror image: it never delegates to a subagent, regardless of
 batch size or whether sub-agent support is even available. /opsx:archive and
 /opsx:bulk-archive are themselves agent-driven, multi-step skills — not a
 single deterministic CLI call — and a subagent handed "run /opsx:archive"
@@ -81,16 +81,16 @@ has no reliable way to resume that skill's own remaining steps once it
 branches internally into something like a separate sync skill, and no way
 to surface an interactive prompt back to the user if one comes up. Both of
 those are failure modes this skill hit in practice, not hypothetical ones —
-see Phase 1 for the full account.
+see the Archive and Extract section for the full account.
 ```
 
-## Phase Breakdown
+## Implementation Steps
 
-### Phase 0: Preflight Checks
+Execute these steps in order without stopping between them unless an error occurs:
 
-**Goal**: confirm the archive operation's inputs are shaped the way Phases 2–6 assume, before any spec or index file is touched. Task A is a narrow exception: once the author has explicitly confirmed a derived `specs_touched`/`decisions` candidate (see below), it writes that confirmed value back into the change's own `design.md` — that's filling in an input Phase 1 expects to already be there, not touching a spec or an index.
+**Preflight Checks**
 
-**Steps**:
+Goal: confirm the archive operation's inputs are shaped correctly before touching any spec or index file. Task A is a narrow exception: once the author confirms a derived `specs_touched`/`decisions` candidate, it writes that back into `design.md` — that's filling in an input step 7 expects to already be there.
 
 1. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
 
@@ -118,42 +118,38 @@ see Phase 1 for the full account.
 
    This is evaluated per change in a bulk-archive batch — one change needing confirmation doesn't block preflight for the others.
 
-3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, confirm `openspec/specs/<capability>/spec.md` contains a `## Purpose` heading. Phase 5 reads this heading directly for the index's Purpose column, and Phase 4 relies on it existing so it can decide where a `## Related Specs` section belongs. If a spec is missing the heading, do not invent placeholder purpose text — ask the user whether to (a) add a placeholder like `_purpose not yet documented_` for now, or (b) fix the spec first. Fixing first is almost always better: a guessed purpose written into the index by this skill becomes content nobody actually authored, and it will look authoritative to the next reader.
+3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, confirm `openspec/specs/<capability>/spec.md` contains a `## Purpose` heading. Index updates read this heading directly for the Purpose column, and spec writing relies on it existing to decide where a `## Related Specs` section belongs. If a spec is missing the heading, do not invent placeholder purpose text — ask the user whether to (a) add a placeholder like `_purpose not yet documented_` for now, or (b) fix the spec first. Fixing first is almost always better: a guessed purpose written into the index by this skill becomes content nobody actually authored, and it will look authoritative to the next reader.
 
-4. For any capability in `specs_touched` that has no `openspec/specs/<capability>/` directory yet — a brand-new capability introduced by this change — note it separately. Phase 4 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and Phase 5's Purpose column will need the user to supply a value manually since nothing exists yet to read.
+4. For any capability in `specs_touched` that has no `openspec/specs/<capability>/` directory yet — a brand-new capability introduced by this change — note it separately. Step 19 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and step 20's Purpose column will need the user to supply a value manually since nothing exists yet to read.
 
-5. Report the preflight summary before proceeding: changes in scope, capabilities touched, and any Task A or Task B outcomes. If Task A ends in a stop for any change — the user chose to pause and fix `design.md` themselves, or no candidate could be derived at all — do not proceed to Phase 1 for that change. A Task A candidate the user confirmed counts as passing, the same as frontmatter that was already well-formed. If Task B fails for some capability, that's fine to resolve later — Phases 1 through 3 don't touch spec bodies, so only flag it as blocking once Phase 4 is about to reach that capability.
+5. Report the preflight summary before proceeding: changes in scope, capabilities touched, and any Task A or Task B outcomes. If Task A ends in a stop for any change — the user chose to pause and fix `design.md` themselves, or no candidate could be derived at all — do not proceed to step 6 for that change. A Task A candidate the user confirmed counts as passing, the same as frontmatter that was already well-formed. If Task B fails for some capability, that's fine to resolve later — steps 6-17 don't touch spec bodies, so only flag it as blocking once step 18 is about to reach that capability.
 
-**Output**: a go/no-go decision per change, plus the list of capabilities needing manual attention before Phase 4.
+**Archive and Extract** (runs inline — never a subagent)
 
-### Phase 1: Archive and Extract (Runs Inline — Never a Subagent)
+6. Let OpenSpec do the actual merge, then read back the data steps 17 and 23 need — done directly in this context, not handed to a subagent.
 
-**Goal**: let OpenSpec do the actual merge, then read back the data Phase 3 and Phase 6 need — done directly in this context, not handed to a subagent.
+This step never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
 
-This phase never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
+- **`/opsx:archive` and `/opsx:bulk-archive` are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent hand-fed the instruction "run `/opsx:archive`" has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued "run `/opsx:archive`" is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
+- **A subagent can't surface an interactive prompt to the user.** `/opsx:archive` and `/opsx:bulk-archive` may raise more than the routine sync y/n — `/opsx:bulk-archive` in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
 
-- **`/opsx:archive` and `/opsx:bulk-archive` are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent hand-fed the instruction "run `/opsx:archive`" has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running Phase 1 directly in this context means the same agent that issued "run `/opsx:archive`" is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
-- **A subagent can't surface an interactive prompt to the user.** `/opsx:archive` and `/opsx:bulk-archive` may raise more than the routine sync y/n — `/opsx:bulk-archive` in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running Phase 1 inline means any such prompt lands in the same conversation the user is already in.
+This does give something up: `/opsx:archive`'s own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the `/opsx:archive`/`/opsx:bulk-archive` skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
 
-This does give something up: `/opsx:archive`'s own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; Phase 4 still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to Phase 1's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the `/opsx:archive`/`/opsx:bulk-archive` skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
+7. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
 
-**Steps**:
+8. **Known interactive prompt — always sync.** `/opsx:archive` and `/opsx:bulk-archive` will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
 
-1. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
+9. Run `/opsx:archive <change-name>` (single change) or `/opsx:bulk-archive` (all pending changes) directly, exactly as if the user had typed the slash command themselves.
 
-2. **Known interactive prompt — always sync.** `/opsx:archive` and `/opsx:bulk-archive` will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
+10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
 
-3. Run `/opsx:archive <change-name>` (single change) or `/opsx:bulk-archive` (all pending changes) directly, exactly as if the user had typed the slash command themselves.
+11. **If any other interactive prompt comes up** — most commonly `/opsx:bulk-archive` asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
 
-4. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of Phase 1.
+12. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
 
-5. **If any other interactive prompt comes up** — most commonly `/opsx:bulk-archive` asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 2. Surface it to the user directly and wait for their answer before continuing.
+13. If ANY merge reports unresolved conflicts, STOP immediately. Do not attempt to resolve it, and do not proceed to step 14 for ANY change in this batch — a partial extraction is worse than none, since there's no way to tell a stalled batch from a clean one otherwise. Report the conflict verbatim to the user and stop. Do not proceed to validation — parsing anything out of a partially-merged batch would propagate garbage into every capability the batch touches.
 
-6. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
-
-7. If ANY merge reports unresolved conflicts, STOP immediately. Do not attempt to resolve it, and do not proceed to step 8 for ANY change in this batch — a partial extraction is worse than none, since there's no way to tell a stalled batch from a clean one otherwise. Report the conflict verbatim to the user and stop. Do not proceed to Phase 2 — parsing anything out of a partially-merged batch would propagate garbage into every capability the batch touches.
-
-8. For each change that archived successfully, read its `design.md` frontmatter from its new archived path (e.g. `openspec/changes/archive/2026-03-02-add-live-sync/design.md`) and build one record:
+14. For each change that archived successfully, read its `design.md` frontmatter from its new archived path (e.g. `openspec/changes/archive/2026-03-02-add-live-sync/design.md`) and build one record:
 
    ```
    {
@@ -167,31 +163,27 @@ This does give something up: `/opsx:archive`'s own internal work — comparing d
    }
    ```
 
-9. Keep the list of records from step 8, grouped by change, for Phase 2 — plus an explicit note to yourself that no unresolved conflicts remain.
+15. Keep the list of records from step 14, grouped by change, for validation — plus an explicit note to yourself that no unresolved conflicts remain.
 
-**Output**: one record per archived change (`change`, `date`, `archivePath`, `specsTouched`, `decisions`), held in this context and passed straight to Phase 2.
+**Output**: one record per archived change (`change`, `date`, `archivePath`, `specsTouched`, `decisions`), held in this context and passed straight to the validation step.
 
-### Phase 2: Validate Extracted Records
+**Validate Extracted Records**
 
-**Goal**: confirm Phase 1's records are structurally sound before Phase 3 depends on them — a sanity check on what Phase 1 produced, not a re-verification of the source data (Phase 0 Task A already confirmed the source `design.md` frontmatter was well-formed before Phase 1 ran).
+**Goal**: confirm archive records are structurally sound before cross-link computation depends on them — a sanity check on what was extracted, not a re-verification of the source data (preflight Task A already confirmed the source `design.md` frontmatter was well-formed before archive ran).
 
-**Steps**:
+16. Confirm every record has a non-empty `specsTouched` and at least one `decisions` entry with `choice` populated. If a record is missing either, something went wrong building it during archive (not in the original data, which Task A already validated) — re-run archive for that change rather than proceeding with a partial record.
 
-1. Confirm every record has a non-empty `specsTouched` and at least one `decisions` entry with `choice` populated. If a record is missing either, something went wrong building it in Phase 1 (not in the original data, which Task A already validated) — re-run Phase 1 for that change rather than proceeding with a partial record.
+17. Keep records grouped **by change**, exactly as returned. Cross-link computation computes pairs within a single change's own `specsTouched` — two unrelated changes archived in the same bulk-archive batch don't imply their capabilities co-touch each other, even though they landed at the same moment.
 
-2. Keep records grouped **by change**, exactly as returned. Phase 3 computes pairs within a single change's own `specsTouched` — two unrelated changes archived in the same bulk-archive batch don't imply their capabilities co-touch each other, even though they landed at the same moment.
+**Output**: the same record set from archive, confirmed structurally complete and ready for cross-link computation and INDEX appending.
 
-**Output**: the same record set from Phase 1, confirmed structurally complete and ready for Phases 3 and 6.
+**Compute Cross-Links (All-Pairs Union)**
 
-### Phase 3: Compute Cross-Links (All-Pairs Union)
+**Goal**: for each change, compute the symmetric co-touch pairs within its own `specs_touched`, and combine those pairs across every change in this archive operation into one set of newly-contributed partners per capability. This step touches zero files — it only combines the `specsTouched` lists already sitting in the validated records. Merging those new partners with whatever `related:` entries a spec already has (never dropping any of them) happens during spec writing, inside the subagent that's already opening that file — there's no reason for the parent to read spec frontmatter just to seed a union that spec writing can do in the same breath as its own file read.
 
-**Goal**: for each change, compute the symmetric co-touch pairs within its own `specs_touched`, and combine those pairs across every change in this archive operation into one set of newly-contributed partners per capability. This step touches zero files — it only combines the `specsTouched` lists already sitting in the Phase 2 records. Merging those new partners with whatever `related:` entries a spec already has (never dropping any of them) happens in Phase 4, inside the subagent that's already opening that file — there's no reason for the parent to read spec frontmatter just to seed a union that Phase 4 can do in the same breath as its own file read.
+18. For a change with `specs_touched: [A, B, C]`, the contributed pairs are all 2-combinations excluding self: `(A,B)`, `(A,C)`, `(B,C)`. Co-touch has no direction — pairing `(A,B)` means A gains B as a related partner **and** B gains A in the same step.
 
-**Steps**:
-
-1. For a change with `specs_touched: [A, B, C]`, the contributed pairs are all 2-combinations excluding self: `(A,B)`, `(A,C)`, `(B,C)`. Co-touch has no direction — pairing `(A,B)` means A gains B as a related partner **and** B gains A in the same step.
-
-2. This is a pure computation with no dependency on file I/O, so it's worth writing as a small pure function rather than eyeballing it per capability:
+19. This is a pure computation with no dependency on file I/O, so it's worth writing as a small pure function rather than eyeballing it per capability:
 
    ```typescript
    type ChangeLink = {
@@ -211,7 +203,7 @@ This does give something up: `/opsx:archive`'s own internal work — comparing d
    // Fold every change's pairs into one partner-set-per-capability map. This
    // starts from an empty map every time — it combines pairs ACROSS the
    // changes in this batch, not against a spec's on-disk related: list. That
-   // merge is deliberately left to Phase 4, which is the one opening the file.
+   // merge is deliberately left to spec writing, which is the step that opens the file.
    const accumulateNewPartners = (
      pairsByChange: ReadonlyArray<ReadonlyArray<readonly [string, string]>>,
    ): ReadonlyMap<string, ReadonlySet<string>> => {
@@ -226,21 +218,19 @@ This does give something up: `/opsx:archive`'s own internal work — comparing d
    };
    ```
 
-3. Fold every change's pairs into the same accumulating map, starting from empty — a bulk-archive batch of three changes touching overlapping capabilities should have all three changes' pairs combined before Phase 4 ever touches a file, so each capability's subagent is invoked once with a complete new-partner list rather than three times with partial data.
+20. Fold every change's pairs into the same accumulating map, starting from empty — a bulk-archive batch of three changes touching overlapping capabilities should have all three changes' pairs combined before spec writing ever touches a file, so each capability's subagent is invoked once with a complete new-partner list rather than three times with partial data.
 
-4. Hand this map to Phase 4 as-is — unsorted and unmerged with any spec's existing `related:` list. Phase 4's subagent is responsible for both the merge (union with whatever's already in the file) and the final alphabetical sort, since it's the one that actually reads the file this all depends on.
+21. Hand this map to spec writing as-is — unsorted and unmerged with any spec's existing `related:` list. The spec-writing subagent is responsible for both the merge (union with whatever's already in the file) and the final alphabetical sort, since it's the one that actually reads the file this all depends on.
 
-**Output**: a map of `capability -> newly contributed partner names`, not yet merged with any spec's existing `related:` list and not yet sorted — both of those happen in Phase 4.
+**Output**: a map of `capability -> newly contributed partner names`, not yet merged with any spec's existing `related:` list and not yet sorted — both of those happen during spec writing.
 
-### Phase 4: Write Spec Frontmatter and Body (Subagent, Always)
+**Write Spec Frontmatter and Body (Subagent, Always)**
 
-**Goal**: merge Phase 3's newly contributed partners into each touched spec's existing `related:` list, persist that plus provenance into frontmatter, and regenerate the `## Related Specs` section to match.
+**Goal**: merge newly contributed partners into each touched spec's existing `related:` list, persist that plus provenance into frontmatter, and regenerate the `## Related Specs` section to match.
 
-Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once Phase 3's new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in Phase 3.
+Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once the new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in cross-link computation.
 
-**Steps**:
-
-1. For each touched capability, spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from Phase 3 — not a final list; the subagent is the one that merges those against whatever the file already has):
+22. For each touched capability, spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from cross-link computation — not a final list; the subagent is the one that merges those against whatever the file already has):
 
    ```
    Update openspec/specs/<capability>/spec.md only. Do not touch any other file.
@@ -278,29 +268,27 @@ Always spawn one subagent per touched capability to do this — every time, not 
    (byte-identical to what was already there) or an actual change, the
    final related: list you wrote, and the capability's current ## Purpose
    heading text (a sentence or short paragraph — you're not writing this,
-   just reading it back so the parent doesn't have to reopen this file in
-   Phase 5). Do not return the file's full contents.
+   just reading it back so the parent doesn't have to reopen this file for
+   index updates). Do not return the file's full contents.
    ```
 
-2. If the capability has no prior `spec.md` (a brand-new capability per Phase 0 step 4), the subagent starts from an empty frontmatter block instead of reading an existing one — same prompt otherwise.
+23. If the capability has no prior `spec.md` (a brand-new capability per preflight step 4), the subagent starts from an empty frontmatter block instead of reading an existing one — same prompt otherwise.
 
-3. Collect each subagent's short report (file, no-op vs. changed, final `related:` list, and Purpose heading text) for Phase 5 and Phase 7. Phase 5 reuses the `related:` and Purpose values directly from this report instead of reopening the file; Phase 7's summary draws only on the no-op/changed status. Nothing else about the write needs to enter the parent's context — a reported no-op is the expected signal that this capability wasn't actually affected by this batch, not something to double-check by re-reading the file.
+24. Collect each subagent's short report (file, no-op vs. changed, final `related:` list, and Purpose heading text) for index updates and reporting. Index updates reuse the `related:` and Purpose values directly from this report instead of reopening the file; the final report draws only on the no-op/changed status. Nothing else about the write needs to enter the parent's context — a reported no-op is the expected signal that this capability wasn't actually affected by this batch, not something to double-check by re-reading the file.
 
-**Output**: every touched capability's `spec.md` updated in place (existing `related:` entries preserved, new ones unioned in and sorted), or confirmed unchanged, with only a short status line plus its `related:`/Purpose values — the small payload Phase 5 needs — entering the parent's context.
+**Output**: every touched capability's `spec.md` updated in place (existing `related:` entries preserved, new ones unioned in and sorted), or confirmed unchanged, with only a short status line plus its `related:`/Purpose values — the small payload for index updates — entering the parent's context.
 
-### Phase 5: Update openspec/specs/INDEX.md
+**Update openspec/specs/INDEX.md**
 
-**Goal**: keep `openspec/specs/INDEX.md` in sync with what Phase 4 just wrote, at the cost of touching only the lines that actually changed — not a re-scan of every capability's `spec.md`, and not even a full read of `specs/INDEX.md` itself. Phase 4's subagents already read each touched capability's current `related:`, `last_touched_by`, and `## Purpose` heading as part of doing their own write, and report those values back — Phase 5 reuses that data directly instead of paying for a second full scan of `openspec/specs/`. The only time this phase looks at capabilities beyond the ones this batch touched, or reads more than a single targeted line of `specs/INDEX.md`, is when the file doesn't exist yet at all — there's no existing state to patch, and a one-time full build is the right move, not a routine one.
+**Goal**: keep `openspec/specs/INDEX.md` in sync with what was just written, at the cost of touching only the lines that actually changed — not a re-scan of every capability's `spec.md`, and not even a full read of `specs/INDEX.md` itself. The spec-writing subagents already read each touched capability's current `related:`, `last_touched_by`, and `## Purpose` heading as part of doing their own write, and report those values back — index updates reuse that data directly instead of paying for a second full scan of `openspec/specs/`. The only time this step looks at capabilities beyond the ones this batch touched, or reads more than a single targeted line of `specs/INDEX.md`, is when the file doesn't exist yet at all — there's no existing state to patch, and a one-time full build is the right move, not a routine one.
 
-**Steps**:
+25. **The common case — `specs/INDEX.md` already exists.** Don't read the whole file into context to do this — locate and edit only the lines that actually change:
 
-1. **The common case — `specs/INDEX.md` already exists.** Don't read the whole file into context to do this — locate and edit only the lines that actually change:
-
-   - **Existing capability**: grep for the line whose first cell exactly matches the capability name (anchored between the leading `| ` and the next `|`, not a loose substring match — `sync/protocol` must not match `sync/protocol-v2`). Replace that single line with the row built from Phase 4's report for that capability (`Purpose`, `related:`, `last_touched_by`). Nothing else in the file is read or touched.
-   - **Brand-new capability** (per Phase 0 step 4): grep for capability-name cells to find the first existing row that sorts after the new one alphabetically, and insert the new row immediately before it (or append at the end if it sorts last). This still only touches one new line — locating the insertion point doesn't require loading row content, just the capability-name column.
+   - **Existing capability**: grep for the line whose first cell exactly matches the capability name (anchored between the leading `| ` and the next `|`, not a loose substring match — `sync/protocol` must not match `sync/protocol-v2`). Replace that single line with the row built from the spec-writing report for that capability (`Purpose`, `related:`, `last_touched_by`). Nothing else in the file is read or touched.
+   - **Brand-new capability** (per preflight step 4): grep for capability-name cells to find the first existing row that sorts after the new one alphabetically, and insert the new row immediately before it (or append at the end if it sorts last). This still only touches one new line — locating the insertion point doesn't require loading row content, just the capability-name column.
    - Every row for every untouched capability is never opened, matched, or rewritten — not just "left identical" as an outcome of a full rebuild, but literally never touched by this operation.
 
-2. Build each row without cross-row padding — single-space cell separation (`| sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |`), not aligned to the widest value in each column:
+26. Build each row without cross-row padding — single-space cell separation (`| sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |`), not aligned to the widest value in each column:
 
    ```markdown
    | Capability | Purpose | Related | Last touched by |
@@ -311,21 +299,19 @@ Always spawn one subagent per touched capability to do this — every time, not 
 
    Markdown tables render correctly regardless of padding — only the header separator's dash count matters, not whitespace consistency across data rows. Keeping cross-row alignment would mean every row's padding depends on every other row's content length, which forces a full-table rewrite the instant any single row's text changes length — exactly the cost this design exists to avoid. A patched row and its untouched neighbors will look slightly ragged in a raw diff; that's the trade for the diff actually being one line.
 
-3. **The bootstrap case — `specs/INDEX.md` doesn't exist yet.** There's no prior state to patch, and patching only the touched rows would permanently omit every untouched capability until each happens to be touched by some future change. List every directory under `openspec/specs/`, and for each one, read its `## Purpose` heading, `related:` frontmatter, and `last_touched_by` directly — the full scan Phase 5 used to do unconditionally. This runs at most once per project, the first time this skill archives anything against it; every archive after that goes through step 1 instead.
+27. **The bootstrap case — `specs/INDEX.md` doesn't exist yet.** There's no prior state to patch, and patching only the touched rows would permanently omit every untouched capability until each happens to be touched by some future change. List every directory under `openspec/specs/`, and for each one, read its `## Purpose` heading, `related:` frontmatter, and `last_touched_by` directly — a full scan. This runs at most once per project, the first time this skill archives anything against it; every archive after that goes through step 25 instead.
 
-4. **Bootstrap case only**: write `openspec/specs/INDEX.md` from the full scan gathered in step 3, using the row format from step 2. If the file already carries a project-specific title or preamble above the table, preserve it. The common case (step 1) has already written its edit directly — there's no separate write step for it.
+28. **Bootstrap case only**: write `openspec/specs/INDEX.md` from the full scan gathered in step 27, using the row format from step 26. If the file already carries a project-specific title or preamble above the table, preserve it. The common case (step 25) has already written its edit directly — there's no separate write step for it.
 
 **Output**: `openspec/specs/INDEX.md`, with one line changed or inserted per capability this batch touched and every other line untouched, or built once from every capability project-wide if the file didn't exist yet.
 
 A patched `specs/INDEX.md` can still drift from reality for reasons outside this skill's control — a `spec.md` hand-edited outside the archive workflow, a capability directory renamed or deleted directly. This skill doesn't re-derive the whole index every run to catch that. Nothing else currently does either: `accelint-archive-synthesis`'s two checks (decision-drift, structural-coupling) both read `specs/INDEX.md` as ground truth rather than auditing it against the `spec.md` files it summarizes. Catching this kind of drift would mean adding an index-reconciliation check to `accelint-archive-synthesis` — a natural fit for a skill that already exists to do periodic, corpus-wide checks — but that check doesn't exist yet. Until it does, this is an accepted, narrow gap rather than a covered one.
 
-### Phase 6: Append to openspec/changes/archive/INDEX.md
+**Append to openspec/changes/archive/INDEX.md**
 
-**Goal**: log one durable row per archived change, inserted at the end of the table's existing data rows — never blindly at the end of the file. Unlike Phase 5, this file is history, and history is append-only — never regenerated, never reordered.
+**Goal**: log one durable row per archived change, inserted at the end of the table's existing data rows — never blindly at the end of the file. Unlike specs INDEX updating, this file is history, and history is append-only — never regenerated, never reordered.
 
-**Steps**:
-
-1. For each change from Phase 2, construct one row:
+29. For each change from validation, construct one row:
 
    ```markdown
    | Change | Date | Decision | Specs touched | Status |
@@ -333,25 +319,23 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
    | add-live-sync | 2026-03-02 | polling with 5s interval | sync/protocol, ui/status-indicator | current |
    ```
 
-   - `Date` is the archive folder's `YYYY-MM-DD` prefix — the same source used in Phase 2, never anything read out of `design.md`.
+   - `Date` is the archive folder's `YYYY-MM-DD` prefix — the same source used in validation, never anything read out of `design.md`.
    - `Decision` is a one-line summary of `decisions[].choice`. If a change recorded more than one decision, concatenate the choices with semicolons (e.g. `polling with 5s interval; client-side dedup on reconnect`) rather than picking just one — every decision the design phase made deserves to survive into the permanent record, even compressed to a phrase.
    - `Status` is written as `current` and this skill never touches that column again after this initial write, for this row or any other. Transitions like `current` → `superseded` belong to `accelint-archive-synthesis`, which has the cross-change context needed to know when a decision has actually been superseded — this skill only ever sees one archive operation at a time and can't safely make that call.
 
-2. **Locate the insertion point — the end of the table, not the end of the file.** Find the header row (`| Change | Date | ... |`), its separator (`| --- | --- | ... |`), and the contiguous block of data rows that follows. Insert the new row(s) immediately after the last of those data rows. This file may carry content after the table — a summary block with a total row count, a `Generated:` date stamp, a status legend, or similar — and that content is not part of the table; do not read past it, move it, or edit it. Appending past it instead of before it is exactly how a data row ends up sitting in prose after a `Status Legend` line instead of inside the table, which is what happened before this step existed: treat any such trailing block as preserved-but-unowned, the same way Phase 5 preserves a project-specific preamble above `specs/INDEX.md`'s table without editing it.
+30. **Locate the insertion point — the end of the table, not the end of the file.** Find the header row (`| Change | Date | ... |`), its separator (`| --- | --- | ... |`), and the contiguous block of data rows that follows. Insert the new row(s) immediately after the last of those data rows. This file may carry content after the table — a summary block with a total row count, a `Generated:` date stamp, a status legend, or similar — and that content is not part of the table; do not read past it, move it, or edit it. Appending past it instead of before it is exactly how a data row ends up sitting in prose after a `Status Legend` line instead of inside the table, which is what happened before this step existed: treat any such trailing block as preserved-but-unowned, the same way index updates preserve a project-specific preamble above `specs/INDEX.md`'s table without editing it.
 
-3. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row (and no trailing content) if missing.
+31. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row (and no trailing content) if missing.
 
-4. Do not re-sort, reformat, or otherwise touch any existing row. The append-only discipline here is what makes this file a reliable audit trail; reordering past rows would make it impossible for anyone to use git blame to see when a decision was recorded relative to the others around it.
+32. Do not re-sort, reformat, or otherwise touch any existing row. The append-only discipline here is what makes this file a reliable audit trail; reordering past rows would make it impossible for anyone to use git blame to see when a decision was recorded relative to the others around it.
 
-5. If the file's trailing content (per step 2) states a total row count, leave it as written even though it will now be stale by however many rows this run just added. Reconciling that count isn't this skill's job any more than pruning `related:` entries or flipping `Status` values is — it's corpus-wide bookkeeping, the same category of accepted gap Phase 5 already lives with for `specs/INDEX.md` drift (see the note at the end of Phase 5), and a reasonable additional check for `accelint-archive-synthesis` to pick up if it doesn't already.
+33. If the file's trailing content (per step 30) states a total row count, leave it as written even though it will now be stale by however many rows this run just added. Reconciling that count isn't this skill's job any more than pruning `related:` entries or flipping `Status` values is — it's corpus-wide bookkeeping, the same category of accepted gap that index updates already live with for `specs/INDEX.md` drift (see the note at the end of that section), and a reasonable additional check for `accelint-archive-synthesis` to pick up if it doesn't already.
 
 **Output**: `openspec/changes/archive/INDEX.md`, with one new row per archived change inserted at the end of the table's data rows, every prior row untouched, and any trailing content after the table preserved exactly as it was — including any count within it that's now stale.
 
-### Phase 7: Report
+**Report**
 
-**Steps**:
-
-1. Summarize what changed:
+34. Summarize what changed:
 
    ```
    ✅ Archive complete: add-live-sync
@@ -369,54 +353,56 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
      pruning is accelint-archive-synthesis's job, not this skill's
    ```
 
-2. If any capability was left with a placeholder purpose or skipped entirely because Phase 0 Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
+35. If any capability was left with a placeholder purpose or skipped entirely because preflight Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
 
 **Output**: a human-readable summary of every file this skill touched.
 
 ## Key Principles
 
-A quick-reference summary — each of these is explained in full where it's actually applied (Phase Breakdown) or enforced (NEVER Do This); this is just the index.
+A quick-reference summary — each of these is explained in full where it's actually applied (Implementation Steps) or enforced (NEVER Do This); this is just the index.
 
 - **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until `/opsx:bulk-archive` resolves conflicts in order; only the merged, archived spec is worth indexing.
 - **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
 - **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
-- **Every write is idempotent.** Flow-style sorted `related:` and Phase 5's row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
+- **Every write is idempotent.** Flow-style sorted `related:` and row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
 - **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
-- **Phase 4 always delegates to subagents, never conditionally; Phase 1 never does, unconditionally.** Phase 4's unconditional delegation keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching phase. Phase 1 runs inline for the opposite reason: `/opsx:archive`/`/opsx:bulk-archive` are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
+- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: `/opsx:archive`/`/opsx:bulk-archive` are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
 
 ## Explicitly Out of Scope
 
 - **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/<capability>/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
-- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the `/opsx:archive`/`/opsx:bulk-archive` skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Phase 1 always goes through the skill, never the raw CLI, even though running it inline (see Phase 1) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
+- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the `/opsx:archive`/`/opsx:bulk-archive` skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
 - **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
 - **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
 - **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
-- **No corpus-wide drift detection in `specs/INDEX.md`.** Phase 5 only ever patches the rows for capabilities this batch's changes declared in `specs_touched`. If some capability's `spec.md` was edited outside this skill and its `INDEX.md` row has gone stale as a result, this skill's hot path doesn't catch that — and neither, currently, does `accelint-archive-synthesis`: its decision-drift and structural-coupling checks both read `specs/INDEX.md` as ground truth rather than verifying it against `spec.md`. This is a real, accepted gap, not a job this skill should absorb into its own per-archive cost.
-- **No reconciling summary stats trailing `changes/archive/INDEX.md`.** If that file carries a total row count or similar after the table, Phase 6 preserves it untouched (see Phase 6 step 2) rather than incrementing it — updating summary stats is corpus-wide bookkeeping in the same family as `specs/INDEX.md` drift above, not a per-archive job.
+- **No corpus-wide drift detection in `specs/INDEX.md`.** Index updates only ever patch the rows for capabilities this batch's changes declared in `specs_touched`. If some capability's `spec.md` was edited outside this skill and its `INDEX.md` row has gone stale as a result, this skill's hot path doesn't catch that — and neither, currently, does `accelint-archive-synthesis`: its decision-drift and structural-coupling checks both read `specs/INDEX.md` as ground truth rather than verifying it against `spec.md`. This is a real, accepted gap, not a job this skill should absorb into its own per-archive cost.
+- **No reconciling summary stats trailing `changes/archive/INDEX.md`.** If that file carries a total row count or similar after the table, the changelog append step preserves it untouched (see step 23 substep 2) rather than incrementing it — updating summary stats is corpus-wide bookkeeping in the same family as `specs/INDEX.md` drift above, not a per-archive job.
 
 ## Error Handling
 
-**Missing or malformed design.md frontmatter (Task A)**: derive a candidate `specs_touched`/`decisions` from the change's own `proposal.md` and delta spec directories, present it to the user for explicit confirmation, and write the confirmed value back into `design.md` before Phase 1 runs for that change. Stop before Phase 1 for that change, with the field named, only if the user chooses to pause and fix it themselves, or if nothing in the change's own files supports a candidate at all.
+**Missing or malformed design.md frontmatter (Task A)**: derive a candidate `specs_touched`/`decisions` from the change's own `proposal.md` and delta spec directories, present it to the user for explicit confirmation, and write the confirmed value back into `design.md` before archive runs for that change. Stop before archive for that change, with the field named, only if the user chooses to pause and fix it themselves, or if nothing in the change's own files supports a candidate at all.
 
-**Missing `## Purpose` heading (Task B)**: don't block Phases 1–3 (they don't touch spec bodies), but stop before Phase 4 reaches that capability and ask the user to either add a placeholder or fix the spec first.
+**Missing `## Purpose` heading (Task B)**: don't block archive, validation, or cross-link computation (they don't touch spec bodies), but stop before spec writing reaches that capability and ask the user to either add a placeholder or fix the spec first.
 
-**A change touches only one capability**: `specs_touched` with a single entry produces zero pairs — that's expected, not an error. Still run Phase 4 for that capability (write `last_touched_by`/`last_touched_on`, regenerate `## Related Specs` even if its list is unchanged) and still add its row to `changes/archive/INDEX.md` in Phase 6.
+**A change touches only one capability**: `specs_touched` with a single entry produces zero pairs — that's expected, not an error. Still run spec writing for that capability (write `last_touched_by`/`last_touched_on`, regenerate `## Related Specs` even if its list is unchanged) and still add its row to `changes/archive/INDEX.md` in the changelog step.
 
-**Brand-new capability with no prior spec.md**: handled explicitly in Phase 0 step 4 and Phase 4 step 2 — the subagent starts from an empty frontmatter block rather than treating the missing file as an error.
+**Brand-new capability with no prior spec.md**: handled explicitly in preflight checks (step 4) and spec writing (step 19 substep 2) — the subagent starts from an empty frontmatter block rather than treating the missing file as an error.
 
-**Native command reports unresolved conflicts**: Phase 1 stops and reports the conflict verbatim to the user immediately without proceeding to extraction (its own step 8); do not proceed to Phase 2.
+**Native command reports unresolved conflicts**: the archive step stops and reports the conflict verbatim to the user immediately without proceeding to extraction (archive step 8); do not proceed to validation.
 
-**`/opsx:archive` or `/opsx:bulk-archive` branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see Phase 1 steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
+**`/opsx:archive` or `/opsx:bulk-archive` branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
 
-**No subagent support available for Phase 4** (e.g. an environment without sub-agent support): fall back to performing Phase 4's steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for Phase 4 only, not the intended default there, and normal operation should always prefer subagents for Phase 4. This has no bearing on Phase 1, which already runs in this context unconditionally by design regardless of sub-agent availability — see Phase 1.
+**No subagent support available for spec writing** (e.g. an environment without sub-agent support): fall back to performing spec-writing steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for spec writing only, not the intended default there, and normal operation should always prefer subagents for spec writing. This has no bearing on the archive step, which already runs in this context unconditionally by design regardless of sub-agent availability — see the Archive and Extract section.
 
-**`specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist yet**: expected on a project's first-ever archive. Create `changes/archive/INDEX.md` fresh with a header row (Phase 6 step 3); `specs/INDEX.md` is built fresh from every capability in Phase 5's bootstrap case, and patched row-by-row on every archive after that.
+**`specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist yet**: expected on a project's first-ever archive. Create `changes/archive/INDEX.md` fresh with a header row (step 23 substep 3); `specs/INDEX.md` is built fresh from every capability in the index update bootstrap case (step 20), and patched row-by-row on every archive after that.
 
-**`changes/archive/INDEX.md` has content after the table** (a total row count, a `Generated:` date, a status legend, or similar): insert new rows at the end of the table's existing data rows, immediately before that content — never after it. See Phase 6 step 2. Do not edit the trailing content itself, and do not treat a stale count within it as something this run needs to fix.
+**`changes/archive/INDEX.md` has content after the table** (a total row count, a `Generated:` date, a status legend, or similar): insert new rows at the end of the table's existing data rows, immediately before that content — never after it. See step 23 substep 2. Do not edit the trailing content itself, and do not treat a stale count within it as something this run needs to fix.
 
 ## NEVER Do This
 
-**NEVER run Phases 2–7 once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
+**NEVER stop between workflow steps and wait for user confirmation unless an error occurs** — this is a continuous workflow from preflight through final report. Once archive completes successfully, immediately proceed to validation, then cross-linking, and so on through the final report. The only legitimate stopping points are: (1) an error that requires user input to resolve, or (2) preflight failing. Do not treat the completion of `/opsx:archive` as a signal to stop and wait — it's a signal to continue to validation.
+
+**NEVER run validation through reporting once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
 
 **NEVER prune a `related:` entry** — this skill only unions. Removing an entry that looks stale is `accelint-archive-synthesis`'s job, and it requires human confirmation even there.
 
@@ -434,17 +420,17 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 **NEVER reorder or rewrite existing rows in `changes/archive/INDEX.md`** — append only. This file's value as an audit trail depends entirely on past rows staying exactly as they were written.
 
-**NEVER append a new row to `changes/archive/INDEX.md` by writing to the end of the file** — locate the end of the table's existing data rows (Phase 6 step 2) and insert there. The file may carry content after the table — a total row count, a `Generated:` date, a status legend — and writing to end-of-file instead of end-of-table lands a data row in prose after that content instead of inside the table, corrupting it.
+**NEVER append a new row to `changes/archive/INDEX.md` by writing to the end of the file** — locate the end of the table's existing data rows (step 23 substep 2) and insert there. The file may carry content after the table — a total row count, a `Generated:` date, a status legend — and writing to end-of-file instead of end-of-table lands a data row in prose after that content instead of inside the table, corrupting it.
 
 **NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
 
 **NEVER decline, skip, or second-guess a sync prompt during `/opsx:archive` or `/opsx:bulk-archive`** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
 
-**NEVER spawn a subagent for Phase 1, even when sub-agent support is available** — always run `/opsx:archive` or `/opsx:bulk-archive` directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See Phase 1 for the full account.
+**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run `/opsx:archive` or `/opsx:bulk-archive` directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
 
-**NEVER run Phase 4 directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
+**NEVER run spec writing directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
 
-**NEVER treat a mid-run branch in `/opsx:archive`/`/opsx:bulk-archive` (most commonly its own sync skill) as the end of Phase 1** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running Phase 1 inline in the first place.
+**NEVER treat a mid-run branch in `/opsx:archive`/`/opsx:bulk-archive` (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
 
 ## Example Usage
 
@@ -457,7 +443,7 @@ Skill: Running preflight checks...
 ✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
 ✓ Both capabilities have a ## Purpose heading
 
-Running /opsx:archive add-live-sync directly (Phase 1 never uses a subagent)...
+Running /opsx:archive add-live-sync directly (archive never uses a subagent)...
 Sync now? (y/n) → yes
 ✓ Synced delta specs, resuming /opsx:archive's remaining steps...
 ✓ /opsx:archive add-live-sync merged, archived to
@@ -540,7 +526,7 @@ User: Run bulk-archive on the pending changes
 Skill: Running preflight checks across 2 pending changes...
 ✓ All design.md frontmatter valid
 
-Running /opsx:bulk-archive directly (Phase 1 never uses a subagent)...
+Running /opsx:bulk-archive directly (archive never uses a subagent)...
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,
   merging in chronological order? (y/n)
@@ -555,4 +541,4 @@ Skill: ✓ Archived add-dark-mode, then update-footer, specs/ui/ merged in that 
 ...
 ```
 
-This is the scenario Phase 1 running inline actually unlocks: a subagent handed `/opsx:bulk-archive` has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running Phase 1 in this context means the question reaches the person who can actually answer it.
+This is the scenario archive running inline actually unlocks: a subagent handed `/opsx:bulk-archive` has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.4.0] - 2026-07-10
+
+### Changed
+- **Remove phase boundaries to prevent premature stopping:** Refactored from phase-based structure to continuous numbered steps
+  - Rationale: Phase headers like "### Phase 0: Preflight Checks", "### Phase 1: Questions", "### Phase 2: Research" create natural stopping points where agents might pause and check with the user mid-workflow, breaking the intended continuous execution flow
+  - Changed structure from:
+    - "### Phase 0: Preflight Checks" / "### Phase 1: Questions" / "### Phase 2: Research" / etc.
+    - To: Single "Implementation Steps" section with instruction "Execute these steps in order without stopping between them" followed by continuous numbered steps (1-N)
+  - Updated workflow diagram: "Phase" column → "Stage" column (higher-level groupings like "Questions", "Research", "Design")
+  - Updated all cross-references throughout (e.g., "Phase 1" → "Questions stage", "Phase 4" → step numbers)
+  - Removed all `**Steps:**` sub-headers that created additional stopping points within phases
+  - Integrated checkpoint instructions directly into the step sequence with clear conditions (e.g., "Step 26: STOP and wait for explicit user approval")
+  - Why: Agents tend to treat phase headers and "Steps:" sub-headers as checkpoint boundaries even when not intended. Continuous numbered steps with explicit STOP instructions only at mandatory checkpoints signal where the workflow should pause vs. continue atomically
+
+### Version
+- Bumped from 1.3.0 → 1.4.0
+
 ## [1.3.0] - 2026-07-08
 
 ### Added

--- a/skills/accelint-qrspi-propose/README.md
+++ b/skills/accelint-qrspi-propose/README.md
@@ -2,10 +2,6 @@
 
 Automate the planning phase of spec-driven development. This skill walks you through Questions → Research → Design → Structure (QRSPI), with mandatory review checkpoints before code gets written.
 
-**This is Phase 1 of a two-phase workflow:**
-- **Phase 1 (this skill)**: Plan the change (Questions → Research → Design → Structure)
-- **Phase 2** (`accelint-qrspi-apply`): Implement with intelligent parallelization
-
 ## What This Does
 
 Takes a ticket or feature request and produces a complete OpenSpec change:
@@ -14,9 +10,8 @@ Takes a ticket or feature request and produces a complete OpenSpec change:
 - Design document (decisions, trade-offs, architectural choices)
 - Delta specs (what changes in the system)
 - Task breakdown (vertical slices for implementation)
-- Parallelization strategy (which tasks can run concurrently)
 
-The skill stops after planning. You run `/accelint-qrspi-apply` (or `/opsx:apply` for manual implementation) when you're ready to implement.
+The skill stops after planning. You run `/opsx:apply` when you're ready to implement.
 
 ## When to Use This
 
@@ -58,24 +53,9 @@ openspec update
 
 The skill will check this before running and guide you if configuration is needed.
 
-## Two-Phase QRSPI Workflow
-
-This skill is Phase 1 (Planning). After completion, you proceed to Phase 2 (Implementation).
-
-| Phase | Skill | Purpose | Output |
-|-------|-------|---------|--------|
-| 1 | `accelint-qrspi-propose` (this skill) | Plan the change | OpenSpec artifacts (proposal, design, specs, tasks) |
-| 2 | `accelint-qrspi-apply` | Implement with parallelization | Working code, tests, validation |
-
-The separation allows you to:
-- Plan multiple changes before implementing any
-- Review and refine plans without wasting implementation effort
-- Clear context between planning and coding
-- Parallelize implementation across independent task slices
-
 ## How It Works
 
-### The Five Planning Phases
+### The Five-Phase Workflow
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -107,15 +87,11 @@ Mandatory checkpoint: You review the design before continuing. This is the "brai
 
 Generate delta specs and task breakdown. A sub-agent receives questions + research + approved design (NO ticket) and creates remaining artifacts with emphasis on vertical slicing.
 
-The skill automatically validates that tasks use vertical slicing (end-to-end feature deliverables) rather than horizontal slicing (architectural layers). If horizontal slicing is detected, the skill converts it to vertical slices automatically.
-
-The skill also ensures a "Parallelization Strategy" section exists in tasks.md, identifying which slices can run in parallel and which have sequential dependencies.
-
 Mandatory checkpoint: You review the task breakdown to ensure vertical slicing (not layer-by-layer).
 
 #### Phase 5: Completion
 
-The skill reports completion and exits. You decide when to run `/accelint-qrspi-apply` (for parallel implementation) or `/opsx:apply` (for manual implementation) to start building.
+The skill reports completion and exits. You decide when to run `/opsx:apply` to start implementation.
 
 ## Key Concepts
 
@@ -163,18 +139,7 @@ Phase 3: All API changes
 Phase 4: All frontend changes
 ```
 
-The skill checks for horizontal slicing and automatically converts to vertical slicing if detected.
-
-### Parallelization Strategy
-
-After task generation, the skill ensures tasks.md includes a "Parallelization Strategy" section that identifies:
-
-- **Independent slices**: Tasks that can run in parallel with no blocking dependencies
-- **Sequential dependencies**: Tasks that must complete before others can start
-- **Critical path**: The longest chain of dependent tasks
-- **Recommended order**: Suggested implementation sequence for optimal parallelization
-
-This section is consumed by `accelint-qrspi-apply` (Phase 2) to orchestrate parallel sub-agent execution. If the section is missing or incomplete, the skill adds it automatically.
+The skill checks for horizontal slicing and warns you if detected.
 
 ### No Automatic Implementation
 
@@ -184,9 +149,7 @@ The skill stops after planning. This allows:
 - Clearing context between planning and coding
 - User control over when implementation begins
 
-Run `/clear` and then:
-- `/accelint-qrspi-apply` to implement with intelligent parallelization (recommended for multi-slice changes)
-- `/opsx:apply` to implement manually (for simpler changes or when you want direct control)
+Run `/clear` and `/opsx:apply` when you're ready to start building.
 
 ## Example Usage
 
@@ -241,7 +204,7 @@ Generated artifacts:
 Next steps:
 1. Review the artifacts one more time if needed
 2. Run /clear to start fresh context for implementation
-3. Run /accelint-qrspi-apply to begin parallel implementation
+3. Run /opsx:apply to begin implementation
 ```
 
 ## Configuration Requirements
@@ -263,30 +226,19 @@ If a sub-agent fails, you'll see the error and can retry that phase or provide m
 
 If artifacts are missing after generation, the skill checks file paths and provides the expected locations for manual inspection.
 
-## Important Notes
-
-### Vertical vs Horizontal Slicing
-
-The skill automatically detects and converts horizontal (layer-by-layer) task structures to vertical (end-to-end feature) slices. Each slice should:
-- Deliver a working, testable increment
-- Cross architectural boundaries
-- Be demonstrable to stakeholders
-- Have minimal dependencies on other slices
-
 ## Tips
 
 Start with clear tickets. The better the input, the better the questions. Include constraints, performance targets, and existing patterns to follow.
 
 The design checkpoint is your leverage point. A 5-minute review here prevents hours of rework later.
 
-Trust the skill's vertical slicing validation. Layer-by-layer development hides integration issues until the end.
+If the skill warns about horizontal slicing, listen. Layer-by-layer development hides integration issues until the end.
 
 Don't rush to implementation. It's fine to create multiple specs before coding. Planning artifacts are cheap; code is expensive.
 
 ## Related Skills
 
-- `accelint-qrspi-apply` - **Phase 2**: Implement QRSPI-planned changes with intelligent parallelization (recommended for multi-slice changes)
 - `accelint-onboard-openspec` - Set up OpenSpec configuration for your project
 - `accelint-onboard-agent` - Create AGENTS.md with behavior rules
-- `opsx:apply` - Manual implementation alternative to accelint-qrspi-apply
+- `opsx:apply` - Implement tasks from the generated change
 - `opsx:verify` - Verify implementation matches artifacts before archiving

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Automate the QRSPI + OpenSpec planning workflow (Questions → Rese
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Accelint QRSPI
@@ -43,7 +43,7 @@ openspec update
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Phase          Context              Output          Checkpoint │
+│  Stage          Context              Output          Checkpoint │
 ├─────────────────────────────────────────────────────────────────┤
 │  Questions      Ticket only          Questions       —          │
 │  Research       Questions only       Research doc    —          │
@@ -60,27 +60,25 @@ openspec update
 │  Done           —                    Exit            —          │
 └─────────────────────────────────────────────────────────────────┘
 
-Note: Ticket is kept OUT of context after Phase 1 to prevent completion bleed.
+Note: Ticket is kept OUT of context after Questions stage to prevent completion bleed.
 
-Critical: Phase 3 generates ONLY proposal.md and design.md, then STOPS for review.
-Phase 5 generates specs/* and tasks.md separately after design approval.
+Critical: Design stage (steps 17-25) generates ONLY proposal.md and design.md, then
+STOPS for review at step 26. Specs/Tasks stage (steps 32-42) generates specs/* and
+tasks.md separately after design approval.
 
-Frontmatter capture happens after Checkpoint 1 approval, not before — design.md
-is only in its final form once the user has approved it or confirmed a manual
-edit, so capturing specs_touched/decisions any earlier risks writing frontmatter
-against content the user is about to change.
+Frontmatter capture happens at step 30 after Checkpoint 1 approval, not before —
+design.md is only in its final form once the user has approved it or confirmed a
+manual edit, so capturing specs_touched/decisions any earlier risks writing
+frontmatter against content the user is about to change.
 
 ⚠️  MANDATORY CHECKPOINTS: The agent MUST pause and wait for explicit user approval
-at both checkpoints. Proceeding without approval bypasses QRSPI's core value.
+at both checkpoints (step 26 and step 43). Proceeding without approval bypasses
+QRSPI's core value.
 ```
 
-## Phase Breakdown
+## Implementation Steps
 
-### Phase 0: Preflight Checks
-
-Before starting, verify the user provided input and OpenSpec has the required workflows enabled.
-
-**Steps**:
+Execute these steps in order without stopping between them:
 
 1. **Validate user input**: Check if the user provided a ticket, feature request, or idea in their prompt (either as skill arguments or in their message). If the prompt is empty or contains only the skill invocation with no actual content:
    ```
@@ -95,8 +93,11 @@ Before starting, verify the user provided input and OpenSpec has the required wo
    Exit the skill and wait for the user to provide input. Do NOT proceed with internal examples or placeholder content.
 
 2. Tell the user: "Checking OpenSpec configuration..."
+
 3. Run `openspec config list` and parse the output
+
 4. Check if the `workflows:` section contains all three required workflows: `explore`, `new`, and `continue`
+
 5. If any are missing:
    ```
    This skill requires the expanded OpenSpec workflows (explore, new, continue).
@@ -112,19 +113,16 @@ Before starting, verify the user provided input and OpenSpec has the required wo
 
    Then re-run this skill.
    ```
+
 6. Exit the skill if required workflows are not enabled
-7. If validation passes and all workflows are present, proceed to Phase 1
 
-### Phase 1: Questions (Ticket Context → Questions)
+7. If validation passes and all workflows are present, continue to step 8
 
-**Goal**: Generate research questions from the ticket, without proposing solutions.
+8. **Generate research questions** (Context isolation: agent sees ONLY the ticket, not prior codebase knowledge or research. This prevents solution-first thinking)
 
-**Context isolation**: The agent generating questions should see ONLY the ticket, not prior codebase knowledge or research. This prevents solution-first thinking.
+9. Accept the ticket description from the user (passed as the skill argument or prompted if missing)
 
-**Steps**:
-
-1. Accept the ticket description from the user (passed as the skill argument or prompted if missing)
-2. Spawn a sub-agent with this exact prompt:
+10. Spawn a sub-agent with this exact prompt:
 
    ```
    /opsx:explore
@@ -137,45 +135,33 @@ Before starting, verify the user provided input and OpenSpec has the required wo
    to know before building this. Do not propose any solutions. Questions only.
    ```
 
-3. Wait for the sub-agent to complete and return the questions
-4. Extract and store the questions — they will be passed to the next phase
+11. Wait for the sub-agent to complete and return the questions
 
-**Output**: A structured list of research questions (no answers yet)
+12. Extract and store the questions — they will be passed to the next step
 
-### Phase 2: Research (Questions Only → Research Doc)
+13. **Answer research questions** (Context isolation: The agent answering questions should see ONLY the questions, not the original ticket. This is the core QRSPI insight — research is objective, ticket-agnostic)
 
-**Goal**: Answer the questions with objective facts from the codebase AND existing specs, without the ticket bleeding into research.
-
-**Context isolation**: The agent answering questions should see ONLY the questions, not the original ticket. This is the core QRSPI insight — research is objective, ticket-agnostic.
-
-**Steps**:
-
-1. Spawn a NEW sub-agent (fresh context) with this exact prompt:
+14. Spawn a NEW sub-agent (fresh context) with this exact prompt:
 
    ```
    /opsx:explore
 
-   [paste ONLY the research questions from Phase 1]
+   [paste ONLY the research questions from step 12]
 
    Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
    ```
 
-2. Wait for the sub-agent to complete and return the research document
-3. Store the research answers — they will inform the design phase
+15. Wait for the sub-agent to complete and return the research document
 
-**Output**: A research document with objective answers to all questions, including relevant current spec content
+16. Store the research answers — they will inform the design step
 
-### Phase 3: Design Scaffolding
+17. **Generate design scaffolding** (Context isolation: The ticket should NOT be in context during artifact generation to prevent "completion bleed". Spawn a sub-agent with only questions + research)
 
-**Goal**: Create the OpenSpec change and generate proposal.md and design.md artifacts.
+18. Read `openspec/config.yaml` to extract the `rules.design` section
 
-**Context isolation**: The ticket should NOT be in context during artifact generation to prevent "completion bleed". Spawn a sub-agent with only questions + research.
+19. Read `CLAUDE.md` or `AGENTS.md` to extract agent behavior context
 
-**Steps**:
-
-1. Read `openspec/config.yaml` to extract the `rules.design` section
-2. Read `CLAUDE.md` or `AGENTS.md` to extract agent behavior context
-3. Spawn a sub-agent with this exact prompt:
+20. Spawn a sub-agent with this exact prompt:
 
    ```
    You are generating OpenSpec artifacts based on QRSPI research. You have access
@@ -183,10 +169,10 @@ Before starting, verify the user provided input and OpenSpec has the required wo
    prevents solution bias.
 
    Research Questions and Answers:
-   [paste questions from Phase 1]
+   [paste questions from step 12]
 
    Research Findings:
-   [paste research doc from Phase 2]
+   [paste research doc from step 16]
 
    OpenSpec Design Rules (from config.yaml):
    [paste the rules.design section verbatim]
@@ -217,33 +203,25 @@ Before starting, verify the user provided input and OpenSpec has the required wo
    "Change name: <slug>"
 
    CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
-   Your job ends here. The parent agent will handle the checkpoint and Phase 5.
+   Your job ends here. The parent agent will handle the checkpoint and further steps.
    If you generate specs/* or tasks.md, you will bypass the mandatory design review.
    ```
 
-4. Wait for the sub-agent to complete
-5. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
-6. Store the change name — it will be passed to Phase 5
-7. Verify the design.md file exists at the reported path
-8. CRITICAL: DO NOT continue to Phase 5 yet. You MUST proceed to Phase 4 checkpoint.
-9. Proceed to Phase 4 (mandatory checkpoint)
+21. Wait for the sub-agent to complete
 
-**Output**: Generated `proposal.md` and `design.md` in `openspec/changes/<slug>/`
+22. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
 
-### Phase 4: Design Review Checkpoint ⚠️ MANDATORY
+23. Store the change name — it will be passed to later steps
 
-**Goal**: Get human approval before proceeding to task breakdown.
+24. Verify the design.md file exists at the reported path
 
-This is the "brain surgery" moment from the QRSPI talk — a correction here costs minutes; the same correction after implementation costs a code review cycle.
+25. CRITICAL: DO NOT continue yet. You MUST proceed to the design review checkpoint next.
 
-CRITICAL: You MUST pause here and wait for user input. DO NOT proceed to Phase 5
-without explicit user approval. If you skip this checkpoint, you defeat the entire
-purpose of QRSPI's separation of design from implementation planning.
+26. ⚠️ **MANDATORY CHECKPOINT: Design Review** (This is the "brain surgery" moment from the QRSPI talk — a correction here costs minutes; the same correction after implementation costs a code review cycle. You MUST pause here and wait for user input. DO NOT proceed without explicit user approval)
 
-**Steps**:
+27. Read the generated `design.md` file
 
-1. Read the generated `design.md` file
-2. Present it to the user with this framing:
+28. Present it to the user with this framing:
 
    ```
    Design artifact generated. Please review for:
@@ -259,8 +237,8 @@ purpose of QRSPI's separation of design from implementation planning.
    (c) Manual edit — edit the file yourself, then tell me when ready
    ```
 
-3. Wait for user input:
-   - **(a) Approve**: Proceed to step 4 below
+29. Wait for user input:
+   - **(a) Approve**: Proceed to step 30 below
    - **(b) Request edits**:
      - User describes changes
      - Make edits to design.md in place
@@ -269,17 +247,17 @@ purpose of QRSPI's separation of design from implementation planning.
    - **(c) Manual edit**:
      - Wait for user confirmation that edits are complete
      - Re-read design.md
-     - Proceed to step 4 below
+     - Proceed to step 30 below
 
-4. **Capture specs_touched/decisions frontmatter.** Once the user has approved (a) or confirmed their manual edits are complete (c), design.md is in its final form for this planning pass — capture its `specs_touched` and `decisions` as structured YAML frontmatter now, not any earlier, so an edit made during this same checkpoint can't leave the frontmatter stale against content that changed after it was written.
+30. **Capture specs_touched/decisions frontmatter.** Once the user has approved (a) or confirmed their manual edits are complete (c), design.md is in its final form for this planning pass — capture its `specs_touched` and `decisions` as structured YAML frontmatter now, not any earlier, so an edit made during this same checkpoint can't leave the frontmatter stale against content that changed after it was written.
 
-   - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (Phase 5 generates those), so there's nothing else to derive it from.
+   - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
    - **`decisions`**: design.md's own decision content — the choices, rationale, and alternatives the design phase already worked through — restructured into a list of `{id, choice, rationale, alternatives}` entries. This is structuring content that's already there, not writing new design content.
    - Write both into design.md's YAML frontmatter:
 
      ```yaml
      ---
-     change: <change-name-from-phase-3>
+     change: <change-name-from-step-23>
      specs_touched: [capability-a, capability-b]
      decisions:
        - id: D1
@@ -289,45 +267,36 @@ purpose of QRSPI's separation of design from implementation planning.
      ---
      ```
 
+   **CRITICAL: Use inline array syntax for specs_touched** — Write `specs_touched: [cap-a, cap-b]` NOT multi-line YAML with hyphens. This keeps frontmatter format consistent with other fields that use inline arrays.
+
    - If design.md already starts with a frontmatter block (e.g. OpenSpec's own metadata), merge into it rather than writing a second block.
    - If `specs_touched` or a clear decisions list can't be confidently read out of the approved design.md/proposal.md, don't guess at either — tell the user what's missing and ask them to add it to design.md directly. A design doc without a clear decisions trail is worth flagging on its own terms, and `accelint-qrspi-archive` needs this frontmatter later to do its cross-capability linking.
    - This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content `/opsx:continue` generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
 
-5. Proceed to Phase 5.
+31. CRITICAL: If the user does not explicitly approve (says "looks good", "approve", "continue", etc.), DO NOT move forward. This checkpoint is mandatory - skipping it bypasses the core value of QRSPI methodology.
 
-**Output**: An approved `design.md` with `specs_touched`/`decisions` captured in its YAML frontmatter, ready for `accelint-qrspi-archive` to read at archive time.
+32. **Generate specs and tasks** (Context isolation: Continue to keep ticket out of context. Spawn a sub-agent with questions + research + approved design.md)
 
-**CRITICAL: DO NOT PROCEED TO PHASE 5 WITHOUT EXPLICIT USER APPROVAL.**
+33. Read the (possibly user-edited) design.md file from step 30
 
-If the user does not explicitly approve (says "looks good", "approve", "continue", etc.),
-DO NOT move forward. This checkpoint is mandatory - skipping it bypasses the core value
-of QRSPI methodology.
+34. Read `openspec/config.yaml` to extract the `rules.spec` and `rules.tasks` sections
 
-### Phase 5: Specs & Tasks Generation
+35. Read `CLAUDE.md` or `AGENTS.md` for agent behavior context
 
-**Goal**: Generate delta specs and task breakdown with vertical slicing.
-
-**Context isolation**: Continue to keep ticket out of context. Spawn a sub-agent with questions + research + approved design.md.
-
-**Steps**:
-
-1. Read the (possibly user-edited) design.md file from Phase 4
-2. Read `openspec/config.yaml` to extract the `rules.spec` and `rules.tasks` sections
-3. Read `CLAUDE.md` or `AGENTS.md` for agent behavior context
-4. Spawn a sub-agent with this exact prompt:
+36. Spawn a sub-agent with this exact prompt:
 
    ```
    You are generating OpenSpec specs and tasks based on QRSPI research and an
    approved design. You have access to research and design, but NOT the original
    ticket text.
 
-   CHANGE NAME: <change-name-from-phase-3>
+   CHANGE NAME: <change-name-from-step-23>
 
    Research Questions and Answers:
-   [paste questions from Phase 1]
+   [paste questions from step 12]
 
    Research Findings:
-   [paste research doc from Phase 2]
+   [paste research doc from step 16]
 
    Approved Design:
    [paste design.md content]
@@ -359,10 +328,13 @@ of QRSPI methodology.
    After tasks.md is generated, report completion and the path to the tasks file.
    ```
 
-5. Wait for the sub-agent to complete
-6. Verify specs/* and tasks.md exist at the reported paths
-7. Read the generated `tasks.md` file
-8. Validate vertical slicing structure:
+37. Wait for the sub-agent to complete
+
+38. Verify specs/* and tasks.md exist at the reported paths
+
+39. Read the generated `tasks.md` file
+
+40. Validate vertical slicing structure:
 
    **VERTICAL SLICING (required for qrspi-apply)**:
 
@@ -379,10 +351,10 @@ of QRSPI methodology.
 
    ✗ WRONG - Horizontal (architectural layers):
    ```
-   Phase 1: All database migrations
-   Phase 2: All service layer changes
-   Phase 3: All API endpoints
-   Phase 4: All frontend components
+   Slice 1: All database migrations
+   Slice 2: All service layer changes
+   Slice 3: All API endpoints
+   Slice 4: All frontend components
    ```
 
    **Indicators of VERTICAL slicing (correct)**:
@@ -405,7 +377,7 @@ of QRSPI methodology.
    - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
    - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
 
-9. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
+41. If horizontal or mixed slicing detected, **automatically convert to vertical slices**:
 
    CRITICAL: The qrspi-apply skill requires vertical slicing. If /opsx:continue
    generated horizontal slices, you MUST restructure them before presenting to the user.
@@ -434,14 +406,14 @@ of QRSPI methodology.
    d) **Update Parallelization Strategy (if it exists)**: If the tasks.md already has
       a "## Parallelization Strategy" section, revise it to reflect the new slice
       structure (which slices can run in parallel, which have dependencies).
-      Note: If the section doesn't exist, the parent agent will add it in step 10.
+      Note: If the section doesn't exist, it will be added in step 42.
 
    e) **Write changes to tasks.md**: Edit the file in place using the Edit tool
 
    f) **Show diff to user**: Display what changed and explain why (e.g., "Converted
       from layer-based to feature-based slices for better parallelization")
 
-10. **CRITICAL: Check for and add Parallelization Strategy section**:
+42. **CRITICAL: Check for and add Parallelization Strategy section**:
 
    After vertical slicing is validated/corrected, check if tasks.md contains a
    "## Parallelization Strategy" section.
@@ -480,10 +452,10 @@ of QRSPI methodology.
    DO NOT overcomplicate with excessive detail or edge cases.
 
    **If the section exists but was part of a horizontal-to-vertical conversion**
-   (step 9d), verify it accurately reflects the new vertical slice structure and
+   (step 41d), verify it accurately reflects the new vertical slice structure and
    update if needed.
 
-11. Present tasks.md to the user for final approval:
+43. ⚠️ **MANDATORY CHECKPOINT: Tasks Review** - Present tasks.md to the user for final approval:
 
    ```
    Specs and tasks generated.
@@ -501,25 +473,16 @@ of QRSPI methodology.
    (c) Manual edit — edit tasks.md yourself, then confirm
    ```
 
-12. Handle user input (same flow as Phase 4: approve, request edits, or manual edit)
+44. Handle user input (same flow as step 29: approve, request edits, or manual edit)
 
-**CRITICAL: DO NOT PROCEED TO PHASE 6 WITHOUT EXPLICIT USER APPROVAL.**
+45. CRITICAL: Wait for the user to explicitly approve the tasks.md structure. If they don't respond or the conversation ends, stop here - do not auto-proceed to completion.
 
-Wait for the user to explicitly approve the tasks.md structure. If they don't respond
-or the conversation ends, stop here - do not auto-proceed to completion.
-
-**Output**: Generated `specs/*` and `tasks.md` in `openspec/changes/<slug>/`
-
-### Phase 6: Completion
-
-After tasks.md is approved:
-
-1. Announce completion:
+46. **Completion** - After tasks.md is approved, announce completion:
 
    ```
    ✅ QRSPI planning phase complete.
 
-   Change name: <change-name-from-phase-3>
+   Change name: <change-name-from-step-23>
 
    Generated artifacts:
    - openspec/changes/<change-slug>/proposal.md
@@ -536,7 +499,7 @@ After tasks.md is approved:
    maintains proper context management.
    ```
 
-2. Exit the skill — do NOT automatically invoke `/accelint-qrspi-apply`
+47. Exit the skill — do NOT automatically invoke `/accelint-qrspi-apply`
 
 ## Key Principles
 
@@ -560,7 +523,7 @@ These are the highest-leverage moments for corrections — before any code is wr
 
 ### Vertical Slicing Enforcement
 
-The skill should actively check for and discourage horizontal (layer-by-layer) slicing. Each phase should deliver a testable end-to-end slice.
+The skill should actively check for and discourage horizontal (layer-by-layer) slicing. Each slice should deliver a testable end-to-end slice.
 
 ### No Automatic Implementation
 
@@ -575,17 +538,17 @@ The skill stops after planning. The user explicitly runs `/accelint-qrspi-apply`
 **If OpenSpec commands fail**:
 - Surface the error to the user
 - Ask if they want to retry or abort
-- Do not continue to next phase on failure
+- Do not continue to next step on failure
 
 **If sub-agent fails**:
 - Show the error from the sub-agent
-- Ask user if they want to retry that phase or provide manual input
+- Ask user if they want to retry that step or provide manual input
 - Allow manual fallback (user provides questions/research directly)
 
-**If `specs_touched` or `decisions` can't be confidently read out of approved design.md/proposal.md (Phase 4 step 4)**:
+**If `specs_touched` or `decisions` can't be confidently read out of approved design.md/proposal.md (step 30)**:
 - Do not guess. Show the user what's missing (e.g. "no capability declarations found" or "no decisions with a stated rationale")
-- Ask them to add it to design.md directly, then re-run step 4
-- Do not block Phase 5 on this — a change can proceed to specs/tasks without this frontmatter, it just means `accelint-qrspi-archive` will need to derive it later from proposal.md and the by-then-existing delta specs instead of reading it straight from frontmatter
+- Ask them to add it to design.md directly, then re-run step 30
+- Do not block later steps on this — a change can proceed to specs/tasks without this frontmatter, it just means `accelint-qrspi-archive` will need to derive it later from proposal.md and the by-then-existing delta specs instead of reading it straight from frontmatter
 
 **If design.md or tasks.md is missing after generation**:
 - Check if the file exists at expected path
@@ -605,23 +568,23 @@ If any of these are missing, guide the user to set them up before running this s
 
 ## NEVER Do This
 
-**NEVER generate artifacts yourself** — Always use /opsx commands (new, continue) to create proposal.md, design.md, specs/*, and tasks.md. The /opsx workflow handles artifact generation following OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design/spec/task rules and create inconsistent outputs. The one narrow exception is Phase 4 step 4's `specs_touched`/`decisions` frontmatter block: that's cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content `/opsx:continue` already generated and the user already approved — not new design content. Even there, only the YAML frontmatter block is written; the design.md body is never touched by this step.
+**NEVER generate artifacts yourself** — Always use /opsx commands (new, continue) to create proposal.md, design.md, specs/*, and tasks.md. The /opsx workflow handles artifact generation following OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design/spec/task rules and create inconsistent outputs. The one narrow exception is step 30's `specs_touched`/`decisions` frontmatter block: that's cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content `/opsx:continue` already generated and the user already approved — not new design content. Even there, only the YAML frontmatter block is written; the design.md body is never touched by this step.
 
-**NEVER generate tasks.md from scratch** — Always use /opsx:continue to create the initial tasks.md. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If /opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) following the validation guidance in Phase 5 Step 10. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert to numbered lists or plain bullets.
+**NEVER generate tasks.md from scratch** — Always use /opsx:continue to create the initial tasks.md. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If /opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) following the validation guidance in step 41. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert to numbered lists or plain bullets.
 
 **NEVER use numbered lists or plain bullets in tasks.md** — All subtasks must use markdown checklist format: `- [ ] instruction`. The qrspi-apply skill tracks completion by checking/unchecking these boxes. If you see numbered lists (1. 2. 3.) or plain bullets (- without [ ]), convert them to `- [ ] ...` format.
 
 **NEVER overcomplicate Parallelization Strategy** — Keep it simple: list which slices can run in parallel, which have sequential dependencies, and recommended implementation order. Don't add excessive detail about every possible edge case or coordination mechanism. The example in this skill shows the right level of detail.
 
-**NEVER continue to specs/tasks without design approval** — Phase 4 checkpoint is mandatory. If you skip the design review and generate tasks immediately, you miss the "brain surgery" moment where corrections are cheap. Fixing design issues after code is written costs review cycles and rework.
+**NEVER continue to specs/tasks without design approval** — Step 26 checkpoint is mandatory. If you skip the design review and generate tasks immediately, you miss the "brain surgery" moment where corrections are cheap. Fixing design issues after code is written costs review cycles and rework.
 
-**NEVER capture specs_touched/decisions frontmatter before design.md is in its final, approved state** — Phase 4 step 4 runs only after (a) approval or (c) confirmed manual edits, never during a (b) request-edits loop or speculatively ahead of approval. Capturing it against a draft that's still being revised is exactly the kind of stale metadata `accelint-qrspi-archive` depends on this skill not producing.
+**NEVER capture specs_touched/decisions frontmatter before design.md is in its final, approved state** — Step 30 runs only after (a) approval or (c) confirmed manual edits, never during a (b) request-edits loop or speculatively ahead of approval. Capturing it against a draft that's still being revised is exactly the kind of stale metadata `accelint-qrspi-archive` depends on this skill not producing.
 
 **NEVER guess specs_touched or decisions when they can't be confidently read out of the approved design.md/proposal.md** — ask the user to add what's missing to design.md directly instead. A silently invented capability list is worse than a visible gap, since `accelint-qrspi-archive` will trust this frontmatter as the author's explicit statement of scope.
 
 **NEVER let the ticket leak into research/design context** — Questions are generated WITH ticket context, but research and design must see ONLY questions + research answers. If the ticket stays in context during research, the agent will propose solutions instead of gathering objective facts about the current codebase.
 
-**NEVER skip the mandatory checkpoints** — Phase 4 (after design.md) and Phase 5 Step 12 (after tasks.md) require explicit user approval before continuing. If you proceed without waiting for user confirmation ("looks good", "approve", "continue"), you bypass the core value of QRSPI: cheap corrections at the design stage. The "brain surgery" moment is when design is reviewed BEFORE specs/tasks are generated. Skipping checkpoints defeats the entire methodology.
+**NEVER skip the mandatory checkpoints** — Step 26 (after design.md) and Step 43 (after tasks.md) require explicit user approval before continuing. If you proceed without waiting for user confirmation ("looks good", "approve", "continue"), you bypass the core value of QRSPI: cheap corrections at the design stage. The "brain surgery" moment is when design is reviewed BEFORE specs/tasks are generated. Skipping checkpoints defeats the entire methodology.
 
 ## Example Usage
 


### PR DESCRIPTION
Remove phase boundaries entirely. Instead of "Phase 1: Archive, Phase 2: Validate", write it as one continuous numbered list: "Step 1: Run archive, Step 2: Extract records from the result, Step 3: Validate records, Step 4: Compute pairs..." No natural stopping points.

- "### Phase 0: Preflight Checks"
- "### Phase 1: Questions"
- "### Phase 2: Research"

These create natural stopping points where an agent might think "I've completed a phase, let me check with the user."