### PR TITLE
fix: consistent link location in doc skills

### DIFF
--- a/skills/accelint-architecture-doc/CHANGELOG.md
+++ b/skills/accelint-architecture-doc/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-08-11
+
+### Fixed
+- **Consistent link location in agent behavior files** — changed ARCHITECTURE.md link placement from near-the-top to within a "Related Documentation" section at the bottom
+  - Now adds/updates a "Related Documentation" section with structured list format
+  - Preserves existing entries if section already exists
+  - Matches the established pattern used across other documentation skills
+  - Rationale: Standardizes cross-reference location across all doc-generating skills, making agent behavior files more predictable and easier to maintain
+
 ## [1.1.0] - 2026-07-08
 
 ### Added

--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -4,7 +4,7 @@ description: Generate or update an ARCHITECTURE.md living document for any codeb
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.1.1"
 ---
 
 # Architecture Doc

--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -275,13 +275,19 @@ ARCHITECTURE.md is a pure technical document about system structure and should n
 
 After writing ARCHITECTURE.md, if Agent A found AGENTS.md or CLAUDE.md (check in that order):
 
-1. **Read the agent behavior file** to check whether it already mentions ARCHITECTURE.md
-2. **If no reference exists,** add this block near the top of the file (after any existing title/header, before main content):
+1. **Read the agent behavior file** to check whether it already has a "Related Documentation" section
+2. **If no "Related Documentation" section exists,** create one at the bottom of the file with this structure:
 
 ```markdown
-## System Architecture
+## Related Documentation
 
-For technical architecture details (components, deployment, data stores, tech stack), see [ARCHITECTURE.md](./ARCHITECTURE.md).
+- **ARCHITECTURE.md** — System architecture, deployment overview, component interactions
+  *(Reference this when behavioral decisions depend on understanding system structure)*
 ```
 
-3. **If using CLAUDE.md** and it simply points to AGENTS.md (e.g., `@AGENTS.md`), update AGENTS.md instead — don't modify the pointer file.
+3. **If a "Related Documentation" section already exists:**
+   - Check if ARCHITECTURE.md is already listed
+   - If not listed, add it to the section following the pattern above
+   - Preserve existing entries in the section
+
+4. **If using CLAUDE.md** and it simply points to AGENTS.md (e.g., `@AGENTS.md`), update AGENTS.md instead — don't modify the pointer file.


### PR DESCRIPTION
Small little fix so that all of the living document skills add the link to the same place in the AGENTS.md file.