### PR TITLE
feat: evals 3

### DIFF
--- a/skills/accelint-skill-prose/CHANGELOG.md
+++ b/skills/accelint-skill-prose/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [0.8.0] - 2026-08-04
+
+### Changed
+- Updated `SKILL.md` to classify workflow prose into action, gate, readiness check, stage note, branch handler, and landmark checkpoint before restructuring, reducing the risk of pseudo-step inflation during strict rewrites.
+- Added stage-aware rewrite guidance to `SKILL.md`, including when to prefer `## Stage:` containers, when to preserve landmark checkpoint numbers, and when a workflow rewrite must be surfaced as structural instead of local cleanup.
+- Expanded the decision tests and required self-check in `SKILL.md` to catch filler numbering, buried first actions, duplicated stage rules, and unannounced structural changes.
+- Updated `references/serial-instruction-guidance.md` with stronger rules for multi-stage workflows, transition-step qualification, landmark-preservation tradeoffs, and post-rewrite audit questions for pseudo-step inflation.
+- Updated `references/checklist.md` so workflow-safety and output-mode checks explicitly catch stage-note promotion, numbering placeholders, and structural rewrites presented as local cleanup.
+
+### Version
+- Minor release at `0.8.0`.
+
+## [0.7.13] - 2026-08-03
+
+### Changed
+- Updated `references/serial-instruction-guidance.md` to prefer neutral stage-container wording (`Stage` or a descriptive section heading) instead of `Phase` when discussing higher-level workflow containers. This is a low-risk precaution based on repo evidence that some agents treat phase-style headings as checkpoint boundaries.
+
+### Version
+- Patch release at `0.7.13`.
+
+## [0.7.12] - 2026-08-03
+
+### Changed
+- Tightened the serial-order rules in `SKILL.md` to align more closely with the house standard: numbered lists for 2 to 3 short steps, `Step 0` plus a checklist for 4 or more steps, stronger `Requires:` and `Done when:` expectations, and a harder rule against plain bullets for ordered work.
+- Added explicit `Step 0` progress tracking to the required self-check workflow so long verification sequences have visible state and better skip observability.
+- Tightened `references/serial-instruction-guidance.md` so `Step 0` is the default for 4 or more ordered steps and the plain-bullets rule is stated as a hard prohibition.
+
+### Version
+- Patch release at `0.7.12`.
+
+## [0.7.11] - 2026-08-03
+
+### Changed
+- Reworked `SKILL.md` to express key operating flows as explicit ordered steps with stronger dependency and gating language around output-mode selection, artifact discovery, rewrite sequencing, and pre-delivery checks.
+- Added a dedicated serial-order section to `SKILL.md` so explicit and implied sequencing cues in skills, prompts, and general prose are detected and strengthened instead of left as soft paragraph logic.
+- Added `references/serial-instruction-guidance.md` for progressive disclosure of sequencing detection, preferred structures, branch handling, and audit questions for workflow-bearing prose.
+
+### Version
+- Patch release at `0.7.11`.
+
+## [0.7.10] - 2026-07-31
+
+### Fixed
+- Tightened the `SKILL.md` frontmatter description so trigger routing more clearly prefers `accelint-skill-prose` when wording controls behavior, while preserving the existing boundary against broader content strategy, policy work, and ordinary prose cleanup.
+- Reduced a few repeated explanatory lines in `SKILL.md` so the root contract is easier to scan without changing workflow semantics, guardrail strength, or progressive-disclosure handoffs.
+- Added concise maintainer guidance to `README.md` about eval coverage, version alignment, and when to keep changes minimal because no benchmark or transcript evidence justifies broader rewrites.
+- Applied a strict-mode local prose pass to `SKILL.md` and `references/checklist.md`, excluding frontmatter as required, to clarify root-first artifact discovery and improve local sentence flow without changing the behavior contract.
+
+### Version
+- Patch release at `0.7.10`.
+
+## [0.7.9] - 2026-07-30
+
+### Fixed
+- Tightened `assets/output-template.md` so unchanged behavior-bearing artifact-set files must use the exact unchanged-file classifications required by the root skill, and clarified that the template `Why:` field must carry that classification.
+- Applied a strict-mode prose pass across `SKILL.md` and the behavior-bearing `references/*.md` files to improve scanability, local sentence structure, and repeated phrasing without changing trigger coverage, workflow semantics, guardrail strength, or exact technical references.
+- Expanded `evals/evals.json` with additional cases for audit-only output-mode violations, `mode=default` local rewrite limits, folder-level artifact discovery, frontmatter boundary drift, exact verb preservation in workflow warnings, and unchanged-file classification checks.
+
+### Version
+- Patch release at `0.7.9`.
+
 ## [0.7.8] - 2026-07-30
 
 ### Fixed

--- a/skills/accelint-skill-prose/README.md
+++ b/skills/accelint-skill-prose/README.md
@@ -1,6 +1,6 @@
 # accelint-skill-prose
 
-Safely tighten behavior-defining prompt artifacts without changing what they mean or how they behave.
+Safely edit behavior-defining prompt artifacts without changing what they mean or how they behave.
 
 This skill is part of the `gohypergiant/agent-skills` repository. Install it through the repo-wide skills flow, not as a standalone npm package.
 
@@ -10,31 +10,21 @@ Install the skill collection, then select `accelint-skill-prose` when the CLI pr
 
 **npm:**
 ```bash
-npx skills add gohypergiant/agent-skills
+npx skills add https://github.com/gohypergiant/agent-skills --skill accelint-skill-prose
 ```
 
 **pnpm:**
 ```bash
-pnpm dlx skills add gohypergiant/agent-skills
+pnpm dlx skills add https://github.com/gohypergiant/agent-skills --skill accelint-skill-prose
 ```
 
 This skill does not ship as a separate package with its own `package.json`.
-
-## Quick Start
-
-The clearest real invocation pattern in this repo is a folder-level request:
-
-```text
-/accelint-skill-prose <path-to-skill-folder>, audit+rewrite, mode=strict
-```
-
-Use that when you want to audit or tighten a whole skill folder instead of a single pasted paragraph.
 
 ## What is accelint-skill-prose?
 
 `accelint-skill-prose` edits prompt artifacts where wording controls behavior, not just style. That includes `SKILL.md` files, `AGENTS.md` or `CLAUDE.md` guidance, prompt templates, guardrails, workflow notes, and behavior-bearing Markdown in `references/` folders.
 
-Its job is to make those files easier to follow and audit without changing trigger coverage, workflow order, guardrail strength, or exact technical meaning.
+It makes those files easier to follow and audit without changing trigger coverage, workflow order, guardrail strength, or exact technical meaning.
 
 ## Why use it?
 
@@ -83,13 +73,13 @@ Progressive-disclosure reference files that the root skill loads when needed.
 
 | File | Purpose |
 |------|---------|
-| `references/checklist.md` | Final pass checks for output-mode compliance, no-rewrite decisions, and cross-file consistency |
-| `references/frontmatter-descriptions.md` | Safe tightening rules for frontmatter descriptions and trigger language |
-| `references/workflow-guardrails.md` | Guidance for workflow order, approval gates, rationale, and behavior-bearing verbs |
-| `references/ste-compatible-rules.md` | Selective Simplified Technical English patterns adapted for behavior-preserving edits |
-| `references/rfc-2119.md` | Guidance for obligation-strength normalization without changing behavior |
-| `references/examples.md` | Worked examples of safe audits, rewrites, and no-rewrite decisions |
 | `references/artifact-patterns.md` | Positive rewrite patterns for descriptions, workflows, guardrails, rationale, and examples |
+| `references/checklist.md` | Final pass checks for output-mode compliance, no-rewrite decisions, and cross-file consistency |
+| `references/examples.md` | Worked examples of safe audits, rewrites, and no-rewrite decisions |
+| `references/frontmatter-descriptions.md` | Safe tightening rules for frontmatter descriptions and trigger language |
+| `references/rfc-2119.md` | Guidance for obligation-strength normalization without changing behavior |
+| `references/ste-compatible-rules.md` | Selective Simplified Technical English patterns adapted for behavior-preserving edits |
+| `references/workflow-guardrails.md` | Guidance for workflow order, approval gates, rationale, and behavior-bearing verbs |
 
 ### `CHANGELOG.md`
 
@@ -99,13 +89,13 @@ Version history for the skill. This repo uses file-driven versioning for skills,
 
 Evaluation prompts that exercise the skill's behavior. This file is more useful to maintainers than end users, but it is also the best source of real request examples in this package.
 
+The current eval set covers multiple risk classes, including audit-only compliance, frontmatter boundary preservation, workflow verb sensitivity, folder-level artifact discovery, unchanged-file classification, and exact-reference preservation.
+
 ## Examples
 
-These examples come from real files in this skill folder. They are the closest thing this package has to usage examples, and they are better than invented samples.
+These examples come from real eval prompts in `evals/evals.json`. They are the closest thing this package has to usage examples, and they are better than invented samples.
 
 ### Audit-only request
-
-Source: `skills/accelint-skill-prose/evals/evals.json`
 
 ```text
 Audit this workflow prose for behavior risk. Do NOT provide a rewrite, only findings.
@@ -113,19 +103,15 @@ Audit this workflow prose for behavior risk. Do NOT provide a rewrite, only find
 
 Use this when you want risk analysis without replacement text.
 
-### Rewrite-only request
-
-Source: `skills/accelint-skill-prose/evals/evals.json`
+### Rewrite-only request with exact preservation
 
 ```text
 Tighten this instruction without changing step number, approval dependency, timing rule, exact tokens, or rationale. Return only the revised instruction in final output.
 ```
 
-Use this when you already know you want a revision and want tight control over what must stay exact.
+Use this when you want tight control over what must stay exact.
 
 ### Frontmatter-description tightening
-
-Source: `skills/accelint-skill-prose/evals/evals.json`
 
 ```text
 Tighten this skill description without losing trigger phrases or task coverage. Keep it suitable for frontmatter. Return only the revised description in final output.
@@ -135,13 +121,13 @@ Use this when the wording in `description:` helps decide when a skill should tri
 
 ### Folder-level skill audit
 
-Source: `skills/accelint-skill-prose/references/examples.md`
-
 ```text
 Request: Tighten this skill's prose safely. The user pasted only one section, but the skill also has `AGENTS.md` and `references/` files.
 ```
 
 Use this when a local rewrite could create drift across a whole skill folder.
+
+Source: `references/examples.md`
 
 ## File Layout
 
@@ -176,6 +162,9 @@ Apache 2.0 - see [../../LICENSE](../../LICENSE) for details.
 
 ## Contributing
 
-If you update this skill, keep `SKILL.md` and `CHANGELOG.md` aligned.
+If you update this skill:
+- keep `SKILL.md` `metadata.version` and `CHANGELOG.md` aligned
+- update `evals/evals.json` when you change trigger boundaries, output-mode rules, rewrite-mode behavior, or folder-level artifact-set expectations
+- prefer minimal, evidence-backed edits over broad rewrites unless benchmark, transcript, or review evidence justifies larger changes
 
 For the broader contributor workflow, see [../../CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/skills/accelint-skill-prose/SKILL.md
+++ b/skills/accelint-skill-prose/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: accelint-skill-prose
-description: Use when creating, auditing, tightening, simplifying, de-slopping, polishing, or reviewing `SKILL.md` files, agent-skill instructions, `CLAUDE.md`/`AGENTS.md`-style guidance, or other behavior-defining prompt artifacts where wording changes can alter trigger coverage, workflow order, guardrails, or exact technical meaning. Use this skill whenever the user wants clearer skill prose without changing behavior, asks for a safe skill-description rewrite, reviews prompt instructions for ambiguity, or needs to preserve exact paths, commands, fields, identifiers, or approval semantics while editing.
+description: Use when creating, auditing, tightening, simplifying, polishing, or reviewing `SKILL.md` files, agent-skill instructions, `CLAUDE.md` or `AGENTS.md` guidance, or other behavior-defining prompt artifacts whose wording controls trigger coverage, workflow order, guardrails, approval semantics, or exact technical meaning. Prefer this skill over general prose editing when the job is to make wording clearer without changing behavior, including safe description rewrites, ambiguity audits, and edits that must preserve exact paths, commands, fields, or identifiers. Do not use it when the main task is broader content strategy, policy design, domain review, or ordinary prose cleanup with no behavior risk.
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "0.7.8"
+  version: "0.8.0"
 ---
 
 # Skill Prose
 
-Use this skill to edit behavior-defining prose while preserving behavior.
+Use this skill to edit behavior-defining prose without changing behavior.
 
 ## Core contract
 
-This skill applies to text that does more than sound good. It controls when a skill triggers, what it promises, what order work happens in, and what must stay exact.
+Use this skill for text whose wording controls behavior, not just tone. In these artifacts, wording controls when a skill triggers, what it promises, what order work happens in, and what must stay exact.
 
 Write in plain, direct English. Do not treat skill prose like ordinary prose. A cleaner sentence is a bad edit if it changes behavior.
 
-Your job is to make the prose easier to follow, easier to audit, and harder to misread while preserving:
+Make the prose easier to follow, easier to audit, and harder to misread while preserving:
 
 - trigger coverage
 - workflow semantics
@@ -26,7 +26,7 @@ Your job is to make the prose easier to follow, easier to audit, and harder to m
 
 Keep one term for one concept. Do not rotate terms just to avoid repetition. In skill prose, stable terminology is part of the behavior contract.
 
-Use compatible ideas from Simplified Technical English when they help, such as short explicit sentences, consistent terminology, active voice by default, and clear separation between instructions and explanation. Do not apply controlled-language rules mechanically if doing so would erase rationale, flatten scope, or weaken behavioral precision.
+Use compatible ideas from Simplified Technical English when they help, such as short explicit sentences, consistent terminology, active voice by default, and clear separation between instructions and explanation. Do not apply controlled-language rules mechanically if that would erase rationale, flatten scope, or weaken behavioral precision.
 
 This skill extends general English editing with extra safety for:
 
@@ -44,7 +44,7 @@ Use `assets/output-template.md` for all outputs.
 
 ### Behavioral drift
 
-Behavioral drift is not limited to paths, fields, and quoted tokens. If a verb changes what an agent may do, when it may do it, or how strongly a rule applies, that verb is behavior-bearing. Preserve it or replace it only with wording that keeps the same behavior.
+Behavioral drift is not limited to paths, fields, and quoted tokens. If a verb changes what an agent may do, when it may do it, or how strongly a rule applies, that verb is behavior-bearing. Preserve it, or replace it only with wording that keeps the same behavior.
 
 Rationale is not filler by default. If a sentence explains why a guardrail exists, why a checkpoint matters, or what risk a timing rule prevents, preserve that rationale unless the user explicitly asked to change the policy rather than tighten the prose.
 
@@ -66,7 +66,7 @@ These are behavior anchors, not decorative prose.
 
 ## What makes this different from general prose editing
 
-In skill prose, these often carry behavior rather than decoration:
+Use this skill when wording itself controls behavior. In these artifacts, these elements often carry behavior rather than decoration:
 
 - trigger phrases
 - examples that define scope
@@ -107,11 +107,13 @@ When goals conflict, use this order:
 
 ## Operating controls
 
-Choose two controls before you edit:
+Choose these controls before you edit.
+Do them in order.
 
-1. **Output mode** — what you will deliver.
-2. **Rewrite mode** — how far you may reshape the prose.
+1. Choose the output mode. This controls what you will deliver.
+2. Choose the rewrite mode. This controls how far you may reshape the prose.
 
+Do not reverse these steps.
 Keep them separate. Output mode controls the deliverable. Rewrite mode controls the rewrite scope.
 
 ### Output mode
@@ -124,9 +126,9 @@ Use this mode when the user wants review, risk analysis, or a check for ambiguit
 
 Do not rewrite the text unless the user explicitly asks for a rewrite.
 
-Do not include replacement wording, “safer” rewrites, or suggested revised sentences in the deliverable. If you need to point to a safer pattern, describe the risk in principle instead of drafting substitute text.
+Do not include replacement wording, "safer" rewrites, or suggested revised sentences in the deliverable. If you need to point to a safer pattern, describe the risk in principle instead of drafting substitute text.
 
-A brief alternative may appear only when the user explicitly asked for examples, or when a single phrase is necessary evidence for why the source is risky. In those cases, keep it at fragment level, not sentence level, and do not let it become a stealth rewrite of the passage.
+A brief alternative may appear only when the user explicitly asked for examples, or when a single phrase is necessary evidence for why the source is risky. In those cases, keep it at fragment level, not sentence level. Do not let it become a stealth rewrite of the passage.
 
 #### Rewrite only
 
@@ -140,10 +142,10 @@ Use this mode when the user wants both findings and a safer revision.
 
 For rewrite tasks, ask the user which rewrite mode they want unless the user already made the scope clear.
 
-Offer these choices:
+Offer these modes:
 
 - **`mode=default`** — local rewrite by default.
-- **`mode=strict`** — structural rewrite allowed when needed.
+- **`mode=strict`** — structural rewrite is allowed when needed.
 
 For audit-only requests, you may proceed without asking for a rewrite mode. If the task expands into a rewrite, ask for the rewrite mode before you rewrite.
 
@@ -169,7 +171,7 @@ Behavior:
 - preserve behavior, but allow structural rewrite when the structure itself causes ambiguity
 - separate instructions, rationale, warnings, and examples when that improves control
 - normalize terminology and obligation language more deliberately across the edited artifact set
-- reorganize only as far as needed to make trigger scope, workflow order, and guardrail force easier to follow
+- reorganize only as far as needed to make trigger scope, workflow order, and guardrail strength easier to follow
 
 Strict mode is not permission to broaden scope casually. In both modes, keep the smallest change that solves the real problem unless the user explicitly asked for a broader rewrite.
 
@@ -182,9 +184,10 @@ Use these lenses when they match the text:
 
 ## Before you edit
 
-### 1. Extract what must stay fixed
+### Step 1: Extract what must stay fixed
+Do this before you tighten, reorder, or relabel anything.
 
-First normalize vocabulary for the concepts that matter. Pick one term for each repeated concept and keep it throughout the edit. Common clusters include trigger / invoke / activate, audit / review / analyze, and field / key / property.
+First, normalize vocabulary for the concepts that matter. Pick one term for each repeated concept and keep it throughout the edit. Common clusters include trigger / invoke / activate, audit / review / analyze, field / key / property, and workflow-role terms such as stage / step / gate / checkpoint / branch / readiness check.
 
 Look for:
 
@@ -199,22 +202,72 @@ Look for:
 
 If the request says to preserve trigger coverage, exact meaning, or specific tokens, raise the preservation threshold further.
 
-### 2. Define the artifact set when the task covers a skill folder
+### Step 2: Define the artifact set when the task covers a skill folder
+Requires: Step 1 is complete.
 
 Default to the root `SKILL.md`, sibling `AGENTS.md` if present, and behavior-bearing Markdown under `references/`. Add other linked instruction files only when they complete the contract.
 
-Read the root `SKILL.md` first. Then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other instruction files before you broaden to a recursive crawl of likely behavior-bearing support files in the skill folder. This includes linked files and other likely behavior-bearing files such as content under `references/`, templates, checklists, and instruction artifacts, even if the user did not paste them inline.
+Read the root `SKILL.md` first. Then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other instruction files. After that, broaden to a recursive crawl of likely behavior-bearing support files in the skill folder. This includes linked files and other likely behavior-bearing files such as content under `references/`, templates, checklists, and instruction artifacts, even if the user did not paste them inline.
 
 Do not assume the visible excerpt is the full contract.
 
 If file discovery is inconclusive, treat that as unresolved rather than as evidence that no support files exist. Retry with a simpler listing method or direct directory inspection. If you still cannot establish the file set, tell the user that the crawl is incomplete before you rewrite anything that could require cross-file alignment.
 
+Done when: You can name the files that complete the behavior contract, or you have disclosed that the crawl is incomplete.
+
+## Serial-order detection and handling
+
+Treat sequence as behavior when the text tells the agent or reader to do one thing before another.
+
+When you tighten workflow-bearing prose, classify each unit before you restructure it:
+- **Action** — do something now
+- **Gate** — stop, wait, require, or branch
+- **Readiness check** — confirm outputs exist or state is complete
+- **Stage note** — purpose, context isolation, rationale, or input scope
+- **Branch handler** — handle approve / request changes / manual edit
+- **Landmark checkpoint** — a named pause or review moment that downstream prose may reference
+
+Do not give all six categories the same structural weight.
+
+Detect and strengthen these cases:
+- **explicit serial instructions** — numbered steps, `Step 1`, `first/next/then/finally`, `before/after/until`, `requires`, `done when`, `return to`, `do not proceed until`
+- **implied step ordering** — one sentence hides multiple actions, one action uses the output of another, a warning implies an unstated gate, or a paragraph mixes discovery, decision, rewrite, and verification
+- **sequencing cues in skill files** — choose output mode before rewrite mode, define the artifact set before cross-file edits, load references before citing them, run self-check before delivery, ask first before edits that need approval
+- **sequencing cues in general prose** — procedural paragraphs, approval notes, policy instructions, workflow warnings, and bullets that are really ordered tasks
+
+When order matters:
+- make the order explicit
+- use a numbered list for 2 to 3 short ordered steps
+- use `### Step 0` plus a checklist, then `### Step N: Name`, for 4 or more ordered steps
+- give every `### Step N: Name` block an operational body, gate, or completion condition
+- do not create a numbered step if it only restates stage purpose, repeats a nearby context rule, announces the next phase, or preserves numbering without operational value
+- add `Requires:` when a step depends on an earlier step
+- add `Done when:` when later work depends on a successful check
+- add a named failure route when a later step must wait for a passing check
+- split `do X and then Y` into separate steps when compliance would be safer
+- put conditions before actions when that makes timing clearer
+- replace emphasis-only warnings with enforceable gates when a later action depends on an earlier check
+- never leave ordered work in plain bullets
+
+For stage-based workflows:
+- if the document already names stages or phases in multiple places, treat that as evidence of an existing organizing mechanic
+- prefer a `## Stage:` container or equivalent higher-level heading when several consecutive items share one phase purpose
+- keep phase purpose, context-isolation rules, rationale, and entry conditions at stage level unless they need a standalone numbered checkpoint
+- preserve landmark step numbers when they are reused across the file or tied to checkpoints
+- do not preserve low-value filler steps only to keep numbering contiguous
+- if stage boundaries, numbering architecture, checkpoint placement, or overview/checklist alignment would change, classify the rewrite as structural and surface that explicitly
+
+Transition-step rule:
+- a transition step is acceptable only when it enforces a real prohibition, readiness boundary, or handoff state that later steps depend on
+- a transition step is not acceptable if the surrounding stage container already makes the navigation obvious
+
+Load `references/serial-instruction-guidance.md` before you edit workflow-bearing prose whose order, approval timing, validation loop, branch logic, or reference-loading sequence matters. Keep `SKILL.md` operational. Use the reference for the detailed detection pass, structure rules, and edge cases.
+
 ## Rewrite method
 
 Use this method whenever you rewrite behavior-defining prose.
 
-### 1. Lead with the operational point
-
+### Step 1: Lead with the operational point
 Start with the rule, action, boundary, or decision the reader must understand.
 
 - In descriptions, surface the scope logic early.
@@ -224,13 +277,15 @@ Start with the rule, action, boundary, or decision the reader must understand.
 
 Do not add a preamble when the instruction works better without one.
 
-### 2. Keep one term for one concept
+### Step 2: Keep one term for one concept
+Requires: Step 1 is complete.
 
 Pick one term for each repeated behavior-bearing concept and keep it stable.
 
 Do not rotate synonyms for style if those synonyms could suggest different scope, timing, or force.
 
-### 3. Match the sentence shape to the job
+### Step 3: Match the sentence shape to the job
+Requires: Steps 1 and 2 are complete.
 
 Choose the clearest accurate sentence shape for the artifact.
 
@@ -240,37 +295,44 @@ Choose the clearest accurate sentence shape for the artifact.
 - **Rationale** — explain why the rule exists without burying the rule itself.
 - **Examples** — keep only examples that anchor scope, edge cases, or expected behavior.
 
-### 4. Separate instruction from explanation when it helps
+### Step 4: Separate instruction from explanation when it helps
+Requires: Steps 1 to 3 are complete.
 
 Procedural text tells the agent what to do. Descriptive text explains what something means, why a rule exists, or when a rule applies.
 
-Separate them when that makes the behavior easier to follow. Do not force everything into imperative form if that would narrow policy text, flatten rationale, or blur scope.
+Separate them when that makes behavior easier to follow. Do not force everything into imperative form if that would narrow policy text, flatten rationale, or blur scope.
 
-### 5. Put conditions before commands when that clarifies the logic
+### Step 5: Put conditions before commands when that clarifies the logic
+Requires: Steps 1 to 4 are complete.
 
 If a rule depends on a condition, put the condition first when doing so makes the logic easier to follow and does not change timing or emphasis.
 
-### 6. Preserve exact obligation strength
+### Step 6: Preserve exact obligation strength
+Requires: Steps 1 to 5 are complete.
 
 Keep requirement, recommendation, permission, and prohibition at the same level.
 
 Use RFC 2119 terms when they genuinely clarify normative force. Do not normalize severity labels mechanically or just to sound more formal.
 
-### 7. Keep the action path easy to scan
+### Step 7: Keep the action path easy to scan
+Requires: Steps 1 to 6 are complete.
 
 Use short paragraphs, clean lists, and bounded sentences when they make the behavior easier to audit.
 
 Do not reshape source text just to make it feel lighter. Scanability helps only when it preserves the same behavior.
 
-### 8. Use the smallest structure that makes the rule clear
+### Step 8: Use the smallest structure that makes the rule clear
+Requires: Steps 1 to 7 are complete.
 
-Do not over-edit. Improve the prose enough that the intended behavior is easier to follow and harder to misread.
+Do not over-edit. Improve the prose enough to make the intended behavior easier to follow and harder to misread.
+
+If the workflow already has an implicit stage model, prefer stage-aware cleanup over flattening adjacent notes into peer numbered steps.
 
 ## Core rules
 
 ### 1. Treat descriptions as trigger logic
 
-Frontmatter descriptions are not just summaries. They help decide when the skill is used.
+Frontmatter descriptions help decide when the skill is used.
 
 When tightening a description:
 
@@ -280,7 +342,7 @@ When tightening a description:
 - do not add adjacent trigger families unless expansion was explicitly requested
 - do not convert a short description into a broad trigger inventory unless the user asked for that
 
-If a phrase does trigger work, keep it or replace it only with wording that preserves the same scope exactly.
+If a phrase does trigger work, keep it, or replace it only with wording that preserves the same scope exactly.
 
 ### 2. Treat workflow prose as executable guidance
 
@@ -296,8 +358,15 @@ Check for:
 - conditions that gate an action
 - warnings that explain why a step matters
 - verbs that carry behavior, such as `stop`, `pause`, `wait`, `proceed`, `skip`, `require`, or `allow`
+- stage boundaries or phase markers that already organize the workflow
+- landmark checkpoints that other sections may reference
 
 Do not merge steps or compress qualifiers if doing so hides decision points.
+Do not promote stage notes, rationale, or handoff summaries into standalone numbered steps unless they carry real operational weight.
+
+If the document already names phases or stages in multiple places, consider a stage-aware rewrite rather than a flat step rewrite.
+If preserving important checkpoints conflicts with step quality, surface that tradeoff explicitly instead of padding the workflow with filler steps.
+
 Do not swap a behavior-bearing verb for a near-synonym unless the new wording preserves the same permission, timing, and obligation level.
 
 ### 3. Preserve exact references exactly
@@ -411,13 +480,13 @@ Do not prepend audit notes or explanation unless the user asked.
 
 Always include the consistent report from `assets/output-template.md`.
 
-Give the risk summary first, then the rewrite, then the completed report.
+Give the risk summary first. Then give the rewrite. Then give the completed report.
 
 ## Progressive disclosure
 
 Load references only when needed.
 
-When the user asks you to work on a skill, crawl the skill folder first. This tells you what behavior-defining prose exists beyond the current excerpt. Treat the skill folder as one behavior contract distributed across an artifact set, not as a root file with optional extras.
+When the user asks you to work on a skill, crawl the skill folder first. Treat the skill folder as one behavior contract distributed across an artifact set, not as a root file with optional extras.
 
 For folder-level work, the default artifact set is the local `SKILL.md`, sibling `AGENTS.md` if present, and behavior-bearing Markdown under `references/`. Read the local `SKILL.md` first. Then inspect files linked from `SKILL.md`, `AGENTS.md`, and adjacent instruction files before you broaden to other likely behavior-bearing files such as `references/` content, templates, checklists, or adjacent instruction files.
 
@@ -436,6 +505,7 @@ Treat local sentence-structure quality as part of the decision, not as a cosmeti
 
 Load references only when needed:
 
+- `references/serial-instruction-guidance.md` — explicit and implied step order, approval timing, validation loops, branching, and when workflow prose must become stronger ordered steps
 - `references/checklist.md` — final pass before delivery, output-mode compliance, no-rewrite decisions, and cross-file consistency checks
 - `references/frontmatter-descriptions.md` — description tightening, trigger-family preservation, and trigger-scope safety
 - `references/workflow-guardrails.md` — workflow, approval, rationale, verb-sensitivity, and exact-reference preservation
@@ -455,6 +525,12 @@ Before you deliver, ask:
 - Did any behavior-bearing verb drift into a softer or different action?
 - Did any rationale sentence get cut even though it explained a guardrail or timing rule?
 - Did any example that defines scope get removed?
+- Did I create any numbered steps that are really stage notes?
+- Did I preserve numbering at the cost of weak filler steps?
+- Is the first real operation easy to find?
+- Did I duplicate a stage-level rule as a numbered step?
+- Would a stage container be safer than more `### Step N` blocks?
+- If the rewrite changed stages, checkpoints, or numbering architecture, did I classify it as structural?
 - Is the rewrite actually clearer, or just shorter?
 
 If any answer is risky, revise less.
@@ -463,7 +539,29 @@ If the task is audit-only, also ask: did I accidentally draft replacement wordin
 
 ## Required self-check before delivery
 
+### Step 0: Track progress
+Do this before any other work when the verification workflow has 4 or more real actions.
+Create a short checklist in your working state or reply and update it after each step.
+
+- [ ] Step 1: Re-read the trigger or scope language
+- [ ] Step 2: Check for accidental synonym drift
+- [ ] Step 3: Check obligation and severity terms
+- [ ] Step 4: Check referents
+- [ ] Step 5: Re-check exact tokens and behavior-bearing verbs
+- [ ] Step 6: Confirm artifact-set discovery
+- [ ] Step 7: Confirm folder-level coverage
+- [ ] Step 8: Confirm local-tightening sweep status
+- [ ] Step 9: Confirm unchanged-file classification if needed
+- [ ] Step 10: Confirm incomplete-discovery disclosure if needed
+- [ ] Step 11: Confirm rationale preservation
+- [ ] Step 12: Confirm structural-behavior equivalence
+- [ ] Step 13: Confirm ordered behavior is still visible
+- [ ] Step 14: Confirm no pseudo-step inflation or filler numbering
+- [ ] Step 15: Confirm structural-rewrite disclosure if needed
+- [ ] Step 16: Confirm audit-only output stayed findings-only
+
 This step is not optional.
+Do not deliver before this check is complete.
 
 1. Re-read the trigger or scope language. Would it still route the same requests?
 2. Search for terms you did not choose during vocabulary normalization. Replace accidental synonym drift.
@@ -473,11 +571,14 @@ This step is not optional.
 6. Confirm that you followed explicit links and references from `SKILL.md`, `AGENTS.md`, and any inspected instruction files before deciding the artifact set was complete.
 7. Confirm that folder-level work covered the full artifact set: root `SKILL.md`, sibling `AGENTS.md` if present, relevant behavior-bearing `references/*.md`, and any other linked instruction files needed to preserve the contract.
 8. If you changed any file in a folder-level rewrite, confirm that you ran a dedicated local-tightening sweep across the other inspected behavior-bearing files before you left them unchanged.
-9. If any inspected behavior-bearing file stayed unchanged, confirm that you can classify the reason exactly as `Already near minimum safe form`, `Rewrite would add drift risk without meaningful clarity gain`, or `Local-tightening sweep incomplete`. Do not use a generic `No edit needed` classification.
+9. If any inspected behavior-bearing file stayed unchanged, classify the reason exactly as `Already near minimum safe form`, `Rewrite would add drift risk without meaningful clarity gain`, or `Local-tightening sweep incomplete`. Do not use a generic `No edit needed` classification.
 10. If discovery was inconclusive at any point, confirm that you retried discovery or explicitly told the user about the incomplete crawl before proceeding.
 11. Confirm that rationale sentences tied to guardrails, approval gates, or timing rules were preserved when they still carry policy meaning.
 12. If the rewrite changed structure, ask whether an agent following only the new version would behave the same way.
-13. If the task was audit-only, confirm that you did not include sentence-level replacement text unless the user explicitly requested examples.
+13. If the text contains explicit or implied ordered instructions, confirm that the order, gates, branch destinations, and return paths are still visible as ordered behavior.
+14. Confirm that you did not create numbered steps that are really stage notes, preserve numbering by padding filler steps, or bury the first real operation behind transition-only steps.
+15. If the rewrite changed stages, checkpoints, numbering architecture, or overview/checklist alignment, confirm that you classified it as structural rather than presenting it as local cleanup.
+16. If the task was audit-only, confirm that you did not include sentence-level replacement text unless the user explicitly requested examples.
 
 ## Limits
 
@@ -487,7 +588,7 @@ This skill improves behavior-defining prose safely. It does not replace domain r
 
 When a rewrite covers a skill folder, check whether the rest of the inspected artifact set — including the root `SKILL.md`, sibling `AGENTS.md`, `references/` content, and other behavior-bearing support files — now uses stale terminology, inconsistent severity language, mismatched examples, broken progressive-disclosure handoffs, or sentence structures that make the behavior harder to follow than necessary. If you changed any file in the artifact set, do a dedicated local-tightening sweep of the other inspected behavior-bearing files before you leave them unchanged. Edit those files when needed so the folder remains internally consistent and locally clear before you deliver the work.
 
-Cross-file alignment is REQUIRED, but it is not sufficient. Local clarity inside each behavior-bearing file is also part of safe delivery.
+Cross-file alignment is required, but it is not sufficient. Local clarity inside each behavior-bearing file is also part of safe delivery.
 
 If the user wants broad content strategy, new workflow design, or repo-wide policy changes, do not smuggle those changes in through prose cleanup. Surface them explicitly.
 

--- a/skills/accelint-skill-prose/assets/output-template.md
+++ b/skills/accelint-skill-prose/assets/output-template.md
@@ -51,7 +51,9 @@ Keep the report factual. Do not imply that a file was reviewed, changed, or left
 ## Usage notes
 
 - For folder-level work, include the root `SKILL.md`, sibling `AGENTS.md` if present, relevant `references/*.md`, and any other linked instruction files you inspected.
-- If a file stayed unchanged because it was already aligned, say that directly.
+- When a behavior-bearing artifact-set file stays unchanged, use the `Why:` field to record the required unchanged-file classification exactly.
+- If a file stayed unchanged because it was already aligned, classify it explicitly as `Already near minimum safe form` or `Rewrite would add drift risk without meaningful clarity gain`, whichever is accurate.
+- If a file stayed unchanged because local-tightening follow-through is still pending, classify it explicitly as `Local-tightening sweep incomplete`.
 - If a file stayed unchanged because it was out of scope, say that directly.
 - If no `AGENTS.md` exists, do not fabricate an entry for it.
 - For audit-only outputs, give the audit findings first, then append this template.

--- a/skills/accelint-skill-prose/evals/evals.json
+++ b/skills/accelint-skill-prose/evals/evals.json
@@ -451,6 +451,103 @@
         "Explains that support files are eligible for edit when consistency or contract preservation requires it.",
         "Does not limit editing to the pasted excerpt alone."
       ]
+    },
+    {
+      "id": 38,
+      "prompt": "Audit this response for output-mode violations. The user asked for audit only.\n\nResponse draft:\n1. Summary: The wording is ambiguous.\n2. Finding: 'mostly okay' is subjective.\n3. Suggested rewrite: 'Do not skip the detailed review unless the user explicitly approves that shortcut.'\n4. Completed report.\n\nDo not rewrite the source passage. Report only whether the response draft complies with the requested mode and why.",
+      "expected_output": "An audit-only compliance review that flags the included rewrite as an output-mode violation and explains why audit-only delivery must stop at findings unless examples were explicitly requested.",
+      "files": [
+        "SKILL.md",
+        "references/checklist.md",
+        "references/examples.md"
+      ],
+      "expectations": [
+        "Identifies that the draft violates audit-only output mode.",
+        "Flags the sentence-level suggested rewrite as disallowed in this context.",
+        "Explains that findings are allowed but replacement wording is not unless explicitly requested.",
+        "Does not rewrite the source passage."
+      ]
+    },
+    {
+      "id": 39,
+      "prompt": "A user asks for a rewrite-only response in mode=default. The source text is a four-item checklist with correct order, but item 3 is wordy. What kind of rewrite is allowed, and what changes should you avoid?",
+      "expected_output": "A concise explanation that mode=default favors a local rewrite of the wordy item while preserving checklist structure, order, and behavior-bearing wording, without escalating into broader reorganization.",
+      "files": [
+        "SKILL.md",
+        "references/checklist.md",
+        "references/examples.md"
+      ],
+      "expectations": [
+        "States that mode=default favors local cleanup rather than structural rewrite.",
+        "Preserves checklist structure and item order.",
+        "Explains that only the wordy item should be tightened unless structure hides behavior.",
+        "Warns against broader reorganization or obligation drift."
+      ]
+    },
+    {
+      "id": 40,
+      "prompt": "You have already read `SKILL.md` for a skill folder. It links to `references/workflow-guardrails.md`, and the folder also has `references/examples.md`, `templates/review-note.md`, and `notes/brainstorm.md`. Which files should you inspect next before a folder-level rewrite, and why?",
+      "expected_output": "A file-discovery decision that follows linked behavior-bearing instruction files first, includes relevant templates when they complete the contract, and does not automatically treat brainstorming notes as part of the artifact set.",
+      "files": [
+        "SKILL.md",
+        "references/workflow-guardrails.md",
+        "references/examples.md"
+      ],
+      "expectations": [
+        "Prioritizes explicitly linked files such as `references/workflow-guardrails.md`.",
+        "Includes other behavior-bearing instruction files like `references/examples.md` when relevant to the contract.",
+        "Treats `templates/review-note.md` as eligible if it is an instruction-bearing template.",
+        "Does not automatically include `notes/brainstorm.md` as part of the artifact set.",
+        "Explains the decision using progressive disclosure or contract-completion logic."
+      ]
+    },
+    {
+      "id": 41,
+      "prompt": "Audit this frontmatter rewrite for boundary drift. Do NOT rewrite it.\n\nOriginal description boundary: planning-only, no implementation.\nCandidate rewrite: 'Use this skill to plan or implement OpenSpec changes, then carry them through validation.'",
+      "expected_output": "An audit-only response that identifies implementation-scope broadening as boundary drift against a planning-only description.",
+      "files": [
+        "SKILL.md",
+        "references/frontmatter-descriptions.md",
+        "references/checklist.md"
+      ],
+      "expectations": [
+        "Flags that 'plan or implement' broadens a planning-only boundary.",
+        "Identifies this as trigger-scope or boundary drift.",
+        "Explains why this would over-trigger the skill for implementation requests.",
+        "Produces findings only rather than a rewrite."
+      ]
+    },
+    {
+      "id": 42,
+      "prompt": "Tighten this workflow warning without losing the exact verb choice or the reason it matters. Return only the revised text in final output.\n\n\"Do not skip Step 14. Skipping it can bypass the approval gate and let the agent proceed before the user has confirmed the task breakdown.\"",
+      "expected_output": "A tighter warning that preserves the exact verb 'skip', the Step 14 reference, the approval-gate risk, and the premature-proceeding rationale.",
+      "files": [
+        "references/workflow-guardrails.md",
+        "references/examples.md"
+      ],
+      "expectations": [
+        "Preserves 'skip' rather than rotating to a softer or different verb.",
+        "Preserves 'Step 14' exactly.",
+        "Preserves the approval-gate risk.",
+        "Preserves the rationale about proceeding before user confirmation.",
+        "Returns only the revised text."
+      ]
+    },
+    {
+      "id": 43,
+      "prompt": "Audit this folder-level completion note for required unchanged-file classification. Do NOT rewrite the files themselves.\n\nCompletion note: 'SKILL.md changed. references/checklist.md unchanged. references/examples.md unchanged.'",
+      "expected_output": "An audit-only response that identifies the missing required unchanged-file classifications and explains what kind of justification is required for unchanged behavior-bearing files.",
+      "files": [
+        "SKILL.md",
+        "assets/output-template.md",
+        "references/checklist.md"
+      ],
+      "expectations": [
+        "Flags that unchanged files need explicit classification rather than bare unchanged status.",
+        "Mentions accepted classifications such as 'Already near minimum safe form' or 'Rewrite would add drift risk without meaningful clarity gain'.",
+        "Explains why generic 'unchanged' is insufficient for folder-level work.",
+        "Does not rewrite the underlying files."
+      ]
     }
   ]
 }

--- a/skills/accelint-skill-prose/references/artifact-patterns.md
+++ b/skills/accelint-skill-prose/references/artifact-patterns.md
@@ -13,12 +13,14 @@ Goal: keep trigger logic compact, explicit, and stable.
 Use this pattern when you are deciding how to shape the description, not when you are checking trigger-family safety in detail. For trigger-preservation rules, load `frontmatter-descriptions.md`.
 
 Shape descriptions so they:
+
 - name the task clearly
 - keep scope-defining nouns and verbs explicit
 - keep boundary language visible
 - avoid marketing filler
 
 Useful order:
+
 1. what the skill does
 2. when to use it
 3. boundary or non-goal when needed
@@ -30,6 +32,7 @@ Goal: make the action path easy to follow without changing order.
 Use this pattern when you are deciding how to present the workflow, not when you are checking exactness, gates, or timing drift in detail. For those safety checks, load `workflow-guardrails.md`.
 
 Shape workflow prose so it:
+
 - leads with the action or timing boundary
 - keeps one step or decision per line when possible
 - keeps approval gates and stop points explicit
@@ -42,6 +45,7 @@ Goal: make the limit direct, exact, and hard to weaken by paraphrase.
 Use this pattern when you are shaping the prose. For obligation-level normalization, load `rfc-2119.md`.
 
 Shape guardrails so they:
+
 - state the prohibition or requirement directly
 - preserve the original obligation level
 - name the protected behavior or risk when that helps compliance
@@ -52,6 +56,7 @@ Shape guardrails so they:
 Goal: explain why a rule exists without burying the rule itself.
 
 Shape rationale so it:
+
 - follows or sits next to the rule it supports
 - names the failure mode the rule prevents
 - stays descriptive rather than turning into a second procedure
@@ -62,6 +67,7 @@ Shape rationale so it:
 Goal: keep examples only when they do real behavior work.
 
 Keep examples when they:
+
 - define scope
 - mark a boundary case
 - show exact output shape
@@ -74,6 +80,7 @@ Remove or tighten examples only when they are redundant and not doing scope or b
 Goal: help the user act without smuggling in a rewrite.
 
 Shape findings so they:
+
 - lead with the highest-risk issue
 - identify the source text or section clearly
 - explain the behavior risk

--- a/skills/accelint-skill-prose/references/checklist.md
+++ b/skills/accelint-skill-prose/references/checklist.md
@@ -1,6 +1,6 @@
 # Skill prose checklist
 
-Run this before you deliver an audit or rewrite.
+Run this checklist before you deliver an audit or rewrite.
 
 ## 1. Trigger safety
 
@@ -16,6 +16,9 @@ Run this before you deliver an audit or rewrite.
 - Did any approval gate, timing rule, or condition become less clear?
 - Did any warning lose the reason the step matters?
 - Did any behavior-bearing verb change meaning, such as `stop` → `pause`, `wait` → `delay`, or `must` → `should`?
+- Did any numbered step become a stage note, transition-only filler, or numbering placeholder?
+- Is the first real operation still easy to find?
+- If the document already had stages or phases, did the rewrite preserve that organizing mechanic or explicitly justify changing it?
 
 ## 3. Guardrail strength
 
@@ -64,7 +67,7 @@ Check that these stayed exact unless the user asked otherwise:
 ## 8. Cross-file consistency
 
 - If the task covered a skill folder, did you define the default artifact set clearly: root `SKILL.md`, sibling `AGENTS.md` if present, relevant behavior-bearing `references/*.md`, and any other linked instruction files needed to preserve the contract?
-- Did you follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other inspected instruction files before broadening to the rest of the behavior-bearing file set?
+- Did you read the root `SKILL.md` first, then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other inspected instruction files before broadening to the rest of the behavior-bearing file set?
 - Did you audit the full behavior-bearing artifact set rather than only the quoted excerpt, and were those files eligible for edit when consistency required it?
 - Did you rewrite any artifact-set files that needed updates so terminology, severity language, workflow wording, examples, and progressive-disclosure handoffs stayed aligned?
 - Did you also check local sentence-structure quality in each behavior-bearing file, rather than treating cross-file alignment as the only rewrite criterion?
@@ -77,12 +80,12 @@ Check that these stayed exact unless the user asked otherwise:
 - Did you keep output mode separate from rewrite mode?
 - If the request was audit-only, did you avoid rewriting the full passage?
 - If the request was rewrite-only, did you avoid prepending audit notes?
-- If the rewrite used `mode=default`, did you keep the structure local unless structure itself hid behavior?
+- If the rewrite used `mode=default`, did you keep the structure local unless the structure itself hid behavior?
 - If the rewrite used `mode=strict`, did you reorganize only as far as needed to clarify behavior?
+- If the rewrite changed stage boundaries, checkpoint placement, numbering architecture, or overview/checklist alignment, did you classify it as structural instead of presenting it as local cleanup?
 - If the safest result was no rewrite, did you say so explicitly instead of forcing a cosmetic edit?
 
 ## 10. Final question
 
 - Is this behaviorally safer than an ordinary prose edit?
 - If risk remains, should you revise less or recommend no rewrite?
-

--- a/skills/accelint-skill-prose/references/examples.md
+++ b/skills/accelint-skill-prose/references/examples.md
@@ -12,6 +12,7 @@ Use these examples when you need a concrete model for what safe editing looks li
 > If the design looks mostly okay, you can skip the detailed review unless there are obvious red flags.
 
 **Good response shape:**
+
 - Summary of risk
 - Findings with source text, risk, and why it matters
 - No full rewritten passage
@@ -24,6 +25,7 @@ The user asked for audit-only output. Giving a rewritten passage would violate m
 **Request:** Audit this workflow note, then give me a safer rewrite.
 
 **Safe response pattern:**
+
 1. Summary of risk
 2. Findings
 3. Rewritten passage
@@ -88,6 +90,7 @@ It collapses distinct trigger families into a vague bucket and weakens the descr
 **Request:** Tighten this skill's prose safely. The user pasted only one section, but the skill also has `AGENTS.md` and `references/` files.
 
 **Good response pattern:**
+
 1. Define the artifact set: root `SKILL.md`, sibling `AGENTS.md` if present, and the behavior-bearing `references/` files that complete the contract
 2. Read the root `SKILL.md`
 3. Load the behavior-bearing support files that carry workflow rules, examples, trigger guidance, or exact wording constraints, including relevant `references/` files
@@ -114,7 +117,7 @@ A local rewrite can create drift if linked files still use older terms, weaker s
 > Complete device setup first. VPN access is provisioned after your device is configured, and you will not receive credentials until IT confirms setup is complete.
 
 **Why the unsafe version drifts:**
-It escalates a simple note into a more procedural, policy-like instruction and adds process detail the source did not require.
+It escalates a simple note into more procedural, policy-like instruction and adds process detail the source did not require.
 
 ## 8. Preserve rationale when it carries policy
 
@@ -161,4 +164,4 @@ The rewrite leads with timing and action, keeps the dependency explicit, and mak
 > Preserve the checklist logic, but group the items into trigger safety, workflow safety, and exact-reference safety if the current order hides the control points.
 
 **Why this distinction matters:**
-Default mode keeps the structure local. Strict mode allows reorganization only when structure itself is the clarity problem.
+Default mode keeps the structure local. Strict mode allows reorganization only when the structure itself is the clarity problem.

--- a/skills/accelint-skill-prose/references/frontmatter-descriptions.md
+++ b/skills/accelint-skill-prose/references/frontmatter-descriptions.md
@@ -6,7 +6,7 @@ Use this reference when tightening a skill description or other short trigger-de
 
 A frontmatter description is compact trigger logic. Treat it like behavior-defining scope, not like marketing copy.
 
-If the description belongs to a skill folder, check the root `SKILL.md` and the relevant behavior-bearing support files before tightening it. Description wording must still match the actual body guidance and boundaries the skill enforces elsewhere across the folder.
+If the description belongs to a skill folder, check the root `SKILL.md` and the relevant behavior-bearing support files before tightening it. The description must still match the body guidance and boundaries the skill enforces across the folder.
 
 ## Preserve exactly when important
 
@@ -16,7 +16,7 @@ Default to preserving these unless the user asked to change them:
 - quoted trigger phrases
 - trigger families whose coverage depends on grouped examples
 - boundary language such as planning-only or audit-only limits
-- named artifact types like `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, prompts, checklists, templates
+- named artifact types like `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, prompts, checklists, and templates
 - exact tool or command references when they define scope
 
 ## Common failure modes
@@ -50,14 +50,15 @@ Bad examples:
 - remove filler around an existing scope phrase
 - shorten repeated framing while keeping the same trigger nouns and verbs
 - preserve representative trigger families even when you compress their phrasing
-- split one dense sentence into two shorter ones if both preserve the same boundary
-- keep quoted phrases and exact scope anchors intact while tightening surrounding text
+- split one dense sentence into two shorter sentences if both preserve the same boundary
+- keep quoted phrases and exact scope anchors intact while tightening the surrounding text
 
 ## No-rewrite cases
 
 Recommend no rewrite when the description is already compact, exact, and behaviorally clear.
 
 Common signs:
+
 - further shortening would drop a trigger family or boundary
 - a long trigger list is doing real coverage work
 - a rephrase would trade exact scope for prettier wording

--- a/skills/accelint-skill-prose/references/rfc-2119.md
+++ b/skills/accelint-skill-prose/references/rfc-2119.md
@@ -35,7 +35,7 @@ Examples:
 - `optional` step → `MAY` or `OPTIONAL`
 - `never` prohibition → usually `MUST NOT` when the rule is meant as a formal hard stop
 
-Apply this to headings, labels, banners, and inline callouts too — not only sentence-level prose. If a heading says `MANDATORY CHECKPOINT`, `CRITICAL STEP`, or `IMPORTANT`, treat that label as behavior-defining severity language unless it is an exact token that must stay unchanged.
+Apply this to headings, labels, banners, and inline callouts too, not only sentence-level prose. If a heading says `MANDATORY CHECKPOINT`, `CRITICAL STEP`, or `IMPORTANT`, treat that label as behavior-defining severity language unless it is an exact token that must stay unchanged.
 
 Choose the term that matches behavior. Do not strengthen or weaken the source rule by accident.
 
@@ -45,7 +45,7 @@ If a user asks for behavior-preserving cleanup and the source uses severity labe
 
 Do not preserve a rhetorical severity label by default just because it appears in a heading or banner. Normalize it unless preserving the original label is required by an exact-token constraint, a quote-preservation request, or another explicit boundary.
 
-Do not normalize mechanically or just to make the prose sound more formal. If you decide to preserve the original severity label, be able to justify that decision explicitly in terms of exactness constraints rather than style preference.
+Do not normalize mechanically or just to make the prose sound more formal. If you decide to preserve the original severity label, be ready to justify that decision explicitly in terms of exactness constraints rather than style preference.
 
 Prefer obligation language over theatrical severity labels when the text is genuinely normative. `CRITICAL` tells the reader how loudly to feel the rule. `MUST` tells the reader what level of compliance the rule requires.
 

--- a/skills/accelint-skill-prose/references/serial-instruction-guidance.md
+++ b/skills/accelint-skill-prose/references/serial-instruction-guidance.md
@@ -1,0 +1,120 @@
+# Serial-instruction guidance for behavior-defining prose
+
+Use this reference when a skill, prompt, `AGENTS.md`, `CLAUDE.md`, workflow note, or guardrail text contains ordered actions, implied sequence, approval timing, validation loops, or branch logic.
+
+## Why this matters here
+
+In behavior-defining prose, sequence is part of the contract.
+
+If the source says an agent must ask first, wait for approval, load references before rewriting, validate before delivery, or return to an earlier step after a failed check, that order is behavior-bearing. A rewrite that makes the prose cleaner but less ordered is a behavior change.
+
+## Detection pass
+
+Run this pass before you edit workflow-bearing prose.
+
+### 1. Detect explicit serial instructions
+Look for:
+- numbered lists
+- `Step 1`, `Stage 2`, `First`, `Next`, `Then`, `After`, `Finally`
+- `before`, `after`, `until`, `once`, `when`, `only then`
+- `requires`, `depends on`, `done when`
+- `if this fails, return to`
+- `do not proceed until`
+- approval gates such as `ask first`, `wait for confirmation`, `pause`, `stop`, or `resume`
+
+### 2. Detect implied step ordering
+Look for:
+- one sentence that contains two or more actions joined by `and`, `then`, or commas
+- paragraphs that mix discovery, decision, rewrite, and verification in one block
+- warnings that imply a missing gate
+- references that must be loaded before a later action is safe
+- statements where one action clearly uses the result of an earlier action
+
+### 3. Detect sequencing cues in skill files
+Look for:
+- output-mode selection before delivery rules
+- rewrite-mode selection before rewriting
+- artifact discovery before cross-file edits
+- reference-loading conditions before rule citation
+- self-check requirements before delivery
+- approval rules before edits that would broaden scope or change structure
+
+### 4. Detect sequencing cues in general prose
+Look for:
+- procedural guidance hidden inside paragraphs
+- policy or workflow notes that bury a timing rule inside rationale
+- branches written as straight lists
+- bullets that are really ordered tasks
+- banner warnings that try to enforce order without a gate
+
+## Preferred structures
+
+Choose the smallest structure that preserves behavior and makes the order hard to miss.
+
+Before you restructure workflow prose, classify each unit as an action, gate, readiness check, stage note, branch handler, or landmark checkpoint. Do not give all six categories the same structural weight.
+
+### 2 to 3 short ordered steps
+Use a numbered list.
+
+### 4 or more ordered steps
+Use this pattern by default:
+
+### Step 0: Track progress
+Use a checklist or task-tracking step before the workflow.
+
+Then use:
+- `### Step N: Name`
+- `Requires:` for dependencies
+- `Done when:` for gates that later steps rely on
+- an explicit failure route such as `If this check fails, return to Step 3.`
+
+### Multi-stage workflows
+If you need a higher-level container above ordered steps, prefer `## Stage:` or a descriptive section heading. Ordered steps still need their own numbered step headings inside that container.
+
+If the document already names stages or phases in more than one place, treat that as evidence of an existing organizing mechanic rather than flattening everything into peer numbered steps.
+Put phase purpose, context isolation, rationale, and entry conditions at stage level unless they need a standalone numbered checkpoint.
+
+### Branching workflows
+Name each branch and the join point.
+
+Good pattern:
+- `If X, go to Step 4a.`
+- `If not X, go to Step 4b.`
+- `Both branches return to Step 5.`
+
+## Rewrite rules
+
+- Treat one step as one action. Split any step that says `and then`.
+- Do not use empty step headings. Every `### Step N: Name` block must contain at least one operational sentence, gate, or completion condition.
+- Do not create a numbered step if it only restates stage purpose, repeats a nearby context rule, announces the next phase, or preserves numbering without operational value.
+- If a step heading only labels a principle, convert that principle into an action the agent or reader can execute, or demote it to a stage note.
+- Never leave ordered work in plain bullets. Replace plain bullets with ordered steps when the work is not actually optional or unordered.
+- Move conditions before actions when that makes timing clearer without changing behavior.
+- Replace emphasis-only warnings with enforceable gates when the workflow depends on order.
+- Keep approval, validation, and retry logic explicit.
+- Keep sequencing cues in the operational file. Move heuristics, examples, and edge cases to references.
+- If the source contract is weakly ordered but clearly intends sequence, strengthen the wording. Do not preserve weak sequencing just because it is already present.
+- Preserve landmark step numbers when they are reused across the file or tied to checkpoints, but do not pad the workflow with weak filler steps only to keep numbering contiguous.
+- Treat a rewrite as structural when it changes stage boundaries, numbering architecture, checkpoint placement, or overview/checklist alignment.
+- A transition step is acceptable only when it enforces a real prohibition, readiness boundary, or handoff state that later steps depend on.
+
+## Audit questions
+
+Ask these before you finalize the edit:
+1. Could an agent now do these steps out of order and still claim compliance?
+2. Did any `ask first`, `wait`, `pause`, `stop`, `return`, or `do not proceed until` rule become softer?
+3. Did any step heading stay empty or act only as decoration instead of instruction?
+4. Did a paragraph still hide multiple actions that should be separate steps?
+5. Did any branch lose its named destination or rejoin point?
+6. Did any validation or approval rule stay as emphasis instead of becoming a gate?
+7. Did I create any numbered steps that are really stage notes, transition-only fillers, or numbering placeholders?
+8. Is the first real operation still easy to find?
+9. Would a stage container be safer than more peer numbered steps?
+10. If the rewrite changed stage boundaries, numbering, or checkpoints, did I surface it as structural?
+11. Would an agent reading only the rewritten text still follow the same order under load?
+
+## Notes for this skill
+
+Load this reference whenever workflow order, approval semantics, guardrail timing, reference-loading order, or validation loops are central to the edit.
+
+For small local edits, keep the main file compact. For heavier sequencing logic, keep the main `SKILL.md` operational and use this reference for the detection pass, structure rules, and edge cases.

--- a/skills/accelint-skill-prose/references/ste-compatible-rules.md
+++ b/skills/accelint-skill-prose/references/ste-compatible-rules.md
@@ -69,7 +69,7 @@ Good uses:
 - separate rationale from the command it supports
 - separate two different obligations into two sentences
 
-Do not shorten mechanically. If a longer sentence is carrying a necessary boundary, keep it or rewrite it carefully.
+Do not shorten mechanically. If a longer sentence carries a necessary boundary, keep it or rewrite it carefully.
 
 ## 4. Do not omit words just to sound concise
 

--- a/skills/accelint-skill-prose/references/workflow-guardrails.md
+++ b/skills/accelint-skill-prose/references/workflow-guardrails.md
@@ -4,7 +4,7 @@ Use this reference when editing skill prose that controls execution order, appro
 
 ## Treat workflow prose as executable guidance
 
-When the user is editing a skill folder, do not assess a workflow passage in isolation if other files finish the workflow contract. Treat the folder as one behavior contract distributed across an artifact set. Default to the root `SKILL.md`, sibling `AGENTS.md` if present, and relevant behavior-bearing `references/*.md`, then add other linked instruction files as needed. Read the root `SKILL.md`, then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other instruction files before broadening to the relevant behavior-bearing support files so you preserve cross-file order, gates, and exact references.
+When the user is editing a skill folder, do not assess a workflow passage in isolation if other files finish the workflow contract. Treat the folder as one behavior contract distributed across an artifact set. Default to the root `SKILL.md`, sibling `AGENTS.md` if present, and relevant behavior-bearing `references/*.md`, then add other linked instruction files as needed. Read the root `SKILL.md`, then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and other instruction files before you broaden to the relevant behavior-bearing support files so you preserve cross-file order, gates, and exact references.
 
 If discovery is inconclusive, retry with a simpler listing method or direct directory inspection. Do not treat an incomplete crawl as evidence that no linked support files exist.
 
@@ -37,7 +37,7 @@ Keep these exact unless the user explicitly asks otherwise:
 
 - moving a step earlier because it sounds cleaner
 - merging two steps that carry different decisions
-- dropping "not before" or similar timing boundaries
+- dropping `not before` or similar timing boundaries
 
 ### Guardrail weakening
 
@@ -63,6 +63,7 @@ Keep these exact unless the user explicitly asks otherwise:
 ## Verb-sensitivity quick check
 
 Before you deliver, ask:
+
 - Did `stop`, `wait`, `skip`, `proceed`, or similar verbs change to a softer or different action?
 - Did a requirement verb like `must` become advice like `should`?
 - Would the rewritten version let the agent act earlier, later, or more optionally than before?


### PR DESCRIPTION
Cherry picked changes from #135 

Three iterations of evals, order of execution was C -> A -> B -> A.

Variant A
1. Comprehensive audit and grade with `skill-creator`
2. Prose optimization with `accelint-skill-prose`
3. Apply changes + changelog bump

Variant B
1. Run full evaluation workflow of `skill-creator`
2. Run iteration loop to improve skills
3. Apply changes + changelog bump

Variant C
1. Run description optimization via `skill-creator`
2. Run evals against description variants
3. Choose best one
4. Validate description include size < 1024 chars