### PR TITLE
feat: prose adjustments

### DIFF
--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.5.0] - 2026-07-22
+
+### Changed
+- **Strengthened question-generation guidance** — the questions sub-agent now explicitly walks the problem tree branch-by-branch, avoids solutioning, and aims for empirically answerable technical questions rather than broad prompts
+  - Rationale: The branch updates tighten the front end of QRSPI so research starts from sharper, dependency-aware questions instead of vague discovery prompts that can miss critical unknowns.
+- **Raised the bar for research-answer objectivity** — the research sub-agent now requires 100% factual findings, explicitly forbids opinions/suggestions/editorializing, and calls out unanswered questions when the codebase or specs do not provide evidence
+  - Rationale: QRSPI depends on a clean separation between research and design. Making the research prompt stricter reduces solution bleed and gives the later design step a more reliable factual base.
+- **Refined skill prose for tighter execution behavior** — wording updates make the Questions and Research steps more explicit about what good output looks like without changing the broader workflow introduced in 1.4.0
+  - Rationale: These branch-level prompt refinements are small in scope but materially improve consistency in how sub-agents interpret the planning workflow.
+
+### Version
+- Bumped from 1.4.0 → 1.5.0
+
 ## [1.4.0] - 2026-07-10
 
 ### Changed

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -131,8 +131,19 @@ Execute these steps in order without stopping between them:
 
    [paste full ticket description here]
 
+   Walk down each branch of the decision tree, resolving dependencies between 
+   decisions one-by-one.
+
    Generate a list of research questions that will tell us everything we need
-   to know before building this. Do not propose any solutions. Questions only.
+   to know before building this. Do NOT propose any solutions. Questions ONLY.
+
+   These questions must be detailed. For example, rather than "How do we handle 
+   payments?", ask "The ticket mentions integrating Stripe, but payment.ts 
+   currently uses a hardcoded PayPal SDK instance. Are we replacing Paypal 
+   entirely,  or building a factory to support both?"
+
+   You MUST dig deep enough to formulate highly specific, file-based 
+   technical questions.
    ```
 
 11. Wait for the sub-agent to complete and return the questions
@@ -148,7 +159,7 @@ Execute these steps in order without stopping between them:
 
    [paste ONLY the research questions from step 12]
 
-   Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
+   Answer each question with 100% facts only. Include exact file:line references where possible. Zero opinions. Zero suggestions. Zero implementation Ideas. Do not critique code quality, and do not editorialize. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file).
    ```
 
 15. Wait for the sub-agent to complete and return the research document

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Automate the QRSPI + OpenSpec planning workflow (Questions → Rese
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Accelint QRSPI

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -131,8 +131,8 @@ Execute these steps in order without stopping between them:
 
    [paste full ticket description here]
 
-   Walk down each branch of the decision tree, resolving dependencies between 
-   decisions one-by-one.
+   Walk down each branch of the problem statement tree, resolving dependencies between 
+   problems one-by-one.
 
    Generate a list of research questions that will tell us everything we need
    to know before building this. Do NOT propose any solutions. Questions ONLY.
@@ -142,8 +142,7 @@ Execute these steps in order without stopping between them:
    currently uses a hardcoded PayPal SDK instance. Are we replacing Paypal 
    entirely,  or building a factory to support both?"
 
-   You MUST dig deep enough to formulate highly specific, file-based 
-   technical questions.
+   You MUST dig deep enough to formulate empirical and robust technical questions.
    ```
 
 11. Wait for the sub-agent to complete and return the questions
@@ -159,7 +158,7 @@ Execute these steps in order without stopping between them:
 
    [paste ONLY the research questions from step 12]
 
-   Answer each question with 100% facts only. Include exact file:line references where possible. Zero opinions. Zero suggestions. Zero implementation Ideas. Do not critique code quality, and do not editorialize. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file).
+   Answer each question with 100% facts only. Zero opinions. Zero suggestions. Zero implementation ideas. Do not critique code quality, and do not editorialize. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Note questions you were unable to empirically answer.
    ```
 
 15. Wait for the sub-agent to complete and return the research document


### PR DESCRIPTION
Will provide comments below showing difference in artifact output.

Prompt used for all tests, only change was SKILL.md contents:

```markdown
/accelint-qrspi-propose 

## Goal

I want to create a <widget widget={new Widget()} /> component for the deck.gl react renderer. Widgets references can be found here:

- https://deck.gl/docs/api-reference/widgets/overview
- https://deck.gl/docs/api-reference/widgets/stats-widget
- https://deck.gl/docs/api-reference/widgets/styling

## Additional Tasks

1. When you go to generate questions during your QRSPI flow, add them to a `questions.md` file in the openspec change folder.
2. When you fact find answers to questions with research during your QRSPI flow, add them to a `answers.md` file in the openspec change folder.

## Notes

- Execute `openspec` commands with `pnpm openspec`
```