### PR TITLE
feat: backport fixes

### DIFF
--- a/skills/accelint-architecture-doc/CHANGELOG.md
+++ b/skills/accelint-architecture-doc/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-08-21
+
+### Changed
+- Tightened `SKILL.md` in strict mode to remove avoidable qualitative execution cues around restructure handling while preserving trigger scope, workflow order, and file-writing behavior
+  - Rationale: The skill still contained a behavior-bearing phrase that could act as a self-justifying branch in the restructure path
+- Kept the roadmap interview rule as always-ask behavior and aligned `README.md` with that canonical rule
+  - Rationale: Roadmap and future-plans content cannot be inferred from codebase discovery, so the skill should continue to ask that turn explicitly
+
+### Version
+- Bumped from 1.2.1 → 1.2.2
+
 ## [1.2.1] - 2026-08-20
 
 ### Changed

--- a/skills/accelint-architecture-doc/README.md
+++ b/skills/accelint-architecture-doc/README.md
@@ -63,6 +63,7 @@ For create, refresh, or restructure workflows, start with a short checklist and 
 1. Ask only about `UNKNOWN` fields and confirmed drift gaps.
 2. Group related questions into conversational turns.
 3. Ask only the turns that match remaining gaps.
+4. Always ask the roadmap turn because roadmap and future-plans information cannot be inferred.
 
 ### Step 5: Show the preview and wait for confirmation
 1. Show the complete `ARCHITECTURE.md` with inference source annotations.
@@ -161,7 +162,7 @@ The skill includes 11 eval scenarios in `evals/evals.json` covering create, refr
 
 ## Version
 
-Current version: 1.2.0
+Current version: 1.2.2
 
 See `CHANGELOG.md` for release history.
 

--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -4,7 +4,7 @@ description: Create or update a living ARCHITECTURE.md for a codebase. Use when 
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.1"
+  version: "1.2.2"
 ---
 
 # Architecture Doc
@@ -21,7 +21,7 @@ Generate or update a living `ARCHITECTURE.md` for the current codebase. It shoul
 - **MUST NOT document internal implementation details in the System Diagram (Section 2)** — that section is a 10,000-foot view of components and data flow. Database schemas, function signatures, and module internals belong elsewhere.
 - **MUST use parallel subagents for Stage 2 discovery when subagents are available** — spawn them simultaneously across discovery domains. Do not scan serially. If subagents are unavailable, use focused inline discovery instead.
 
-## Before Writing, Ask
+## Before writing, ask
 
 Check these points before you start.
 Do them in order.
@@ -124,7 +124,7 @@ Classify the task in this order:
    - **Clearly follows the template as an architecture doc** — recognizable top-level architecture sections, with multiple headings that align to the template, such as Project Structure, High-Level System Diagram, Core Components, Data Stores, or Deployment & Infrastructure → **MODE 2: Refresh**
    - **Has real content but does NOT follow the template** → **MODE 3: Restructure** `(offer proactively — see below)`
 
-**MODE 3: Restructure** — When the file has real content in an unrecognized shape and restructuring would materially improve usability, surface this immediately. Require an explicit user choice before you modify that structure:
+**MODE 3: Restructure** — When the file has real content in an unrecognized shape and restructuring would improve usability, surface this immediately. Require an explicit user choice before you modify that structure:
 
 > "ARCHITECTURE.md exists but doesn't follow the standard template structure. I recommend restructuring it — this makes it consistent for agents and engineers onboarding to the codebase. How would you like to proceed?
 >

--- a/skills/accelint-english-manager/CHANGELOG.md
+++ b/skills/accelint-english-manager/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this skill will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to semantic versioning.
 
+## [1.3.9] - 2026-08-21
+
+### Changed
+- Tightened `SKILL.md` so reference-loading order is explicit in drafting, revision, and audit workflows, and so serial-order guidance does not imply a new permission to upgrade warnings into gates.
+- Added a final self-check on qualitative wording so hidden gates and fallback cues are more likely to be caught before delivery.
+
 ## [1.3.8] - 2026-08-19
 
 ### Changed

--- a/skills/accelint-english-manager/SKILL.md
+++ b/skills/accelint-english-manager/SKILL.md
@@ -4,7 +4,7 @@ description: Use when the user wants prose rewritten, tightened, audited, simpli
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.3.8"
+  version: "1.3.9"
 ---
 
 # English Manager
@@ -25,7 +25,7 @@ Use these together. They are not separate modes.
 These outrank style preferences.
 
 - Preserve the user's meaning before you optimize wording.
-- Preserve requested tone, audience fit, and explicit format constraints.
+- Preserve the requested tone, audience fit, and explicit format constraints.
 - Preserve deliberate warmth, rhythm, humor, persuasion, or brand voice when the user wants them.
 - Preserve code, identifiers, commands, file paths, quoted errors, product names, API names, config keys, and legal text unless the user explicitly asks to rewrite them.
 - Keep real uncertainty, real nuance, and real obligation levels. Do not make text sound simpler by making it less true.
@@ -181,7 +181,7 @@ When order matters:
 - add a named failure route when a later step must wait for a passing check
 - split `do X and then Y` into separate steps when that improves compliance
 - put conditions before actions when that makes timing clearer
-- replace emphasis-only warnings with enforceable gates when a later action depends on an earlier check
+- replace emphasis-only warnings with enforceable gates only when a later action already depends on an earlier check
 - never leave ordered work in plain bullets
 
 Load `references/serial-instruction-guidance.md` before you rewrite or audit any text with real workflow order, gating, branching, or validation loops. Keep `SKILL.md` operational. Use the reference for deeper detection logic, structure rules, and edge cases.
@@ -257,7 +257,7 @@ Done when: repeated concepts use stable terms.
 ### Step 7: Make the action path easy to scan
 Requires: Steps 5 and 6 are complete.
 Do this when the reader must act.
-If the text contains ordered actions, load `references/serial-instruction-guidance.md` and make the order explicit.
+If the text contains ordered actions, load `references/serial-instruction-guidance.md` before you make the order explicit.
 Done when: ordered actions are visible as ordered actions.
 
 ### Step 8: Run the self-check before delivery
@@ -307,7 +307,7 @@ Done when: the remaining wording is carrying meaning or control.
 
 ### Step 6: Split overloaded sentences or restructure only when substitution alone will not work
 Requires: Steps 4 and 5 are complete.
-If the source hides sequence, gates, or branch logic, load `references/serial-instruction-guidance.md` and rewrite the sequence explicitly.
+If the source hides sequence, gates, or branch logic, load `references/serial-instruction-guidance.md` before you rewrite the sequence explicitly.
 If sequence checks fail, return to Step 4.
 Done when: the workflow cannot be read as unordered advice.
 
@@ -337,7 +337,7 @@ Done when: the audit shape matches the risk and request.
 
 ### Step 4: Load the right references before citing them
 Requires: Step 3 is complete.
-If the user asked for STE checking, load only the relevant part of `references/ste-rules.md` that you need and do not invent rule numbers.
+If the user asked for STE checking, load only the relevant part of `references/ste-rules.md` that you need. Do not invent rule numbers.
 If the text contains ordered actions or weak sequencing cues, load `references/serial-instruction-guidance.md` before you judge whether the sequence is clear enough.
 Done when: every cited rule comes from a loaded reference.
 
@@ -373,6 +373,7 @@ Before you deliver, confirm:
 6. Any required gate, dependency, or validation step still blocks the later step clearly.
 7. The final answer matches the requested output mode.
 8. The final answer matches the requested rewrite mode.
+9. Any remaining qualitative wording still has a clear operational role and does not act as a hidden gate.
 
 For a deeper mechanical pass, load `references/checklist.md`.
 

--- a/skills/accelint-prompt-manager/CHANGELOG.md
+++ b/skills/accelint-prompt-manager/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the accelint-prompt-manager skill will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2026-08-21
+
+### Added
+- **Focused self-check pass for skill-safe wording changes** — added a dedicated end-of-skill review checklist to catch wording changes that can silently alter behavior
+  - Added serial-instruction, obligation-strength, exact-reference, and cross-file-consistency passes so future edits re-check workflow order, guardrails, and referenced identifiers before handoff
+  - Rationale: this skill is behavior-defining prose, so small wording changes need an explicit final scrutiny step to prevent accidental semantic drift
+
+### Changed
+- **Structured top-level guidance for better scanability without behavior change** — converted narrative guidance under `Your Role and Output` into explicit subsections
+  - Promoted workflow summary, primary delivery, clarification, post-delivery, and example guidance into their own headings so agents can find critical rules faster
+  - Normalized spacing and list formatting around workflow steps to keep the ordered instructions easier to scan
+
+
+### Version
+- Bumped from 2.4.3 → 2.4.4 (patch version: behavior-preserving structure and self-check additions)
+
 ## [2.4.3] - 2026-08-19
 
 ### Changed

--- a/skills/accelint-prompt-manager/SKILL.md
+++ b/skills/accelint-prompt-manager/SKILL.md
@@ -4,7 +4,7 @@ description: Turn user-provided requests, drafts, or prompt text into clearer, m
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "2.4.3"
+  version: "2.4.4"
 allowed-tools: Read AskUserQuestion Write Bash
 ---
 
@@ -21,27 +21,32 @@ Do NOT:
 - **Do NOT try to run the optimized prompt** — Hand the optimized prompt to the user so they or Claude can execute it.
 - **Do NOT research external resources** — Work only with the user's input text. Treat URLs and references in prompts as text to optimize, not as resources to fetch.
 
-Workflow summary:
+### Workflow Summary
+
 1. Decide whether the user wants prompt optimization or task execution.
 2. Identify ambiguities, missing constraints, trade-offs, and complexity.
 3. Create an optimized prompt, or ask targeted clarifying questions when needed.
 4. Deliver the optimized prompt directly to the user.
 5. After delivery, optionally save the optimized prompt or copy it to the clipboard.
 
-Primary delivery:
+### Primary Delivery
+
 - Always present the optimized prompt first in your response, inside a markdown code block for easy copying.
 - Never save files before delivering the optimized prompt.
 
-Clarification rule:
+### Clarification Rule
+
 - If critical details are missing and guessing would materially change the output, ask a small set of targeted questions before producing the final optimized prompt.
 - Group related questions.
 - Explain why the questions matter.
 - Avoid overwhelming the user.
 
-Optional post-delivery:
+### Optional Post-Delivery
+
 - After presenting the optimized prompt, offer to save it to a markdown file, copy it to the clipboard, or both.
 
-Example:
+### Example
+
 - User: "make this data look better"
 - You: *Analyze vagueness* → *Create a clear prompt with specific success criteria* → *Output the optimized prompt in a markdown code block* → *Offer to save or copy the optimized prompt*
 - You do NOT: Try to access the data yourself, or try to make the data look better yourself.
@@ -147,6 +152,7 @@ Use this progress checklist to track optimization:
 ```
 
 ### Step 0: Verify Intent
+
 Ask this gate question before Step 1 unless a skip condition applies:
 
 "I specialize in optimizing prompts to make them clearer and more actionable. Is that what you need, or did you want me to help with the task itself?"
@@ -162,6 +168,7 @@ Skip this gate question when:
 Done when: The skill has confirmed prompt optimization, or it has stopped and handed execution back to the user.
 
 ### Step 1: Intake & Assessment
+
 **Goal:** Determine whether the user wants prompt optimization or task execution. Then understand intent, skill level, task complexity, and execution context.
 
 **Actions:**
@@ -189,6 +196,7 @@ Done when: The skill has confirmed prompt optimization, or it has stopped and ha
 Done when: You have a clear understanding of request type, intent, user calibration, complexity level, and execution context.
 
 ### Step 2: Pattern Detection
+
 **Goal:** Identify credit-killing patterns, ambiguities, and trade-offs that undermine prompt effectiveness.
 
 **Actions:**
@@ -232,6 +240,7 @@ Done when: You have a clear understanding of request type, intent, user calibrat
 Done when: You have a categorized list of patterns, ambiguities, trade-offs, and missing context, plus a decision on whether clarification is required.
 
 ### Step 3: Framework Selection & Optimization
+
 **Goal:** Apply the appropriate framework (CO-STAR, RISEN, or RODES) and safe optimization techniques to create a clear, actionable prompt.
 
 **Actions:**
@@ -274,6 +283,7 @@ Done when: You have a categorized list of patterns, ambiguities, trade-offs, and
 Done when: You have an optimized prompt that addresses the Step 2 issues, applies the appropriate framework structure, and matches the execution context.
 
 ### Step 4: Validation & Handoff
+
 **Goal:** Quality-check the optimized prompt and provide clear next steps.
 
 **Actions:**
@@ -306,7 +316,7 @@ Done when: You have an optimized prompt that addresses the Step 2 issues, applie
    - Use triple backticks with the `markdown` language identifier for clean formatting.
 
 5. **Offer Post-Delivery Options**
-   Do this only after Step 4 is complete and the optimized prompt is already delivered.
+   - Do this only after Step 4 is complete and the optimized prompt is already delivered.
 
    Offer:
    - "Would you like me to save this to a markdown file?"
@@ -365,3 +375,14 @@ Use these defaults unless the user or context clearly calls for something else:
 3. **Extremely vague request** — Ask foundational questions such as artifact type, audience, purpose, constraints, and success criteria before drafting.
 4. **High-complexity execution request** — Recommend plan mode in the optimized prompt or guidance because the downstream task needs design before execution.
 5. **Prompt already strong** — Make only small, high-value edits rather than forcing a full framework rewrite.
+
+## Focused Self-Check
+
+Before you finish, run these focused scrutiny passes:
+
+1. **Serial instruction pass** — Confirm step order, gates, skip conditions, and post-delivery timing are explicit and still correct.
+2. **Plain-English pass** — Tighten expository prose so it stays direct and easy to scan without dropping behavior.
+3. **Qualitative wording pass** — Remove or tighten unnecessary qualitative wording that can act as a hidden gate or permission slip.
+4. **Obligation pass** — Confirm requirement strength stays exact, especially around `MUST`, `DO NOT`, `NEVER`, and plan-mode guidance.
+5. **Exact-reference pass** — Re-check file paths, framework names, tool names, commands, and quoted user-facing text.
+6. **Cross-file consistency pass** — Re-check loaded references and `AGENTS.md` for terminology, workflow, and guardrail alignment.

--- a/skills/accelint-skill-prose/CHANGELOG.md
+++ b/skills/accelint-skill-prose/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.9.4] - 2026-08-21
+
+### Changed
+- Tightened `SKILL.md` operating controls and later workflow sections so ordered headings stay scoped, the required output-mode and rewrite-mode selection order stays visible, and prerequisite/completion lines use a consistent `Requires: Complete ...` / `Done when:` style
+- Reworked the `SKILL.md` self-check so the former `Step 1.5` qualitative-gate check is folded into `Step 2`, keeping the numbered verification flow linear and the Step 0 checklist aligned with the verification headings
+- Clarified `SKILL.md` progressive-disclosure wording so the default folder-level artifact set appears before the crawl-order instructions, reducing duplicate discovery wording without changing the required read order
+- Tightened `SKILL.md` response-formatting guidance and `README.md` support-file descriptions so the folder-level contract stays easier to scan and the published docs mention qualitative-gate detection explicitly
+
+### Version
+- Patch release at `0.9.4`.
+
 ## [0.9.3] - 2026-08-20
 
 ### Changed

--- a/skills/accelint-skill-prose/README.md
+++ b/skills/accelint-skill-prose/README.md
@@ -69,7 +69,7 @@ If you use this skill for audit-only, rewrite-only, or audit-plus-rewrite work, 
 
 ### `references/*.md`
 
-Progressive-disclosure reference files that can complete the behavior contract when the root skill depends on them.
+Progressive-disclosure reference files that can complete the behavior contract when the root `SKILL.md` depends on them.
 
 | File | Purpose |
 |------|---------|
@@ -90,7 +90,7 @@ Version history for the skill. This repo uses file-driven versioning for skills,
 
 Evaluation prompts that exercise the skill's behavior. This file is more useful to maintainers than end users, but it is also the best source of real request examples in this package.
 
-The current eval set covers multiple risk classes, including audit-only compliance, frontmatter boundary preservation, workflow verb sensitivity, folder-level artifact discovery, unchanged-file classification, and exact-reference preservation.
+The current eval set covers multiple risk classes, including audit-only compliance, frontmatter boundary preservation, workflow verb sensitivity, folder-level artifact discovery, unchanged-file classification, exact-reference preservation, and qualitative-gate detection.
 
 ## Examples
 

--- a/skills/accelint-skill-prose/SKILL.md
+++ b/skills/accelint-skill-prose/SKILL.md
@@ -4,7 +4,7 @@ description: Use when creating, auditing, tightening, simplifying, polishing, or
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "0.9.3"
+  version: "0.9.4"
 ---
 
 # Skill Prose
@@ -124,9 +124,9 @@ Do them in order.
 Do not reverse these steps.
 Keep them separate. Output mode controls the deliverable. Rewrite mode controls the rewrite scope.
 
-### Output mode
+### Operating control 1: Choose the output mode
 
-Choose the output mode first. Output mode controls the deliverable, not the rewrite scope.
+Output mode controls the deliverable, not the rewrite scope.
 
 #### Audit only
 
@@ -148,7 +148,7 @@ Use this mode when the user wants cleaner final text directly.
 
 Use this mode when the user wants both findings and a safer revision.
 
-### Rewrite mode
+### Operating control 2: Choose the rewrite mode
 
 Choose the rewrite mode after the output mode.
 
@@ -161,7 +161,7 @@ Offer these modes:
 
 For audit-only requests, you may proceed without asking for a rewrite mode. If the task expands into a rewrite, ask for the rewrite mode before you rewrite.
 
-### Apply the rewrite mode
+### Operating control 3: Apply the rewrite mode
 
 #### `mode=default`
 
@@ -187,7 +187,7 @@ Behavior:
 
 Strict mode is not permission to broaden scope casually. In both modes, keep the smallest change that solves the real problem unless the user explicitly asked for a broader rewrite.
 
-### Artifact focus
+### Operating control 4: Choose the artifact focus
 
 Use these lenses when they match the text:
 
@@ -196,7 +196,7 @@ Use these lenses when they match the text:
 
 ## Before you edit
 
-### Step 1: Extract what must stay fixed
+### Before-you-edit step 1: Extract what must stay fixed
 Do this before you tighten, reorder, or relabel anything.
 
 First, normalize vocabulary for the concepts that matter. Pick one term for each repeated concept and keep it throughout the edit when the source already treats those terms as equivalent. Common clusters include trigger / invoke / activate, audit / review / analyze, field / key / property, and workflow-role terms such as stage / step / gate / checkpoint / branch / readiness check. Do not normalize two source terms into one if they may differ in permission, timing, scope, or workflow role.
@@ -215,8 +215,8 @@ Look for:
 
 If the request says to preserve trigger coverage, exact meaning, or specific tokens, raise the preservation threshold further.
 
-### Step 2: Define the artifact set when the task covers a skill folder
-Requires: Step 1 is complete.
+### Before-you-edit step 2: Define the artifact set when the task covers a skill folder
+Requires: Complete Before-you-edit step 1.
 
 Default to the root `SKILL.md`, sibling `AGENTS.md` if present, and behavior-bearing Markdown under `references/`. Add other linked instruction files when the root file depends on them for trigger scope, workflow order, guardrails, examples that define scope, or exact-reference meaning. Do not infer contract significance from perceived usefulness alone.
 
@@ -234,7 +234,7 @@ Treat sequence as behavior when the text tells the agent or reader to do one thi
 
 Load `references/serial-instruction-guidance.md` before you edit workflow-bearing prose whose order, approval timing, validation loop, branch logic, or reference-loading sequence matters. Keep `SKILL.md` operational. Use the reference for the detailed detection pass, structure rules, and edge cases.
 
-### Step 1: Classify each workflow unit before you restructure it
+### Serial-order step 1: Classify each workflow unit before you restructure it
 Classify each unit as one of these:
 - **Action** — do something now
 - **Gate** — stop, wait, require, or branch
@@ -244,19 +244,19 @@ Classify each unit as one of these:
 - **Landmark checkpoint** — a named pause or review moment that downstream prose may reference
 
 Do not give all six categories the same structural weight.
-Done when: every unit you may reshape has a category.
+Done when: Every unit you may reshape has a category.
 
-### Step 2: Detect ordered behavior before you tighten it
-Requires: Step 1 is complete.
+### Serial-order step 2: Detect ordered behavior before you tighten it
+Requires: Complete Serial-order step 1.
 Detect and make these cases explicit without adding new behavior:
 - **explicit serial instructions** — numbered steps, `Step 1`, `first/next/then/finally`, `before/after/until`, `requires`, `done when`, `return to`, `do not proceed until`
 - **implied step ordering** — one sentence hides multiple actions, one action uses the output of another, a warning implies an unstated gate, a qualitative cue acts as a hidden fallback condition, or a paragraph mixes discovery, decision, rewrite, and verification
 - **sequencing cues in skill files** — choose output mode before rewrite mode, define the artifact set before cross-file edits, load references before citing them, run self-check before delivery, ask first before edits that need approval
 - **sequencing cues in general prose** — procedural paragraphs, approval notes, policy instructions, workflow warnings, and bullets that are really ordered tasks
-Done when: you can name the ordered actions, gates, checks, and branches that the rewrite must preserve.
+Done when: You can name the ordered actions, gates, checks, and branches that the rewrite must preserve.
 
-### Step 3: Choose the smallest ordered structure that keeps compliance visible
-Requires: Step 2 is complete.
+### Serial-order step 3: Choose the smallest ordered structure that keeps compliance visible
+Requires: Complete Serial-order step 2.
 When order matters:
 - make the order explicit
 - use a numbered list for 2 to 3 short ordered steps
@@ -270,10 +270,10 @@ When order matters:
 - put conditions before actions when that makes timing clearer
 - restate an enforceable gate only when the source already makes the dependency mandatory through explicit timing, requirement, or stop/wait language
 - never leave ordered work in plain bullets
-Done when: the workflow shape makes the intended order, gates, and retry path hard to miss.
+Done when: The workflow shape makes the intended order, gates, and retry path hard to miss.
 
-### Step 4: Preserve stage mechanics and reject filler steps
-Requires: Step 3 is complete.
+### Serial-order step 4: Preserve stage mechanics and reject filler steps
+Requires: Complete Serial-order step 3.
 For stage-based workflows:
 - if the document already names stages or phases in multiple places, treat that as evidence of an existing organizing mechanic
 - prefer a `## Stage:` container or equivalent higher-level heading when several consecutive items share one phase purpose
@@ -285,13 +285,13 @@ For stage-based workflows:
 Transition-step rule:
 - a transition step is acceptable only when it enforces a real prohibition, readiness boundary, or handoff state that later steps depend on
 - a transition step is not acceptable if the surrounding stage container already makes the navigation obvious
-Done when: stage notes stay at stage level, operational steps stay operational, and any structural rewrite is disclosed as structural.
+Done when: Stage notes stay at stage level, operational steps stay operational, and any structural rewrite is disclosed as structural.
 
 ## Rewrite method
 
 Use this method whenever you rewrite behavior-defining prose.
 
-### Step 1: Lead with the operational point
+### Rewrite-method step 1: Lead with the operational point
 Start with the rule, action, boundary, or decision the reader must understand.
 
 - In descriptions, surface the scope logic early.
@@ -301,15 +301,15 @@ Start with the rule, action, boundary, or decision the reader must understand.
 
 Do not add a preamble when the instruction works better without one.
 
-### Step 2: Keep one term for one concept
-Requires: Step 1 is complete.
+### Rewrite-method step 2: Keep one term for one concept
+Requires: Complete Rewrite-method step 1.
 
 Pick one term for each repeated behavior-bearing concept and keep it stable.
 
 Do not rotate synonyms for style if those synonyms could suggest different scope, timing, or force.
 
-### Step 3: Match the sentence shape to the job
-Requires: Steps 1 and 2 are complete.
+### Rewrite-method step 3: Match the sentence shape to the job
+Requires: Complete Rewrite-method steps 1 and 2.
 
 Choose the clearest accurate sentence shape for the artifact.
 
@@ -319,34 +319,34 @@ Choose the clearest accurate sentence shape for the artifact.
 - **Rationale** — explain why the rule exists without burying the rule itself.
 - **Examples** — keep only examples that anchor scope, edge cases, or expected behavior.
 
-### Step 4: Separate instruction from explanation when it helps
-Requires: Steps 1 to 3 are complete.
+### Rewrite-method step 4: Separate instruction from explanation when it helps
+Requires: Complete Rewrite-method steps 1 to 3.
 
 Procedural text tells the agent what to do. Descriptive text explains what something means, why a rule exists, or when a rule applies.
 
 Separate them when that makes behavior easier to follow. Do not force everything into imperative form if that would narrow policy text, flatten rationale, or blur scope.
 
-### Step 5: Put conditions before commands when that clarifies the logic
-Requires: Steps 1 to 4 are complete.
+### Rewrite-method step 5: Put conditions before commands when that clarifies the logic
+Requires: Complete Rewrite-method steps 1 to 4.
 
 If a rule depends on a condition, put the condition first when doing so makes the logic easier to follow and does not change timing or emphasis.
 
-### Step 6: Preserve exact obligation strength
-Requires: Steps 1 to 5 are complete.
+### Rewrite-method step 6: Preserve exact obligation strength
+Requires: Complete Rewrite-method steps 1 to 5.
 
 Keep requirement, recommendation, permission, and prohibition at the same level.
 
 Preserve original obligation wording by default. Use RFC 2119 terms only when the user explicitly asked for normalization or when the source already states the obligation level unambiguously and the conversion is strictly lossless. Do not normalize severity labels mechanically or just to sound more formal.
 
-### Step 7: Keep the action path easy to scan
-Requires: Steps 1 to 6 are complete.
+### Rewrite-method step 7: Keep the action path easy to scan
+Requires: Complete Rewrite-method steps 1 to 6.
 
 Use short paragraphs, clean lists, and bounded sentences when they make the behavior easier to audit.
 
 Do not reshape source text just to make it feel lighter. Scanability helps only when it preserves the same behavior.
 
-### Step 8: Use the smallest structure that makes the rule clear
-Requires: Steps 1 to 7 are complete.
+### Rewrite-method step 8: Use the smallest structure that makes the rule clear
+Requires: Complete Rewrite-method steps 1 to 7.
 
 Do not over-edit. Improve the prose enough to make the intended behavior easier to follow and harder to misread.
 
@@ -468,7 +468,7 @@ If the text is already compact, exact, and behaviorally clear, prefer an explici
 
 Rewrite mode controls how far you may reshape the source. Output mode controls what you return to the user.
 
-For your own responses, you may borrow lightweight cognitive-load reduction patterns when they improve response navigation without changing claim strength. Good examples include numbered findings, explicit next steps, and brief progress-visible summaries.
+For your own responses, you may use lightweight navigation aids when they improve scanability without changing claim strength. Good examples include numbered findings, explicit next steps, and brief progress-visible summaries.
 
 Formatting help applies to the response only, not to the source text or its policy content. Do not let response-formatting choices override audit accuracy. Do not reshape source text just to make it feel more ADHD-friendly unless the user explicitly asked for that delivery style.
 
@@ -513,9 +513,9 @@ Load references only when needed.
 
 When the user asks you to work on a skill, crawl the skill folder first. Treat the skill folder as one behavior contract distributed across an artifact set, not as a root file with optional extras.
 
-Do the crawl in order. Read the local `SKILL.md` first. Then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and adjacent instruction files before you broaden to other likely behavior-bearing files.
+For folder-level work, the default artifact set is the local `SKILL.md`, sibling `AGENTS.md` if present, and behavior-bearing Markdown under `references/`.
 
-For folder-level work, the default artifact set is the local `SKILL.md`, sibling `AGENTS.md` if present, and behavior-bearing Markdown under `references/`. Read the local `SKILL.md` first. Then inspect files linked from `SKILL.md`, `AGENTS.md`, and adjacent instruction files before you broaden to other likely behavior-bearing files such as `references/` content, templates, checklists, or adjacent instruction files.
+Do the crawl in order. Read the local `SKILL.md` first. Then follow explicit links and references from `SKILL.md`, `AGENTS.md`, and adjacent instruction files before you broaden to other likely behavior-bearing files such as `references/` content, templates, checklists, or adjacent instruction files.
 
 When the task covers a skill folder, audit the artifact set, not only the quoted excerpt. Rewrite other artifact-set files only when a source-preserving inconsistency would otherwise remain after the requested edit, such as a mismatch in terminology, obligation level, examples that define scope, workflow wording, or progressive-disclosure handoffs.
 
@@ -575,23 +575,22 @@ If the task is audit-only, also ask: did I accidentally draft replacement wordin
 Do this before any other work when the verification workflow has 4 or more real actions.
 Create a short checklist in your working state or reply and update it after each step.
 
-- [ ] Step 1: Re-read the trigger or scope language
-- [ ] Step 1.5: Check qualitative gates and fallback cues
-- [ ] Step 2: Check for accidental synonym drift
-- [ ] Step 3: Check obligation and severity terms
-- [ ] Step 4: Check referents
-- [ ] Step 5: Re-check exact tokens and behavior-bearing verbs
-- [ ] Step 6: Confirm artifact-set discovery
-- [ ] Step 7: Confirm folder-level coverage
-- [ ] Step 8: Confirm local-tightening sweep status
-- [ ] Step 9: Confirm unchanged-file classification if needed
-- [ ] Step 10: Confirm incomplete-discovery disclosure if needed
-- [ ] Step 11: Confirm rationale preservation
-- [ ] Step 12: Confirm structural-behavior equivalence
-- [ ] Step 13: Confirm ordered behavior is still visible
-- [ ] Step 14: Confirm no pseudo-step inflation or filler numbering
-- [ ] Step 15: Confirm structural-rewrite disclosure if needed
-- [ ] Step 16: Confirm audit-only output stayed findings-only
+- [ ] Re-read the trigger or scope language
+- [ ] Check qualitative gates, fallback cues, and accidental synonym drift
+- [ ] Check obligation and severity terms
+- [ ] Check referents
+- [ ] Re-check exact tokens and behavior-bearing verbs
+- [ ] Confirm artifact-set discovery
+- [ ] Confirm folder-level coverage
+- [ ] Confirm local-tightening sweep status
+- [ ] Confirm unchanged-file classification if needed
+- [ ] Confirm incomplete-discovery disclosure if needed
+- [ ] Confirm rationale preservation
+- [ ] Confirm structural-behavior equivalence
+- [ ] Confirm ordered behavior is still visible
+- [ ] Confirm no pseudo-step inflation or filler numbering
+- [ ] Confirm structural-rewrite disclosure if needed
+- [ ] Confirm audit-only output stayed findings-only
 
 This step is not optional.
 Do not deliver before this check is complete.
@@ -599,15 +598,13 @@ Do not deliver before this check is complete.
 ### Step 1: Re-read the trigger or scope language
 Would it still route the same requests?
 
-### Step 1.5: Check qualitative gates and fallback cues
+### Step 2: Check qualitative gates, fallback cues, and accidental synonym drift
 Search for qualitative words and phrases that may act as hidden gates, exceptions, or permission slips, such as `small`, `large`, `simple`, `complex`, `practical`, `impractical`, `reasonable`, `brittle`, `significant`, `materially`, `beneficial`, `if needed`, `when appropriate`, `without reason`, and environment-shaping phrases like `constrained environment`.
 Confirm that each remaining use is either source-supported and operationally bounded, or explicitly flagged as unresolved policy ambiguity. Confirm that no qualitative branch term was merely replaced with another qualitative branch term.
-
-### Step 2: Check for accidental synonym drift
 Search for terms you did not choose during vocabulary normalization. Replace accidental synonym drift.
 
 ### Step 3: Check obligation and severity terms
-Search for `MUST`, `REQUIRED`, `MUST NOT`, `SHOULD`, `RECOMMENDED`, `MAY`, `OPTIONAL`, `avoid`, `critical`, `important`, `mandatory`, and `required`.
+Search for `MUST`, `REQUIRED`, `MUST NOT`, `SHOULD`, `RECOMMENDED`, `MAY`, `OPTIONAL`, `avoid`, `never`, `critical`, `important`, `mandatory`, and `required`.
 Confirm obligation strength did not shift by accident. Check headings, banners, and checkpoint labels too, not just sentence-level prose. If you normalized severity labels, confirm the source already made the obligation level explicit enough to preserve exactly. If you preserved an informal severity label like `MANDATORY` or `CRITICAL`, confirm you had an exactness reason to do so.
 
 ### Step 4: Check referents
@@ -623,7 +620,7 @@ Confirm that you followed explicit links and references from `SKILL.md`, `AGENTS
 Confirm that folder-level work covered the full artifact set: root `SKILL.md`, sibling `AGENTS.md` if present, relevant behavior-bearing `references/*.md`, and any other linked instruction files needed to preserve the contract.
 
 ### Step 8: Confirm local-tightening sweep status
-Requires: Step 7 is complete.
+Requires: Complete self-check Step 7.
 If you changed any file in a folder-level rewrite, confirm that you ran a dedicated local-tightening sweep across the other inspected behavior-bearing files before you left them unchanged.
 
 ### Step 9: Confirm unchanged-file classification if needed
@@ -649,17 +646,3 @@ If the rewrite changed stages, checkpoints, numbering architecture, or overview/
 
 ### Step 16: Confirm audit-only output stayed findings-only
 If the task was audit-only, confirm that you did not include sentence-level replacement text unless the user explicitly requested examples.
-
-## Limits
-
-This skill is not a full Simplified Technical English enforcement pass, and it is not a general ADHD-friendly rewriting mode. Use compatible ideas from those disciplines selectively and subordinate them to behavior preservation.
-
-This skill improves behavior-defining prose safely. It does not replace domain review.
-
-When a rewrite covers a skill folder, check whether the rest of the inspected artifact set — including the root `SKILL.md`, sibling `AGENTS.md`, `references/` content, and other behavior-bearing support files — now uses stale terminology, inconsistent severity language, mismatched examples, broken progressive-disclosure handoffs, or other concrete mismatches that would change the behavior contract. If you changed any file in the artifact set, run a consistency check across the other inspected behavior-bearing files before you leave them unchanged. Edit those files only when needed so the folder remains internally consistent without propagating optional stylistic preferences before you deliver the work.
-
-Cross-file alignment is required, but it is not sufficient. Local clarity inside each behavior-bearing file matters only after behavior preservation and concrete consistency checks pass.
-
-If the user wants broad content strategy, new workflow design, or repo-wide policy changes, do not smuggle those changes in through prose cleanup. Surface them explicitly.
-
-This skill does not impose arbitrary word-count limits, blanket modal bans, or creative-writing style rules. Use compact wording where it improves clarity, but preserve precision when precision is the behavior.


### PR DESCRIPTION
@belsrc had some great input on one of our `accelint-architecture-doc` evaluation updates where the `accelint-skill-prose` skill was injecting qualitative wording unnecessarily. As such, this is just re-running `accelint-skill-prose` on the skills we had previously updated to ensure they follow the new guidance.