### PR TITLE
feat: evals 2

### DIFF
--- a/skills/accelint-english-manager/CHANGELOG.md
+++ b/skills/accelint-english-manager/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this skill will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to semantic versioning.
 
+## [1.3.7] - 2026-08-03
+
+### Changed
+- Updated `references/serial-instruction-guidance.md` to prefer neutral stage-container wording (`Stage` or a descriptive section heading) instead of `Phase` when describing higher-level workflow containers. This is a low-risk precaution based on repo evidence that some agents treat phase-style headings as checkpoint boundaries.
+
+## [1.3.6] - 2026-08-03
+
+### Changed
+- Tightened the serial-instruction guidance in `SKILL.md` to align more closely with the house standard: numbered lists for 2 to 3 short steps, `Step 0` plus a checklist for 4 or more steps, explicit `Requires:` and `Done when:` guidance, and a stronger prohibition against plain bullets for ordered work.
+- Upgraded the revision workflow in `SKILL.md` to model `Step 0` progress tracking, clearer dependencies, done conditions, and explicit loop-back behavior when sequencing checks fail.
+- Tightened `references/serial-instruction-guidance.md` so `Step 0` is the default for 4 or more ordered steps and the prohibition on plain bullets is stated more absolutely.
+
+## [1.3.5] - 2026-08-03
+
+### Changed
+- Reworked `SKILL.md` so the main operating flow uses explicit step ordering, stronger sequencing language, and clearer gates around mode selection, rewriting, auditing, and pre-delivery checks.
+- Added a dedicated serial-instruction section to `SKILL.md` so explicit and implied ordered actions are detected and strengthened instead of left in soft paragraph form.
+- Added `references/serial-instruction-guidance.md` for progressive disclosure of sequencing heuristics, structure rules, branching guidance, and delivery checks for ordered prose.
+
+## [1.3.4] - 2026-07-31
+
+### Changed
+- Tightened `README.md` so the quick-start guidance matches the skill's actual mode-selection workflow and points readers to `SKILL.md` for canonical trigger boundaries.
+- Reduced duplication between `README.md`, `references/examples.md`, and `references/checklist.md` by clarifying each file's role and trimming repeated instructional framing.
+- Updated audit-only guidance in `SKILL.md` and `references/examples.md` to use finding language that stays audit-first instead of implying an automatic rewrite.
+
+## [1.3.3] - 2026-07-30
+
+### Changed
+- Tightened `SKILL.md` mode-selection wording so the skill asks for a mode without overusing RFC 2119 language in its own prose, while preserving the same workflow.
+- Clarified that generic cleanup requests such as "plain English" or "clean this up" should stay on the default plain-language path unless the user explicitly asks for strict mode.
+- Added an explicit limit that the skill must not invent new requirements, commitments, or product behavior while improving prose.
+
 ## [1.3.2] - 2026-07-30
 
 ### Changed

--- a/skills/accelint-english-manager/README.md
+++ b/skills/accelint-english-manager/README.md
@@ -2,27 +2,27 @@
 
 Rewrite English so it is clearer, plainer, easier to scan, and easier to act on without changing the user's meaning.
 
-This skill is part of the `gohypergiant/agent-skills` repository. Install it through the repo-wide skills flow, not as a standalone npm package.
+This skill is part of the `gohypergiant/agent-skills` repository. Install it through the repo-wide skills workflow.
 
 ## Installation
 
-Install the skill collection, then select `accelint-english-manager` when the CLI prompts you.
+Use the [Agent Skills](https://agentskills.io/) CLI to install from the repository:
 
 **npm:**
 ```bash
-npx skills add gohypergiant/agent-skills
+npx skills add https://github.com/gohypergiant/agent-skills --skill accelint-english-manager
 ```
 
 **pnpm:**
 ```bash
-pnpm dlx skills add gohypergiant/agent-skills
+pnpm dlx skills add https://github.com/gohypergiant/agent-skills --skill accelint-english-manager
 ```
 
-This skill does not ship as a separate package with its own `package.json`.
+Select `accelint-english-manager` when prompted. This skill is not published as a standalone npm package.
 
 ## Quick Start
 
-This skill works best when you tell it both the job and the mode.
+Specify the job and the mode up front when you can. If the mode is missing, the skill should ask before rewriting:
 
 ```text
 /accelint-english-manager audit+rewrite in strict mode the following:
@@ -32,27 +32,41 @@ This page is intended to provide users with a helpful overview of how project ac
 "
 ```
 
-That prompt shape is already used elsewhere in this repo when another skill needs a final prose-polish pass.
+This prompt shape is already used elsewhere in this repo when another skill needs a final prose-polish pass.
 
 ## What is accelint-english-manager?
 
-`accelint-english-manager` is an editorial skill for rewriting English without drifting meaning, tone, audience, or required constraints. It is built for docs, prompts, support replies, release notes, UI copy, policy text, and other writing where clarity matters more than flourish.
+`accelint-english-manager` rewrites English to make it clearer without drifting meaning, tone, audience, or required constraints. Use it for docs, prompts, support replies, release notes, UI copy, policy text, and other writing where clarity matters more than flourish.
 
-The skill combines plain-language discipline, STE-leaning structure, and ADHD-friendly shaping. It uses those together rather than treating them as separate modes.
+The skill combines plain-language discipline, STE-leaning structure, and ADHD-friendly shaping. It uses them together rather than treating them as separate modes.
 
 ## Why use it?
 
-A lot of editing tools make text shorter but less accurate. Others flatten the voice so much that the result sounds robotic.
+Many editing tools make text shorter but less accurate. Others flatten the voice so much that the result sounds robotic.
 
-This skill is meant to avoid both problems.
+This skill avoids both problems:
 
-- It preserves meaning before it optimizes wording.
-- It keeps exact technical text, commands, identifiers, and file paths intact unless the user asks to rewrite them.
-- It separates rewrite scope with `mode=default` and `mode=strict`.
-- It supports audit-only, rewrite-only, and audit-plus-rewrite work.
-- It explicitly avoids claiming official ASD-STE100 compliance.
+- Preserves meaning before optimizing wording
+- Keeps exact technical text, commands, identifiers, and file paths intact unless asked to rewrite them
+- Separates rewrite scope with `mode=default` and `mode=strict`
+- Supports audit-only, rewrite-only, and audit-plus-rewrite work
+- Does not claim official ASD-STE100 compliance
 
-Use it when you want cleaner writing that still does the same job. If you need subject-matter review, legal review, or formal standards certification, this skill is not a substitute for those.
+Use it when you want cleaner writing that still does the same job. If you need subject-matter review, legal review, or formal standards certification, this skill is not a substitute.
+
+## When to use this skill
+
+Use this skill for prose-improvement requests where the main job is to make writing clearer without changing its intended meaning.
+
+Common triggers include:
+- "plain English", "simple English", "make this clearer", "make this more direct"
+- "clean this up", "edit this", "review this writing", "grammar check"
+- "too wordy", "too formal", "less fluffy", "friendlier", "shorter"
+- "audit then rewrite", "keep the tone", `mode=strict`, `STE`, `ASD-STE100`, `ADHD-friendly`
+
+Common artifacts include docs, prompts, emails, UI copy, support replies, release notes, status updates, incident notes, procedural text, and other LLM-written prose.
+
+Do not use it for fact-checking, policy setting, or substantive content design. For the canonical trigger and boundary language, see [`SKILL.md`](./SKILL.md).
 
 ## API
 
@@ -110,7 +124,7 @@ Evaluation prompts for the skill. These are most useful to maintainers, but they
 
 ## Examples
 
-These examples come from real files in this repo. They are better than made-up prompts because they reflect how this skill is actually exercised.
+These examples come from real files in this repo.
 
 ### Audit plus rewrite
 
@@ -120,8 +134,6 @@ Source: `skills/accelint-english-manager/evals/evals.json`
 Audit this paragraph and list the highest-risk issues first, then give a rewrite: 'We have identified an issue that may have impacted some users during the deployment window, and engineering is currently working to remediate the situation as quickly as possible.'
 ```
 
-Use this when you want both findings and a revised version.
-
 ### Rewrite-only release note cleanup
 
 Source: `skills/accelint-english-manager/evals/evals.json`
@@ -130,33 +142,14 @@ Source: `skills/accelint-english-manager/evals/evals.json`
 Tighten this release note entry without changing scope or adding hype: 'This update includes improvements to export reliability and reduces the number of cases where scheduled reports fail when a data source responds slowly.' Return only the revised release note in final output.
 ```
 
-Use this when you want a cleaner final version with no audit commentary.
+See [`references/examples.md`](./references/examples.md) for more worked before/after patterns and audit shapes.
 
-### Error-help rewrite with exact technical text preserved
+## Architecture & Development Guides
 
-Source: `skills/accelint-english-manager/evals/evals.json`
+For project structure and maintenance guidance, see:
 
-```text
-Rewrite this error help text so it is clearer and easier to act on, but keep the command and filename exact: 'The config loader was unable to parse settings.json. Please check the file for trailing commas and then rerun sync --apply.' Return only the revised text in final output.
-```
-
-Use this when commands, filenames, or other technical text must stay exact.
-
-### Strict prose-polish pass
-
-Source: `skills/accelint-readme-writer/SKILL.md`
-
-```text
-/accelint-english-manager audit+rewrite in strict mode the following:
-
-"
-[PASTE CONTENT HERE]
-"
-
-I do not want a report, just apply the new content to the output directly.
-```
-
-Use this when another workflow needs a final cleanup pass with tighter control.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — system architecture and tech stack
+- [AGENTS.md](../../AGENTS.md) — agent behavior and workflow conventions
 
 ## Further Reading
 

--- a/skills/accelint-english-manager/SKILL.md
+++ b/skills/accelint-english-manager/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: accelint-english-manager
-description: Use when drafting, rewriting, simplifying, reviewing, editing, polishing, humanizing, de-slopping, cleaning up, or checking written English that must become plainer, clearer, more direct, easier to scan, or easier to act on without changing the user's intended meaning, audience, tone, or explicit constraints. Also use when the user says "plain English", "simple English", "make this readable", "make this clearer", "make this direct", "make this sound better", "too wordy", "too formal", "edit this", "clean this up", "review this writing", "grammar check", "Orwell", "STE", "ASD-STE100", "ADHD-friendly", "shorter", "less fluffy", or asks for clearer docs, prompts, emails, UI copy, reports, support replies, release notes, or instructions. Make sure to use this skill for LLM-written documentation or LLM-generated responses that need stronger clarity, scanability, plain-language discipline, or tone-preserving cleanup.
+description: Use when the user wants prose rewritten, tightened, audited, simplified, polished, humanized, grammar-checked, or made plainer, clearer, shorter, easier to scan, or easier to act on without changing the intended meaning, audience, tone, or explicit constraints. Trigger on requests such as plain English, simple English, make this clearer, make this more direct, clean this up, edit this, review this writing, grammar check, too wordy, too formal, less fluffy, friendlier, shorter, audit then rewrite, keep the tone, mode=strict, STE, ASD-STE100, or ADHD-friendly. Also trigger for docs, prompts, emails, UI copy, support replies, release notes, status updates, incident notes, procedural text, and other LLM-written prose. Prefer this skill when the main job is improving English prose or preserving tone while increasing clarity, including audit-only requests and exact-text-preservation constraints, but not when the real task is fact-checking, policy setting, or substantive content design.
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.3.2"
+  version: "1.3.7"
 ---
 
 # English Manager
@@ -18,7 +18,7 @@ This skill uses one default writing system:
 - **STE-leaning structure** for technical clarity and stable terminology
 - **ADHD-friendly shaping** for scanability and actionability when the text helps someone do something
 
-Use these together. They are not competing modes.
+Use these together. They are not separate modes.
 
 ## Hard constraints
 
@@ -35,28 +35,30 @@ These outrank style preferences.
 
 Choose the smallest fitting path before you edit.
 
-### 1. Ask for the mode first
-
-For drafting or rewriting tasks, you MUST ask the user which mode they want before you edit, unless the user already specified the mode explicitly.
+### Step 1: Ask for the mode first
+For drafting or rewriting tasks, ask the user which mode they want before you edit, unless the user already specified the mode explicitly.
 
 Offer these choices:
 - **`mode=default`** — local rewrite by default, plain and direct
 - **`mode=strict`** — stricter technical control, structural rewrite allowed when needed
 
-If the user does not choose a mode, you SHOULD ask a short clarifying question instead of assuming.
+If the user did not choose a mode, ask a short clarifying question instead of assuming.
 
-For audit-only requests, you MAY proceed without asking for a mode if the user clearly wants review rather than a rewrite. If the audit later expands into a rewrite, you MUST ask for the mode before rewriting.
+For audit-only requests, you may proceed without asking for a mode if the user clearly wants review rather than a rewrite.
+Do not rewrite until the mode is known.
+If the audit later expands into a rewrite, ask for the mode before rewriting.
 
-### 2. Choose the output mode
+### Step 2: Choose the output mode
+Do this after Step 1.
 
 - **Audit only** — review the text without rewriting it unless the user asks.
 - **Rewrite only** — return cleaner final text directly.
 - **Audit plus rewrite** — give findings first, then the rewrite.
 
-If the user asks for only the rewrite, return only the rewrite.
-Do not return audit notes unless the user asked for them.
+If the user asks for only the rewrite, return only the rewrite. Do not return audit notes unless the user asked for them.
 
-### 3. Preserve the constraints
+### Step 3: Preserve the constraints
+Do this before you rewrite or restructure anything.
 
 Extract and protect these first:
 - meaning
@@ -68,7 +70,8 @@ Extract and protect these first:
 
 If a style rule conflicts with an explicit user constraint, the constraint wins.
 
-### 4. Choose the scope through the mode
+### Step 4: Choose the scope through the mode
+Requires: Steps 1 to 3 are complete.
 
 Let the mode set your default rewrite scope.
 
@@ -144,14 +147,40 @@ Use these writing modes when they materially help.
 | Mode | When | Apply |
 |---|---|---|
 | **mode=default** | Most requests | Plain-language discipline, stable terminology, scanable structure, action-first shaping when useful, and local rewrites by default |
-| **mode=strict** | The user explicitly asks for STE, ASD-STE100-style writing, very strict plain language, or highly controlled technical wording | Default mode + stronger STE structure, stronger modality discipline, stronger procedural/descriptive separation, tighter terminology control, and structural rewrites when needed for clarity or control |
+| **mode=strict** | The user explicitly asks for STE, ASD-STE100-style writing, very strict plain language, highly controlled technical wording, or a stricter audit of technical prose | Default mode + stronger STE structure, stronger modality discipline, stronger procedural/descriptive separation, tighter terminology control, and structural rewrites when needed for clarity or control |
 
 If the user asks for strict STE-style review:
 1. Say that you can do a strict STE-leaning review.
 2. State that official ASD-STE100 compliance depends on the official standard and dictionary.
-3. Load only the relevant part of `references/ste-rules.md` that you need for the request.
+3. Load only the relevant part of `references/ste-rules.md` that the request needs.
 4. Cite rule numbers only from the part of `references/ste-rules.md` that you actually loaded.
 5. If you did not load the relevant rule text, do not cite rule numbers.
+
+If the user asks for "plain English," "simple English," "clean this up," or a similar generic cleanup request without naming a mode, treat that as a plain-language goal, not as implicit `mode=strict`.
+
+## Serial-order detection and handling
+
+Treat sequence as behavior when the text tells the reader or agent to do one thing before another.
+
+Detect and strengthen these cases:
+- **explicit serial instructions** — numbered steps, `first/next/then/finally`, `before/after/until`, `requires`, `depends on`, `done when`, `return to`
+- **implied step ordering** — one sentence hides multiple actions, one action depends on the output of another, or a warning implies a missing gate
+- **sequencing cues in skill files** — ask-for-mode first, choose output mode before delivery, preserve constraints before rewriting, load rule references before citing them, run self-check before delivery
+- **sequencing cues in general prose** — procedures, operational notes, support steps, onboarding text, prompts, and any paragraph where setup, action, validation, and delivery are mixed together
+
+When order matters:
+- make the sequence explicit
+- use a numbered list for 2 to 3 short ordered steps
+- use `### Step 0` plus a checklist, then `### Step N: Name`, for 4 or more ordered steps
+- add `Requires:` when a step depends on an earlier step
+- add `Done when:` when later work depends on a successful check
+- add a named failure route when a later step must wait for a passing check
+- split `do X and then Y` into separate steps when that improves compliance
+- put conditions before actions when that makes timing clearer
+- replace emphasis-only warnings with enforceable gates when a later action depends on an earlier check
+- never leave ordered work in plain bullets
+
+Load `references/serial-instruction-guidance.md` before you rewrite or audit any text with real workflow order, gating, branching, or validation loops. Keep `SKILL.md` operational. Use the reference for deeper detection logic, structure rules, and edge cases.
 
 ## Output rules
 
@@ -162,7 +191,7 @@ Default to a compact review unless the user asks for something more formal.
 Use this shape:
 1. **Summary** — 1 to 3 sentences on the main clarity, tone, or actionability issues
 2. **Highest-risk issues first** — especially meaning drift, ambiguity, hidden actions, obligation drift, or broken structure
-3. **Targeted findings** — offending text, better rewrite, and a brief note only when it helps
+3. **Targeted findings** — source text, risk, and a brief note only when it helps
 4. **Optional full rewrite** — include it only if the user asked for one or the passage has repeated issues
 
 ### Rewrite only
@@ -179,6 +208,7 @@ Give the findings first, then the rewrite.
 
 Load references only when they materially help.
 
+- `references/serial-instruction-guidance.md` — ordered instructions, implied sequencing, gating, branching, validation loops, and when a paragraph should become explicit steps
 - `references/substitutions.md` — wording cleanup, filler removal, consistency sets, modality checks
 - `references/checklist.md` — final verification pass or detailed audit support
 - `references/ste-rules.md` — technical, procedural, instructional, or explicit STE requests; also for `mode=strict`
@@ -191,32 +221,105 @@ Load references only when they materially help.
 
 ### For drafting from scratch
 
-1. Ask the user which mode they want, unless they already specified it.
-2. Choose the output mode.
-3. Extract the constraints.
-4. Apply `mode=default` or `mode=strict`, and let that set the default scope.
-5. Draft in direct English.
-6. Keep repeated terms stable.
-7. If the reader must act, make the action path easy to scan.
-8. Run the self-check before delivery.
+### Step 1: Ask for the mode
+Do this first unless the user already specified the mode.
+Done when: the rewrite mode is explicit, or the request is truly audit-only.
+
+### Step 2: Choose the output mode
+Requires: Step 1 is complete when the request needs a rewrite mode.
+Choose `Audit only`, `Rewrite only`, or `Audit plus rewrite` before you draft.
+
+### Step 3: Extract the constraints
+Requires: Steps 1 and 2 are complete.
+Identify the meaning, audience, tone, format, and exact wording that must stay fixed before you draft.
+
+### Step 4: Apply the mode
+Requires: Step 3 is complete.
+Let `mode=default` or `mode=strict` set the default scope.
+Done when: the allowed rewrite scope is clear.
+
+### Step 5: Draft in direct English
+Requires: Steps 1 to 4 are complete.
+Write in plain, direct English that preserves the user's intended meaning, audience, tone, and explicit constraints.
+
+### Step 6: Keep repeated terms stable
+Requires: Step 5 is complete.
+Use one term for one concept. Do not rotate synonyms for style.
+
+### Step 7: Make the action path easy to scan
+Requires: Steps 5 and 6 are complete.
+Do this when the reader must act.
+If the text contains ordered actions, load `references/serial-instruction-guidance.md` and make the order explicit.
+
+### Step 8: Run the self-check before delivery
+Requires: Steps 1 to 7 are complete.
+Do not deliver before Step 8 is complete.
+If the self-check fails, return to the earliest affected step.
 
 ### For revising existing text
 
-1. Ask the user which mode they want, unless they already specified it.
-2. Preserve the user's meaning and constraints.
-3. Apply `mode=default` or `mode=strict`, and let that set the default scope.
-4. Tighten the wording with the smallest change that fixes the problem.
-5. Remove filler, stale phrasing, and avoidable abstraction.
-6. Split overloaded sentences or restructure when substitution alone will not work.
-7. Recheck pronouns, modality, and untouchables.
-8. Run the self-check before delivery.
+### Step 0: Track progress
+Do this before any other work when the rewrite workflow has 4 or more real actions.
+Create a short checklist in your working state or reply and update it after each step.
+
+- [ ] Step 1: Ask for the mode
+- [ ] Step 2: Preserve the user's meaning and constraints
+- [ ] Step 3: Apply the mode
+- [ ] Step 4: Tighten the wording with the smallest safe change
+- [ ] Step 5: Remove filler, stale phrasing, and avoidable abstraction
+- [ ] Step 6: Split overloaded sentences or restructure only when substitution alone will not work
+- [ ] Step 7: Recheck pronouns, modality, and untouchables
+- [ ] Step 8: Run the self-check before delivery
+
+### Step 1: Ask for the mode
+Do this first unless the user already specified the mode.
+Done when: the rewrite mode is explicit, or the request is truly audit-only.
+
+### Step 2: Preserve the user's meaning and constraints
+Requires: Step 1 is complete.
+Do this before any rewrite.
+Done when: meaning, audience, tone, format, and untouchables are identified.
+
+### Step 3: Apply the mode
+Requires: Steps 1 and 2 are complete.
+Let `mode=default` or `mode=strict` set the default scope.
+Done when: the allowed rewrite scope is clear.
+
+### Step 4: Tighten the wording with the smallest safe change
+Requires: Steps 1 to 3 are complete.
+
+### Step 5: Remove filler, stale phrasing, and avoidable abstraction
+Requires: Step 4 is complete.
+
+### Step 6: Split overloaded sentences or restructure only when substitution alone will not work
+Requires: Steps 4 and 5 are complete.
+If the source hides sequence, gates, or branch logic, load `references/serial-instruction-guidance.md` and rewrite the sequence explicitly.
+If sequence checks fail, return to Step 4.
+
+### Step 7: Recheck pronouns, modality, and untouchables
+Requires: Steps 4 to 6 are complete.
+Done when: referents are clear and obligation strength still matches the source.
+
+### Step 8: Run the self-check before delivery
+Requires: Steps 1 to 7 are complete.
+Do not deliver before Step 8 is complete.
+If the self-check fails, return to the earliest affected step.
 
 ### For checking text instead of rewriting it
 
-1. Identify the highest-risk issues first.
-2. Keep the review proportional to the request.
-3. Use a stricter, rule-based audit format only when the user asks for it or the text is high-consequence.
-4. If the user asked for STE checking, load only the relevant part of `references/ste-rules.md` that you need and do not invent rule numbers.
+### Step 1: Identify the highest-risk issues first
+Put meaning drift, ambiguity, hidden actions, obligation drift, and weak sequencing first.
+
+### Step 2: Keep the review proportional to the request
+
+### Step 3: Use a stricter, rule-based audit format only when the user asks for it or the text is high-consequence
+
+### Step 4: Load the right references before citing them
+If the user asked for STE checking, load only the relevant part of `references/ste-rules.md` that you need and do not invent rule numbers.
+If the text contains ordered actions or weak sequencing cues, load `references/serial-instruction-guidance.md` before you judge whether the sequence is clear enough.
+
+### Step 5: Run the self-check before delivery
+Do not deliver before Step 5 is complete.
 
 ## Conflict resolution
 
@@ -241,13 +344,17 @@ Before you deliver, confirm:
 2. Key terms stayed stable.
 3. Obligation, permission, capability, and uncertainty did not drift.
 4. Untouchables stayed exact.
-5. The final answer matches the requested output mode.
-6. The final answer matches the requested rewrite mode.
+5. Any explicit or implied ordered instructions are still visible as ordered instructions.
+6. Any required gate, dependency, or validation step still blocks the later step clearly.
+7. The final answer matches the requested output mode.
+8. The final answer matches the requested rewrite mode.
 
 For a deeper mechanical pass, load `references/checklist.md`.
 
 ## Limits
 
 This skill improves clarity and execution-readiness. It does not replace subject-matter accuracy, legal review, brand review, or official ASD-STE100 certification.
+
+It is also a writing skill, not a fact-checking or policy-setting skill. Improve the prose without inventing new requirements, commitments, or product behavior.
 
 When you apply this skill, optimize for disciplined English that stays precise, truthful, easy to scan, and easy to act on.

--- a/skills/accelint-english-manager/evals/evals.json
+++ b/skills/accelint-english-manager/evals/evals.json
@@ -2,11 +2,24 @@
   "skill_name": "accelint-english-manager",
   "evals": [
     {
+      "id": 1,
+      "prompt": "Audit this paragraph only. Do not rewrite it unless I ask: 'We are in the process of working to improve the overall quality of the reporting experience for users going forward.' Keep the review compact and list the highest-risk issues first.",
+      "expected_output": "A compact audit-only response that identifies filler, vagueness, and weak actionability without providing a rewrite unless clearly framed as optional and user-requested.",
+      "files": [],
+      "expectations": [
+        "The response stays in audit-only mode rather than defaulting to a rewrite.",
+        "The review is compact and prioritizes the highest-risk clarity issues first.",
+        "The audit identifies vague or inflated phrasing such as 'in the process of working' or 'going forward'.",
+        "The audit explains why the sentence is hard to act on or hard to read.",
+        "The response does not invent a broader strategy, policy, or product context."
+      ]
+    },
+    {
       "id": 2,
       "prompt": "Audit this paragraph and list the highest-risk issues first, then give a rewrite: 'We have identified an issue that may have impacted some users during the deployment window, and engineering is currently working to remediate the situation as quickly as possible.'",
       "expected_output": "A severity-ordered audit plus a direct rewrite that distinguishes fake hedges from real uncertainty, avoids inventing unsupported specifics, and replaces inflated language with plainer wording.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The response includes an audit, not just a rewrite.",
         "The audit identifies at least one high-risk clarity or truthfulness problem before presenting the rewrite.",
         "The rewrite preserves uncertainty honestly rather than overstating what is known.",
@@ -15,11 +28,24 @@
       ]
     },
     {
+      "id": 3,
+      "prompt": "Rewrite this in plain English. Keep the meaning and keep it as a single sentence. Return only the revised sentence: 'Users are advised that account recovery functionality may experience intermittent degradation following the maintenance event.'",
+      "expected_output": "A rewrite-only response that returns a single clearer sentence, preserves the maintenance-related uncertainty, and does not add audit notes.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the rewritten sentence.",
+        "The rewrite stays as a single sentence.",
+        "The rewrite preserves the idea that account recovery may be intermittently affected after maintenance.",
+        "The rewrite uses plainer wording than the source.",
+        "The response does not include audit commentary or extra explanation."
+      ]
+    },
+    {
       "id": 4,
       "prompt": "Make this friendlier but still plain and direct: 'We are thrilled to announce that our small team has finally shipped the update we have been dreaming about for months.'",
       "expected_output": "A voice-preserving rewrite that removes inflation without flattening warmth.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The rewrite becomes friendlier while staying plain and direct.",
         "The rewrite preserves warmth rather than flattening the positive tone completely.",
         "The rewrite removes inflation such as exaggerated enthusiasm or overstatement.",
@@ -28,11 +54,91 @@
       ]
     },
     {
+      "id": 5,
+      "prompt": "I need a strict pass on this technical instruction. Use mode=strict. Audit first, then rewrite: 'Prior to initiating the shutdown procedure, operators should ensure that all nonessential peripheral equipment has been appropriately disconnected.'",
+      "expected_output": "A strict-mode audit-plus-rewrite response that tightens technical wording, controls modality carefully, and uses stronger procedural clarity than default mode would.",
+      "files": [
+        "references/ste-rules.md"
+      ],
+      "expectations": [
+        "The response reflects strict mode rather than a casual cleanup.",
+        "The response includes an audit before the rewrite.",
+        "The rewrite preserves the shutdown-before-disconnect sequence.",
+        "The rewrite keeps the obligation level accurate rather than strengthening it by accident.",
+        "The rewrite uses tighter procedural wording than the source."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Please do a default-mode cleanup only. Keep this close to the original and do not restructure it into steps: 'Before you start the shutdown, make sure any nonessential peripheral equipment is disconnected.' Return only the rewrite.",
+      "expected_output": "A default-mode local rewrite that stays close to the source, preserves sentence-level structure, and does not escalate into strict procedural formatting.",
+      "files": [],
+      "expectations": [
+        "The response behaves like default mode rather than strict mode.",
+        "The rewrite stays close to the original wording and structure.",
+        "The rewrite preserves the shutdown-before-disconnect sequence.",
+        "The rewrite does not turn the sentence into numbered steps or a checklist.",
+        "The final output returns only the rewrite."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Rewrite this status message, but keep every quoted string, command, and file path exact. Return only the revised message: 'If \"npm run build\" fails after you edit /apps/docs/content.config.ts, post the exact error in #docs-infra before you retry.'",
+      "expected_output": "A clearer rewrite-only status message that preserves the exact quoted command, file path, and channel name.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the revised message.",
+        "The rewrite preserves the exact quoted command `\"npm run build\"`.",
+        "The rewrite preserves the exact file path `/apps/docs/content.config.ts`.",
+        "The rewrite preserves the exact channel name `#docs-infra`.",
+        "The rewrite improves clarity without changing the technical meaning or sequence."
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Do an audit only on this customer-facing sentence and flag any tone risk: 'We regret to inform you that your request cannot be processed at this time due to an issue on our end.' No rewrite unless I ask.",
+      "expected_output": "A concise audit-only response that reviews clarity and tone risk without automatically rewriting the sentence.",
+      "files": [],
+      "expectations": [
+        "The response remains audit-only.",
+        "The audit comments on customer-facing tone, including whether the apology or wording feels stiff.",
+        "The audit identifies any vagueness around the issue or next step.",
+        "The response does not automatically provide a rewritten sentence.",
+        "The response stays proportional rather than becoming a full support-policy review."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Rewrite this UI helper text so it is clearer and shorter, but keep the warning meaning: 'Deleting this workspace will permanently remove saved views, automation rules, and historical export data.' Return only the revised text.",
+      "expected_output": "A concise UI-style rewrite that preserves the permanent-deletion warning and the three affected data categories.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the revised helper text.",
+        "The rewrite preserves the permanent-deletion meaning.",
+        "The rewrite preserves the three affected items: saved views, automation rules, and historical export data.",
+        "The rewrite is shorter or tighter than the source.",
+        "The rewrite stays suitable for UI copy rather than becoming a long explanation."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Clean up this internal support macro. Keep it warm, plain, and easy to act on, but do not add new troubleshooting steps: 'Thanks for hanging in there. We took a look and it seems like the sync may not have completed all the way on the first try, so if you run it one more time now it should finish normally.' Return only the revised reply.",
+      "expected_output": "A support-ready rewrite that preserves warmth, keeps the likely-cause framing, and improves actionability without adding steps.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the revised support reply.",
+        "The rewrite preserves a warm tone.",
+        "The rewrite preserves the suggestion to try the sync again now.",
+        "The rewrite preserves the uncertainty that the sync may not have completed on the first try.",
+        "The rewrite does not add extra troubleshooting or escalation steps."
+      ]
+    },
+    {
       "id": 11,
       "prompt": "Tighten this sentence without adding scope or examples: 'This page explains the backup policy and when restores need approval from operations.'",
       "expected_output": "A minimal rewrite that becomes clearer and tighter while preserving the backup-policy scope and the restore-approval condition without adding new examples, artifacts, or structure.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The rewrite is tighter and clearer than the source sentence.",
         "The rewrite preserves the original topic: the backup policy and restore approval.",
         "The rewrite preserves the approval condition for restores rather than dropping or broadening it.",
@@ -45,7 +151,7 @@
       "prompt": "Clean up this short internal note, but keep it a note rather than turning it into a checklist or policy: 'If the sync fails at night, leave a note for the morning team and include the job ID if you have it.'",
       "expected_output": "A local rewrite that improves clarity and flow, keeps the optional nature of the job ID, and does not expand the note into a procedure, checklist, or broader operations guidance.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The rewrite stays an internal note rather than becoming a checklist, procedure, or policy.",
         "The rewrite preserves the original condition: if the sync fails at night.",
         "The rewrite preserves the instruction to leave a note for the morning team.",
@@ -54,11 +160,78 @@
       ]
     },
     {
+      "id": 13,
+      "prompt": "Please rewrite this docs paragraph so it is easier to scan, but keep it as a paragraph and preserve the existing tone: 'To get access, most users can send a request through the admin panel, and once that request is reviewed the account will usually be provisioned automatically unless the workspace is still on the legacy flow.' Return only the revised paragraph.",
+      "expected_output": "A docs-friendly paragraph rewrite that improves scanability while keeping paragraph form, preserving tone, and keeping the legacy-flow exception.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the revised paragraph.",
+        "The rewrite stays in paragraph form rather than converting to bullets or steps.",
+        "The rewrite preserves the meaning that most users request access through the admin panel.",
+        "The rewrite preserves the exception for workspaces still on the legacy flow.",
+        "The rewrite is easier to scan than the source."
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Audit this release-note sentence for hype and precision, then rewrite it: 'This major update dramatically improves export performance and delivers a game-changing reliability boost for all scheduled reports.'",
+      "expected_output": "An audit-plus-rewrite response that identifies hype and unsupported certainty, then rewrites the sentence into a factual release-note style claim.",
+      "files": [],
+      "expectations": [
+        "The response includes an audit before the rewrite.",
+        "The audit identifies hype terms such as 'dramatically' or 'game-changing'.",
+        "The rewrite removes hype and unsupported universal claims such as 'for all scheduled reports' unless justified.",
+        "The rewrite remains suitable for release notes rather than turning into a support note or engineering memo.",
+        "The rewrite stays factual and clearer than the source."
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Make this incident update plainer, but keep the real uncertainty and do not make it sound more certain than it is: 'We believe the queue backlog was caused by a brief database failover, although we are still verifying whether a second latency spike contributed.' Return only the revised update.",
+      "expected_output": "A rewrite-only incident update that preserves both the likely cause and the unresolved uncertainty without collapsing nuance.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the revised update.",
+        "The rewrite preserves the likely cause that a brief database failover caused the backlog.",
+        "The rewrite preserves the unresolved possibility that a second latency spike also contributed.",
+        "The rewrite does not overstate certainty.",
+        "The rewrite is plainer and easier to read than the source."
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "Strict mode. Review this procedural warning for STE-style issues, then rewrite it: 'Do not under any circumstances proceed with panel removal until the unit has been electrically isolated and all charge indicators are confirmed dark.'",
+      "expected_output": "A strict-mode technical audit-plus-rewrite response that improves procedural control and preserves the safety gating sequence.",
+      "files": [
+        "references/ste-rules.md"
+      ],
+      "expectations": [
+        "The response reflects strict mode and a technical procedural context.",
+        "The response includes a review before the rewrite.",
+        "The rewrite preserves the prohibition on proceeding before isolation and dark indicators are confirmed.",
+        "The rewrite keeps the safety-critical order of operations intact.",
+        "The rewrite is more controlled and direct than the original wording."
+      ]
+    },
+    {
+      "id": 17,
+      "prompt": "The user did not pick a mode. Before rewriting this, handle that correctly: 'Please clean up this operator instruction so it's easier to follow: Verify line pressure is nominal before opening the bypass valve.'",
+      "expected_output": "A response that asks a short clarifying question about mode instead of assuming default or strict rewrite mode.",
+      "files": [],
+      "expectations": [
+        "The response asks the user to choose a mode rather than silently assuming one.",
+        "The question is short and focused.",
+        "The response does not perform the rewrite yet.",
+        "The response does not turn the interaction into a long explanation of the entire skill.",
+        "The response preserves the possibility of either default or strict mode."
+      ]
+    },
+    {
       "id": 18,
       "prompt": "Rewrite this plain-English request more clearly, but do not turn it into an audit, checklist, or expanded artifact: 'Can you make this onboarding note easier to scan? New hires keep missing the bit about VPN access happening after device setup.' Return only the revised note in final output.",
       "expected_output": "A concise local rewrite in final output that improves scanability, preserves the onboarding-note format, and keeps the sequencing point that VPN access happens after device setup without expanding into broader procedure or policy.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised note, not an audit or explanation.",
         "The rewrite stays a note rather than becoming a checklist, policy, or expanded procedure.",
         "The rewrite preserves the sequencing point that VPN access happens after device setup.",
@@ -71,7 +244,7 @@
       "prompt": "Tighten this release note entry without changing scope or adding hype: 'This update includes improvements to export reliability and reduces the number of cases where scheduled reports fail when a data source responds slowly.' Return only the revised release note in final output.",
       "expected_output": "A tighter release-note sentence in final output that preserves the two concrete claims, stays factual, and does not add hype, extra benefits, or broader product claims.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised release note.",
         "The rewrite preserves both claims: improved export reliability and fewer scheduled-report failures when a data source is slow.",
         "The rewrite stays factual and does not add hype or unsupported benefits.",
@@ -84,7 +257,7 @@
       "prompt": "Rewrite this error help text so it is clearer and easier to act on, but keep the command and filename exact: 'The config loader was unable to parse settings.json. Please check the file for trailing commas and then rerun sync --apply.' Return only the revised text in final output.",
       "expected_output": "A concise action-oriented rewrite in final output that preserves the exact `settings.json` filename and `sync --apply` command while making the failure and next action clearer.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised help text.",
         "The rewrite preserves the exact filename `settings.json`.",
         "The rewrite preserves the exact command `sync --apply`.",
@@ -97,7 +270,7 @@
       "prompt": "Review this paragraph for over-simplification risk, then rewrite it if needed: 'The migration can change how cached sessions behave, so some users may need to sign in again after the deploy.'",
       "expected_output": "A compact audit plus rewrite that keeps the real uncertainty, avoids fake force, and preserves the relationship between the migration and possible reauthentication.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The response includes a brief audit before any rewrite.",
         "The audit distinguishes real uncertainty from wording that could be tightened safely.",
         "The rewrite preserves the possibility that only some users need to sign in again.",
@@ -112,7 +285,7 @@
       "files": [
         "references/rfc-2119.md"
       ],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised text.",
         "The rewrite normalizes CRITICAL into MUST or REQUIRED language.",
         "The rewrite normalizes IMPORTANT into SHOULD or RECOMMENDED language.",
@@ -128,7 +301,7 @@
       "files": [
         "references/rfc-2119.md"
       ],
-      "assertions": [
+      "expectations": [
         "The response includes an audit before any rewrite.",
         "The audit notes ambiguity or inconsistency in informal severity wording such as Important or critical.",
         "The rewrite preserves the requirement to keep exact file paths.",
@@ -142,7 +315,7 @@
       "prompt": "Make this support reply clearer and easier to act on, but keep the apology and do not add steps: 'Sorry about the mess here — it looks like the export got stuck after you changed the date range. If you try the same export again now, it should go through.' Return only the revised reply in final output.",
       "expected_output": "A concise support reply in final output that keeps the apology, preserves the likely cause and suggested retry, and improves clarity without adding troubleshooting steps or removing warmth.",
       "files": [],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised support reply.",
         "The rewrite preserves the apology rather than stripping it out.",
         "The rewrite preserves the likely cause that the export got stuck after the date-range change.",
@@ -158,7 +331,7 @@
       "files": [
         "references/use-cases.md"
       ],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised blurb.",
         "The rewrite preserves both key claims: teams can ship changes faster and still keep traceability during review.",
         "The rewrite stays concise and technically clear.",
@@ -173,7 +346,7 @@
       "files": [
         "references/adhd-patterns.md"
       ],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised note.",
         "The rewrite improves scanability and makes the next action easier to spot.",
         "The rewrite stays a note rather than becoming numbered steps or a checklist.",
@@ -188,7 +361,7 @@
       "files": [
         "references/rfc-2119.md"
       ],
-      "assertions": [
+      "expectations": [
         "The response includes an audit before any rewrite.",
         "The audit addresses whether 'Important' and 'should' reflect a recommendation or a requirement.",
         "The rewrite preserves the requirement or recommendation level rather than strengthening it by accident.",
@@ -204,13 +377,65 @@
         "references/use-cases.md",
         "references/substitutions.md"
       ],
-      "assertions": [
+      "expectations": [
         "The final output returns only the revised two-paragraph text.",
         "The rewrite preserves the overview scope instead of expanding into a policy or procedure.",
         "The rewrite preserves the exception for legacy environments.",
         "The rewrite preserves the condition that some approvals may need coordination with operations before access is granted.",
         "The rewrite does not convert the content into bullets, numbered steps, or a checklist.",
         "The rewrite is plainer and more direct than the source."
+      ]
+    },
+    {
+      "id": 29,
+      "prompt": "The user asks for a rewrite but includes a non-negotiable exact quote to preserve: 'Please clean this up, but keep this sentence exactly as written: \"Support can restore deleted projects for 30 days.\" You can rewrite the rest: We generally tell users that deleted workspaces are not recoverable, which is confusing because support has a limited recovery path.'",
+      "expected_output": "A rewrite-aware response that preserves the exact quoted sentence unchanged while improving the surrounding prose and keeping the policy nuance intact.",
+      "files": [],
+      "expectations": [
+        "The response preserves the exact quoted sentence `\"Support can restore deleted projects for 30 days.\"` unchanged.",
+        "The rewrite clarifies the relationship between the general user message and the limited recovery path.",
+        "The rewrite does not alter the policy meaning.",
+        "The response respects the exact-text preservation constraint above style preferences.",
+        "The rewrite improves clarity around the confusing contradiction in the source."
+      ]
+    },
+    {
+      "id": 30,
+      "prompt": "Audit this sentence only. Tell me whether it even needs a rewrite: 'Load references/checklist.md before delivery.'",
+      "expected_output": "A compact audit response that may correctly decide no rewrite is needed because the sentence is already clear, exact, and minimal.",
+      "files": [],
+      "expectations": [
+        "The response does not force a rewrite just because the user asked for a check.",
+        "The audit evaluates whether the sentence is already near-optimal.",
+        "The response recognizes the exact file path should stay unchanged.",
+        "The response stays compact.",
+        "If a rewrite is suggested, it remains equally exact and minimal."
+      ]
+    },
+    {
+      "id": 31,
+      "prompt": "Rewrite this engineering update in plain English, but keep the product names, API names, and config keys exact: 'After the AtlasSync migration, clients using EventBridge forwarding must set retryMode=adaptive or Delivery API retries may cluster during regional failover.' Return only the rewrite.",
+      "expected_output": "A plain-English technical rewrite that preserves exact technical identifiers while clarifying the causal relationship and action.",
+      "files": [],
+      "expectations": [
+        "The final output returns only the rewrite.",
+        "The rewrite preserves the exact product or API names `AtlasSync`, `EventBridge`, and `Delivery API`.",
+        "The rewrite preserves the exact config key/value `retryMode=adaptive`.",
+        "The rewrite preserves the condition that this applies after the AtlasSync migration and to clients using EventBridge forwarding.",
+        "The rewrite improves readability without weakening the technical accuracy."
+      ]
+    },
+    {
+      "id": 32,
+      "prompt": "Review this mixed-mode request correctly: 'First, audit this note for clarity. Then rewrite it in default mode and keep it warm: We looked into it and there is a possibility the invoice reminder was sent because your billing contact was updated right before the scheduled run.'",
+      "expected_output": "An audit-plus-rewrite response that respects the explicit default mode, preserves warmth, and keeps the real uncertainty about the likely cause.",
+      "files": [],
+      "expectations": [
+        "The response includes findings first and then the rewrite.",
+        "The response respects the explicit default mode.",
+        "The rewrite preserves warmth rather than becoming cold or legalistic.",
+        "The rewrite preserves the uncertainty that the billing-contact update may have caused the reminder.",
+        "The response does not escalate into strict technical restructuring."
       ]
     }
   ]

--- a/skills/accelint-english-manager/references/adhd-patterns.md
+++ b/skills/accelint-english-manager/references/adhd-patterns.md
@@ -45,11 +45,11 @@ When the reader must do more than one thing:
 - keep each step bounded
 - avoid stacking many actions into one step
 
-Use only as much structure as the work needs.
+Use only as much structure as the task needs.
 
 ### 3. Restate current state across turns
 
-Across turns, restate what is done and what is next.
+Across turns, restate what is done and what comes next.
 
 Good pattern:
 

--- a/skills/accelint-english-manager/references/checklist.md
+++ b/skills/accelint-english-manager/references/checklist.md
@@ -1,6 +1,6 @@
 # English discipline checklist
 
-Run this checklist before you deliver a rewrite, a draft, or a style audit.
+Run this checklist when you need a deeper verification pass before you deliver a rewrite, draft, or style audit.
 
 ## 1. Preserve the user's job to be done
 
@@ -11,7 +11,7 @@ Check first:
 - Did the requested tone stay intact?
 - Did any explicit format or wording constraints stay intact?
 
-If not, fix that first. No style improvement is worth breaking the user's intent.
+If not, fix that first. No style improvement is worth breaking user intent.
 
 ## 2. Mechanical checks
 
@@ -82,7 +82,7 @@ Ask:
 - Is it easier to act on?
 - Is it still the same message?
 
-If all three are true, deliver it.
+If all three are true, deliver it. Use this file as the deeper mechanical pass after the shorter required self-check in `SKILL.md`.
 
 
 ## STE-specific audit note
@@ -93,7 +93,7 @@ If the user asked for strict STE-style review, load only the relevant part of `s
 - offending text
 - compliant rewrite
 
-Do not invent rule numbers. Use only the rule numbers present in the part of the reference that you actually loaded.
+Do not invent rule numbers. Use only rule numbers from the part of the reference that you actually loaded.
 
 ## Multi-pass editing note
 
@@ -104,4 +104,4 @@ For long drafts or large rewrites, prefer multiple passes:
 3. standardize terminology and modality
 4. re-check tone, nuance, and actionability
 
-This reduces accidental meaning drift. It also works better in constrained tool contexts.
+This reduces accidental meaning drift and works better in constrained tool contexts.

--- a/skills/accelint-english-manager/references/examples.md
+++ b/skills/accelint-english-manager/references/examples.md
@@ -1,8 +1,10 @@
 # Examples by writing type
 
-Use this reference when a concrete pattern will help before drafting, rewriting, or auditing text.
+Use this reference when a concrete before/after pattern will help before you draft, rewrite, or audit text.
 
-These examples are intentionally short. Use them to anchor judgment. Do not force a template onto unrelated prose. Favor the core default method first: state the point early, use direct wording, keep terms stable, and apply stronger structure only when it helps the reader.
+This file is an example bank. Use `references/use-cases.md` for context-specific adaptation guidance.
+
+These examples are intentionally short. Use them to anchor judgment. Do not force a template onto unrelated prose.
 
 ## Procedural rewrite
 
@@ -102,9 +104,9 @@ Why this helps:
 
 **Audit finding:**
 - **Category:** filler and weak modality
-- **Offending text:** "In order to ensure," "should provide guidance," "intuitive and user-friendly"
-- **Better rewrite:** "To help users finish onboarding, the system must give clear guidance."
-- **Note:** If this is product copy instead of a requirement, replace `must` with a factual statement about current behavior.
+- **Source text:** "In order to ensure," "should provide guidance," "intuitive and user-friendly"
+- **Risk:** The sentence hides whether this is a requirement or a descriptive claim. It also uses filler and vague quality terms.
+- **Brief note:** If this is a requirement, the final rewrite should state the obligation directly. If it is product copy, the final rewrite should state the current behavior.
 
 ## Audit example with severity ordering
 
@@ -114,9 +116,9 @@ Why this helps:
 
 **Finding:**
 - **Category:** procedural structure
-- **Offending text:** "You may want to rotate the key after the deploy if the old secret is still active in production."
-- **Better rewrite:** "If the old secret is still active in production, rotate the key after the deploy."
-- **Note:** This keeps the condition, removes weak modality, and makes the action explicit.
+- **Source text:** "You may want to rotate the key after the deploy if the old secret is still active in production."
+- **Risk:** The required action is easy to miss because the condition and command are buried in weak modality.
+- **Brief note:** A rewrite should put the condition first and make the action explicit.
 
 ## Hybrid technical rewrite
 
@@ -143,7 +145,7 @@ This reminder helps you avoid over-applying technical or ADHD-oriented structure
 
 ## Reusable example patterns
 
-Use these patterns in this reference:
+Use these patterns from this reference:
 - before/after pairs for the same sentence or paragraph
 - one instruction per step
 - condition first, then action
@@ -155,7 +157,6 @@ Do not copy examples too literally when they depend on:
 - commands or file paths from another project
 - timestamps, metrics, or incidents from another system
 
-
 ## When to use this file
 
 Use this file when:
@@ -163,4 +164,3 @@ Use this file when:
 - the text mixes clarity goals with voice-sensitive constraints
 - a procedural or support rewrite needs a quick anchor before drafting
 - the model is over-correcting toward rigidity and needs examples of when to stay light
-- you want examples of the difference between the core default method and stronger structure

--- a/skills/accelint-english-manager/references/rfc-2119.md
+++ b/skills/accelint-english-manager/references/rfc-2119.md
@@ -47,7 +47,7 @@ Examples:
 - `important` recommendation → `SHOULD` or `RECOMMENDED`
 - `optional` step → `MAY` or `OPTIONAL`
 
-Choose the term that matches the truth of the source. Do not use a stronger modal just to sound clearer.
+Choose the term that matches the truth of the source. Do not use a stronger modal only to sound clearer.
 
 ## Editing rule
 

--- a/skills/accelint-english-manager/references/serial-instruction-guidance.md
+++ b/skills/accelint-english-manager/references/serial-instruction-guidance.md
@@ -1,0 +1,100 @@
+# Serial-instruction guidance
+
+Use this reference when the text contains ordered actions, implied sequence, gating, or workflow-like prose that can fail if an agent reads it as unordered advice.
+
+## What to detect
+
+Check for explicit serial instructions first.
+
+Common signals:
+- numbered steps
+- `Step 1`, `Stage 2`, `First`, `Next`, `Then`, `After that`, `Finally`
+- `before`, `after`, `until`, `once`, `when`, `only then`, `do not ... until`
+- `requires`, `depends on`, `done when`, `if this passes, continue`
+- branch markers such as `if`, `otherwise`, `else`, `skip`, `return to`
+
+Then check for implied sequence.
+
+Common signals:
+- one sentence contains two or more actions joined by `and`, `and then`, `then`, or commas
+- a warning tells the reader to validate, review, confirm, or approve before a later action
+- a paragraph mixes setup, execution, validation, and delivery in one block
+- a list uses bullets for work that is actually ordered
+- the text assumes an output from one action is needed by the next action
+
+Also check for sequencing cues in skill files and other prompt artifacts.
+
+Common signals:
+- trigger text that implies an audit before a rewrite
+- workflow sections that tell the agent to ask first, then choose a mode, then edit
+- approval rules that require the user to confirm before a later action
+- reference-loading rules that depend on the request type or risk level
+- self-check sections that must happen before delivery
+
+Also check for sequencing cues in general prose.
+
+Common signals:
+- instructions for a user to follow
+- onboarding, support, setup, incident, or release notes that hide action order in paragraphs
+- explanatory prose that contains real commands or gates inside the explanation
+- normative or procedural text where order affects safety, correctness, or obligation
+
+## What to do when sequence matters
+
+Use the smallest structure that makes the order hard to miss.
+
+### For 2 to 3 short steps
+Use a numbered list.
+
+### For 4 or more ordered steps
+Use this pattern by default:
+1. Add `### Step 0: Track progress`.
+2. Put a checklist under Step 0.
+3. Convert each ordered action into `### Step N: Name`.
+4. Add `Requires:` when a step depends on an earlier step.
+5. Add `Done when:` when later work depends on a successful check.
+6. Add an explicit failure route such as `If this fails, return to Step 3.`
+
+### For stage containers
+If you need a higher-level container above ordered steps, prefer a neutral section label such as `## Stage N` or a descriptive heading. Put ordered steps inside the container. Give the container an exit condition when the outcome matters.
+
+### For branches
+Name the branch destination. Do not leave a branch implied.
+
+Good pattern:
+- `If X, go to Step 4a.`
+- `If not X, go to Step 4b.`
+- `Both branches return to Step 5.`
+
+## Rewrite rules
+
+- One step is one action. Split any step that says `and then`.
+- Do not use empty step headings. Every `### Step N: Name` block must contain at least one operational sentence, gate, or completion condition.
+- If a step heading only labels a principle, convert that principle into an action the reader or agent can execute.
+- Put the condition before the action when that makes timing easier to follow.
+- Replace emphasis-only warnings with enforceable gates when the text really depends on order.
+- Never leave ordered work in plain bullets.
+- Do not merge setup, action, validation, and delivery into one instruction.
+- Keep sequence visible in the main artifact. Move heuristics, examples, and edge cases to a reference file.
+
+## Delivery checks
+
+Before you deliver, confirm:
+1. Every ordered action is visible as an ordered action.
+2. No step heading is empty or purely decorative.
+3. Every dependent step names what must be true first.
+4. Every validation or approval gate blocks the later step clearly.
+5. Every branch names its next step.
+6. The final text cannot be read as `do these in any order` when order matters.
+7. Any checklist or progress-tracking instruction appears before the workflow it tracks.
+
+## Notes for this skill
+
+Apply this reference when you are rewriting or auditing:
+- procedures
+- support instructions
+- operational notes
+- prompts or agent instructions
+- any prose where the reader must act in sequence
+
+When sequence is weak but real, make it explicit. Do not preserve a soft, paragraph-shaped workflow just because it sounds natural.

--- a/skills/accelint-english-manager/references/ste-rules.md
+++ b/skills/accelint-english-manager/references/ste-rules.md
@@ -2,7 +2,7 @@
 
 Use this reference when the request is technical, procedural, instructional, or explicitly asks for STE or ASD-STE100-style writing. It is the main overlay for `mode=strict`.
 
-Load only the section or rule group that the current request needs. You do not need to load this whole file for every strict request.
+Load only the section or rule group that the current request needs. You do not need this whole file for every strict request.
 
 This is a software-oriented, STE-inspired synthesis for technical clarity and LLM-output cleanup. It is not an official copy of the ASD dictionary and does not claim compliance.
 
@@ -32,7 +32,7 @@ Examples:
 - config / settings / options / configuration
 - run / execute / invoke / launch
 
-Repeated clarity is better than elegant variation, especially in technical and procedural text.
+Repeated clarity is better than stylistic variation, especially in technical and procedural text.
 
 ### Prefer common words when accuracy survives
 
@@ -58,8 +58,7 @@ Examples:
 - compile
 - hydrate
 
-If a technical term may confuse the intended reader, define it once or link to its definition.
-Do not replace an official or canonical technical name with a friendlier phrase if that would reduce precision.
+If a technical term may confuse the intended reader, define it once or link to its definition. Do not replace an official or canonical technical name with a friendlier phrase if that would reduce precision.
 
 ### Keep one meaning and one grammatical role when possible
 
@@ -99,7 +98,7 @@ Avoid when plain alternatives exist:
 
 Prefer active voice, but passive can be acceptable in descriptive writing when the actor is unknown or irrelevant and active phrasing would reduce accuracy.
 
-Use a different sentence construction when a direct word swap would distort the meaning.
+Use a different sentence structure when a direct word swap would distort the meaning.
 
 ## 4. Condition before command
 
@@ -125,7 +124,7 @@ Prefer:
 - one topic per paragraph
 - short paragraphs for scanability
 
-Target a maximum of 20 words for procedure steps and 25 words for descriptive sentences. Exceed only when splitting would reduce accuracy or readability.
+Target a maximum of 20 words for procedure steps and 25 words for descriptive sentences. Exceed that only when splitting would reduce accuracy or readability.
 
 Break long noun chains with prepositions.
 Preserve official long names on first mention. Then shorten carefully or use an established abbreviation if that improves clarity.
@@ -162,7 +161,7 @@ Put the command or condition first. Then state the risk.
 
 ## 8. Avoid filler and AI-slop markers
 
-Common patterns to delete or rewrite:
+Delete or rewrite these common patterns:
 
 - it is worth noting that
 - crucially

--- a/skills/accelint-english-manager/references/substitutions.md
+++ b/skills/accelint-english-manager/references/substitutions.md
@@ -122,4 +122,4 @@ Watch for phrases that often survive because they sound polished:
 - "flexible"
 - "seamless"
 
-These terms are not weak because they are long. They are weak because they often hide the actual claim. Replace them with evidence or a concrete behavior.
+These terms are not weak because they are long. They are weak because they often hide the real claim. Replace them with evidence or a concrete behavior.

--- a/skills/accelint-english-manager/references/use-cases.md
+++ b/skills/accelint-english-manager/references/use-cases.md
@@ -1,6 +1,6 @@
 # Use cases and adaptation notes
 
-Use this reference to adapt the core writing method to different contexts. Do not flatten everything into the same style.
+Use this reference to adapt the core writing method to different contexts. Do not flatten every case into the same style.
 
 The core defaults still apply:
 - preserve meaning and constraints
@@ -41,7 +41,7 @@ Use:
 - warning before risk
 - numbered procedures
 
-This context benefits strongly from stronger STE-style structure and stronger ADHD-friendly shaping.
+This context benefits from stronger STE-style structure and stronger ADHD-friendly shaping.
 
 ## Error messages and support answers
 
@@ -81,7 +81,7 @@ Use:
 
 Default mode: `mode=default`
 
-Use this section for writing that must be technically clear but still needs persuasion, trust, or brand fit.
+Use this section for writing that must stay technically clear but still needs persuasion, trust, or brand fit.
 
 Examples:
 - RFC summaries
@@ -131,7 +131,7 @@ Still remove:
 
 ## ADHD-friendly chat or coaching output
 
-Default mode: `mode=default`, plus `references/adhd-patterns.md` when the reader needs stronger execution shaping
+Default mode: `mode=default`, plus `references/adhd-patterns.md` when the reader needs stronger execution shaping.
 
 Use:
 - action first


### PR DESCRIPTION
Cherry picked changes from #135 

Three iterations of evals, order of execution was C -> A -> B -> A.

Variant A
1. Comprehensive audit and grade with `skill-creator`
2. Prose optimization with `accelint-skill-prose`
3. Apply changes + changelog bump

Variant B
1. Run full evaluation workflow of `skill-creator`
2. Run iteration loop to improve skills
3. Apply changes + changelog bump

Variant C
1. Run description optimization via `skill-creator`
2. Run evals against description variants
3. Choose best one
4. Validate description include size < 1024 chars