### PR TITLE
refactor: make skill invocation agent agnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,31 @@ I do not want a report, just apply the new content to the output directly.
 Invoke the openspec-bulk-archive-change skill.
 ```
 
+### Placeholder Replacement in Instructions
+
+When writing skill instructions that include placeholders to be replaced by agents:
+
+**Include step references in placeholders** — use `<paste X from step N>` instead of `<paste X>` to make replacement intent explicit and avoid confusion
+
+**Problem pattern:**
+```
+OpenSpec Design Rules (from config.yaml):
+<paste the rules.design section verbatim>
+```
+*Result: May send literal `<paste the rules.design section verbatim>` to subagent without replacement*
+
+**Correct pattern:**
+```
+OpenSpec Design Rules (from config.yaml):
+<paste the rules.design section verbatim from step 18>
+```
+*Result: Agent knows to replace with content from step 18 before passing to subagent*
+
+This applies when:
+- Writing multi-step skill instructions with placeholders
+- Constructing prompts for subagents that should include content from earlier steps
+- Any situation where placeholder replacement timing matters
+
 ---
 
 ## Workflow Procedures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,26 +30,24 @@ Focus primarily on creating, auditing, refining, and documenting reusable agent 
 
 ## Skill Invocation Convention
 
-When skills need to invoke other skills (either directly or in subagent prompts), use **agent-agnostic XML-based invocation** instead of slash-command syntax. This ensures compatibility across different agent harnesses (Claude Code, Codex, Pi, etc.).
+When skills need to invoke other skills (either directly or in subagent prompts), use **prose-based invocation**. This approach is simple, agent-agnostic, and works reliably across different harnesses (Claude Code, Codex, Pi, etc.).
 
 ### Standard Format
 
-```xml
-<skill_invocation>
-  <skill>skill-name</skill>
-  <args>arguments-if-any</args>
-</skill_invocation>
+Use natural language to direct skill invocation:
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "skill-name" — do not attempt to run this as a terminal command.
+```
+Invoke the [skill-name] skill.
+
+[any arguments or context for the skill]
 ```
 
 ### Why This Format
 
+- **Simple and clear**: Uses natural language that agents understand reliably
 - **Agent-agnostic**: Works across Claude Code, Codex, Pi, and other harnesses
-- **Explicit intent**: The XML structure and negative instruction prevent misinterpretation as shell commands
-- **Parseable**: Structured format makes it easy for harnesses to detect and route skill invocations
-- **Self-documenting**: The negative instruction clarifies intent for both agents and humans reading the skill
+- **Flexible**: Easily accommodates complex arguments and contextual information
+- **Proven**: After testing structured approaches (XML, slash commands), prose proved most reliable
 
 ### When to Use
 
@@ -59,48 +57,35 @@ Execute the internal skill "skill-name" — do not attempt to run this as a term
 
 ### What NOT to Use
 
-- **Slash commands**: `/skill-name` — harness-specific, easily confused with shell commands
-- **Backtick references**: `` `skill-name` `` — only for prose references, not actual invocations
+- **Slash commands**: `/skill-name` — harness-specific, not reliable across platforms
+- **XML tags**: `<skill_invocation>` — overly complex, doesn't work reliably
 - **Function-style calls**: `skill-name()` — ambiguous, no standard parsing
 
 ### Examples
 
-**Single skill with simple argument:**
-```xml
-<skill_invocation>
-  <skill>opsx:apply</skill>
-  <args>change-name</args>
-</skill_invocation>
+**Skill with simple argument:**
+```
+Invoke the openspec-apply-change skill.
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+change-name
 ```
 
 **Skill with complex arguments:**
-```xml
-<skill_invocation>
-  <skill>accelint-english-manager</skill>
-  <args>audit+rewrite in strict mode the following:
+```
+Invoke the accelint-english-manager skill.
+
+audit+rewrite in strict mode the following:
 
 "
 [CONTENT HERE]
 "
 
-I do not want a report, just apply the new content to the output directly.</args>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
+I do not want a report, just apply the new content to the output directly.
 ```
 
 **Skill with no arguments:**
-```xml
-<skill_invocation>
-  <skill>opsx:bulk-archive</skill>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+```
+Invoke the openspec-bulk-archive-change skill.
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,83 @@ Focus primarily on creating, auditing, refining, and documenting reusable agent 
 
 ---
 
+## Skill Invocation Convention
+
+When skills need to invoke other skills (either directly or in subagent prompts), use **agent-agnostic XML-based invocation** instead of slash-command syntax. This ensures compatibility across different agent harnesses (Claude Code, Codex, Pi, etc.).
+
+### Standard Format
+
+```xml
+<skill_invocation>
+  <skill>skill-name</skill>
+  <args>arguments-if-any</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "skill-name" — do not attempt to run this as a terminal command.
+```
+
+### Why This Format
+
+- **Agent-agnostic**: Works across Claude Code, Codex, Pi, and other harnesses
+- **Explicit intent**: The XML structure and negative instruction prevent misinterpretation as shell commands
+- **Parseable**: Structured format makes it easy for harnesses to detect and route skill invocations
+- **Self-documenting**: The negative instruction clarifies intent for both agents and humans reading the skill
+
+### When to Use
+
+- **In SKILL.md instructions**: When the skill's workflow involves invoking other skills
+- **In subagent prompts**: When spawning a subagent that should invoke a skill
+- **In examples and templates**: To demonstrate correct skill orchestration patterns
+
+### What NOT to Use
+
+- **Slash commands**: `/skill-name` — harness-specific, easily confused with shell commands
+- **Backtick references**: `` `skill-name` `` — only for prose references, not actual invocations
+- **Function-style calls**: `skill-name()` — ambiguous, no standard parsing
+
+### Examples
+
+**Single skill with simple argument:**
+```xml
+<skill_invocation>
+  <skill>opsx:apply</skill>
+  <args>change-name</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+```
+
+**Skill with complex arguments:**
+```xml
+<skill_invocation>
+  <skill>accelint-english-manager</skill>
+  <args>audit+rewrite in strict mode the following:
+
+"
+[CONTENT HERE]
+"
+
+I do not want a report, just apply the new content to the output directly.</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
+```
+
+**Skill with no arguments:**
+```xml
+<skill_invocation>
+  <skill>opsx:bulk-archive</skill>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+```
+
+---
+
 ## Workflow Procedures
 
 ### New Features

--- a/skills/accelint-archive-synthesis/CHANGELOG.md
+++ b/skills/accelint-archive-synthesis/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
 ## [1.1.1] - 2026-07-24
 
 ### Fixed

--- a/skills/accelint-archive-synthesis/CHANGELOG.md
+++ b/skills/accelint-archive-synthesis/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.2.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.1.1] - 2026-07-24

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -72,7 +72,7 @@ The skill works with any corpus size but warns if fewer than ~10 archived change
 │  Structural       Median related-count across specs/INDEX.md,       Candidate │
 │  Coupling         flag outliers ≥5 and ≥2× median                   findings  │
 │  Compile Report   Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
-│                   findings, /opsx:verify register                   report    │
+│                   findings, openspec-verify-change register                   report    │
 │  Human Review     Present report; human confirms, dismisses, or     Confirmed │
 │                   defers each finding                               findings  │
 │  Route            Update Status (confirmed contradictions only)     Docs +    │
@@ -137,7 +137,7 @@ Surfaces capabilities whose `related:` count suggests boundary overgrowth — at
 
 ### Phase 4: Compile Report
 
-Assembles everything into one report using `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register:
+Assembles everything into one report using `openspec-verify-change`'s CRITICAL/WARNING/SUGGESTION register:
 
 ```
 ## Archive Synthesis Report — <date>
@@ -268,30 +268,24 @@ Decision column is condensed one-liner from `design.md` frontmatter. This skill'
 Uses exact same `findings:` shape `accelint-qrspi-apply` Phase 4 uses:
 
 ```
-<skill_invocation>
-  <skill>accelint-architecture-doc</skill>
-  <args>
+Invoke the accelint-architecture-doc skill.
+
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
 findings:
 - [Plain factual statement about what archive shows, never instruction]
-  </args>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 ```
 
 Writer skill merges with its own codebase scan before presenting to human — same Mode 3 Refresh path manual run would take.
 
 **Rephrasing discipline**: Every findings: line is plain fact about what archive shows ("sync/protocol's stated budget constraint may no longer hold, given later message-broker adoption"), never instruction ("update sync/protocol's spec to remove constraint") — that would pre-empt writer skill's Mode 3 interview.
 
-### Relationship to `/opsx:verify`
+### Relationship to `openspec-verify-change`
 
 Borrows CRITICAL/WARNING/SUGGESTION register deliberately so reports read as familiar artifacts. But they check fundamentally different things:
 
-- `/opsx:verify`: Forward-looking, per-change, before archival (does implementation match its own design.md/tasks.md?)
+- `openspec-verify-change`: Forward-looking, per-change, before archival (does implementation match its own design.md/tasks.md?)
 - This skill: Backward-looking, cross-archive, periodic (does archive agree with itself?)
 
 Complementary, not redundant. A change can pass verification cleanly and still surface in decision-drift finding years later.
@@ -357,19 +351,13 @@ Skill:
 ✓ archive/INDEX.md: add-live-sync row Status → "superseded by
   adopt-notification-gateway (2026-06-18)"
 
-<skill_invocation>
-  <skill>accelint-architecture-doc</skill>
-  <args>
+Invoke the accelint-architecture-doc skill.
+
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
 findings:
 - sync/protocol budget constraint may be stale
-  </args>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 
@@ -536,7 +524,7 @@ Check the archive cadence after first few runs. If 15 changes means checking twi
 
 Trust dismissed-pair tracking. A decision-drift dismissal is permanent (pair never re-flagged). A structural coupling dismissal is not (count rechecked every run).
 
-The verification report format matches `/opsx:verify` deliberately. Both check correctness, just at different scopes.
+The verification report format matches `openspec-verify-change` deliberately. Both check correctness, just at different scopes.
 
 When a finding targets multiple docs, each writer skill invocation is independent. One succeeding doesn't depend on another.
 
@@ -562,7 +550,7 @@ Tier 0: raw/                   openspec/changes/archive/*.md (immutable log)
 Tier 1: wiki/ pages            openspec/specs/<capability>/spec.md (current understanding)
 Tier 2: CLAUDE.md index        config.yaml + ARCHITECTURE.md + AGENTS.md + README.md (hub docs)
 
-Op: ingest                 →   <skill_invocation><skill>openspec-archive-change</skill></skill_invocation> + qrspi-apply Phase 4
+Op: ingest                 →   openspec-archive-change + qrspi-apply Phase 4
 Op: query                  →   artifact load at propose/apply time
 Op: lint                   →   accelint-archive-synthesis (this skill)
 ```

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -545,7 +545,7 @@ Tier 0: raw/                   openspec/changes/archive/*.md (immutable log)
 Tier 1: wiki/ pages            openspec/specs/<capability>/spec.md (current understanding)
 Tier 2: CLAUDE.md index        config.yaml + ARCHITECTURE.md + AGENTS.md + README.md (hub docs)
 
-Op: ingest                 →   openspec-archive-change + qrspi-apply Phase 4
+Op: ingest                 →   accelint-qrspi-apply Phase 4 + accelint-qrspi-archive
 Op: query                  →   artifact load at propose/apply time
 Op: lint                   →   accelint-archive-synthesis (this skill)
 ```

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -268,12 +268,19 @@ Decision column is condensed one-liner from `design.md` frontmatter. This skill'
 Uses exact same `findings:` shape `accelint-qrspi-apply` Phase 4 uses:
 
 ```
-/accelint-architecture-doc
+<skill_invocation>
+  <skill>accelint-architecture-doc</skill>
+  <args>
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
 findings:
 - [Plain factual statement about what archive shows, never instruction]
+  </args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 ```
 
 Writer skill merges with its own codebase scan before presenting to human — same Mode 3 Refresh path manual run would take.
@@ -349,8 +356,20 @@ User: adopt-notification-gateway — the budget constraint's gone now.
 Skill:
 ✓ archive/INDEX.md: add-live-sync row Status → "superseded by
   adopt-notification-gateway (2026-06-18)"
-[invokes accelint-architecture-doc with findings: — sync/protocol budget
-  constraint may be stale]
+
+<skill_invocation>
+  <skill>accelint-architecture-doc</skill>
+  <args>
+We found the following during periodic archive synthesis. Treat this as known
+context and refresh the affected section(s).
+
+findings:
+- sync/protocol budget constraint may be stale
+  </args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 
@@ -543,7 +562,7 @@ Tier 0: raw/                   openspec/changes/archive/*.md (immutable log)
 Tier 1: wiki/ pages            openspec/specs/<capability>/spec.md (current understanding)
 Tier 2: CLAUDE.md index        config.yaml + ARCHITECTURE.md + AGENTS.md + README.md (hub docs)
 
-Op: ingest                 →   /opsx:archive + qrspi-apply Phase 4
+Op: ingest                 →   <skill_invocation><skill>opsx:archive</skill></skill_invocation> + qrspi-apply Phase 4
 Op: query                  →   artifact load at propose/apply time
 Op: lint                   →   accelint-archive-synthesis (this skill)
 ```

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -562,7 +562,7 @@ Tier 0: raw/                   openspec/changes/archive/*.md (immutable log)
 Tier 1: wiki/ pages            openspec/specs/<capability>/spec.md (current understanding)
 Tier 2: CLAUDE.md index        config.yaml + ARCHITECTURE.md + AGENTS.md + README.md (hub docs)
 
-Op: ingest                 →   <skill_invocation><skill>opsx:archive</skill></skill_invocation> + qrspi-apply Phase 4
+Op: ingest                 →   <skill_invocation><skill>openspec-archive-change</skill></skill_invocation> + qrspi-apply Phase 4
 Op: query                  →   artifact load at propose/apply time
 Op: lint                   →   accelint-archive-synthesis (this skill)
 ```

--- a/skills/accelint-archive-synthesis/README.md
+++ b/skills/accelint-archive-synthesis/README.md
@@ -351,13 +351,8 @@ Skill:
 ✓ archive/INDEX.md: add-live-sync row Status → "superseded by
   adopt-notification-gateway (2026-06-18)"
 
-Invoke the accelint-architecture-doc skill.
-
-We found the following during periodic archive synthesis. Treat this as known
-context and refresh the affected section(s).
-
-findings:
-- sync/protocol budget constraint may be stale
+[invokes accelint-architecture-doc with findings: — sync/protocol budget
+  constraint may be stale]
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 

--- a/skills/accelint-archive-synthesis/SKILL.md
+++ b/skills/accelint-archive-synthesis/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires the OpenSpec CLI, sub-agent support, and a project already onboarded with accelint-qrspi-archive so that openspec/changes/archive/INDEX.md and openspec/specs/INDEX.md exist and are populated. Routing confirmed findings requires the shared findings - interface (Mode 3 Refresh support) in whichever writer skill(s) a given finding targets; without it, this skill still produces its report but degrades to manual guidance for that step.
 metadata:
   author: accelint
-  version: "1.1.1"
+  version: "1.2.0"
 ---
 
 # Accelint Archive Synthesis
@@ -72,7 +72,9 @@ This file is not a column of either index and is never touched by `accelint-qrsp
 Routing a confirmed finding to a writer skill uses the exact same `findings:` shape `accelint-qrspi-apply` Step 5 already uses — this skill is the interface's second caller, not a new one:
 
 ```
-/accelint-architecture-doc
+<skill_invocation>
+  <skill>accelint-architecture-doc</skill>
+  <args>
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
@@ -82,6 +84,11 @@ findings:
   message broker, but adopt-websocket-gateway (2026-09-14) later adopted a
   message broker for an unrelated capability — worth confirming the original
   budget constraint still holds before sync/protocol's spec is next touched"]
+  </args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 ```
 
 The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Step 4) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Step 8 for what happens to those instead.
@@ -492,16 +499,41 @@ User: adopt-notification-gateway — the budget constraint's gone now.
 Skill:
 ✓ archive/INDEX.md: add-live-sync row Status → "superseded by
   adopt-notification-gateway (2026-06-18)"
-[invokes accelint-architecture-doc with findings: — sync/protocol budget
-  constraint may be stale]
+
+<skill_invocation>
+  <skill>accelint-architecture-doc</skill>
+  <args>
+We found the following during periodic archive synthesis. Treat this as known
+context and refresh the affected section(s).
+
+findings:
+- sync/protocol budget constraint may be stale
+  </args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
+
 ✓ Finding 2 confirmed.
 ✓ specs/INDEX.md: cache/layer row patched — related: [cli-core] →
   [cli-core, rule-engine] (Purpose unchanged, last_touched_by left
   exactly as it was — this patch isn't an archived change, so
   attribution doesn't move)
 ✓ Finding 3 confirmed.
-[invokes accelint-architecture-doc with findings: — sync/protocol
-  structural coupling, routed to Known Technical Debt review]
+
+<skill_invocation>
+  <skill>accelint-architecture-doc</skill>
+  <args>
+We found the following during periodic archive synthesis. Treat this as known
+context and refresh the affected section(s).
+
+findings:
+- sync/protocol structural coupling, routed to Known Technical Debt review
+  </args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 

--- a/skills/accelint-archive-synthesis/SKILL.md
+++ b/skills/accelint-archive-synthesis/SKILL.md
@@ -18,7 +18,7 @@ That backward-looking scope is also what keeps this skill's footprint small and 
 
 **Automates**: a periodic, corpus-wide consistency check across every archived OpenSpec change, surfacing contradictions between past decisions, flagging capabilities that have become structurally over-coupled, and flagging `specs/INDEX.md` rows that have drifted from the `spec.md` files they summarize.
 **Scope**: `openspec/changes/archive/INDEX.md`, `openspec/specs/INDEX.md`, and — for the reconciliation check only — a lightweight read of each `spec.md`'s `## Purpose` heading and `related:` frontmatter. This skill never originates a change, never implements a fix, and never edits a hub doc itself.
-**Output**: a CRITICAL / WARNING / SUGGESTION report in the same register as `/opsx:verify`, plus, only after a human confirms a specific finding, a `Status` column update on the relevant archive row, a single-row patch or removal on `specs/INDEX.md`, and/or an independent invocation of the affected writer skill(s) via the shared `findings:` interface — see Step 8 for which finding types get which.
+**Output**: a CRITICAL / WARNING / SUGGESTION report in the same register as `openspec-verify-change`, plus, only after a human confirms a specific finding, a `Status` column update on the relevant archive row, a single-row patch or removal on `specs/INDEX.md`, and/or an independent invocation of the affected writer skill(s) via the shared `findings:` interface — see Step 8 for which finding types get which.
 **Does NOT**: run automatically, run as a blocking step inside any other skill's workflow, rewrite any document directly, write any `archive/INDEX.md` column other than `Status`, write to `specs/INDEX.md` beyond a single confirmed row's patch or removal, introduce any severity or status state beyond CRITICAL/WARNING/SUGGESTION and current/superseded, or reconcile a contradiction on its own judgment without a human confirming which side of it stands.
 
 ## Prerequisites
@@ -71,10 +71,9 @@ This file is not a column of either index and is never touched by `accelint-qrsp
 
 Routing a confirmed finding to a writer skill uses the exact same `findings:` shape `accelint-qrspi-apply` Step 5 already uses — this skill is the interface's second caller, not a new one:
 
-```
-<skill_invocation>
-  <skill>accelint-architecture-doc</skill>
-  <args>
+```text
+Invoke the accelint-architecture-doc skill.
+
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
@@ -84,20 +83,15 @@ findings:
   message broker, but adopt-websocket-gateway (2026-09-14) later adopted a
   message broker for an unrelated capability — worth confirming the original
   budget constraint still holds before sync/protocol's spec is next touched"]
-  </args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 ```
 
 The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Step 4) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Step 8 for what happens to those instead.
 
 **Rephrasing discipline.** Every line inside `findings:` is a plain factual statement about what the archive shows, never an instruction and never a conclusion the writer skill hasn't reached itself yet. "sync/protocol's stated budget constraint may no longer hold, given a later change's message-broker adoption" is correctly phrased; "update sync/protocol's spec to remove the budget constraint" is not — that second phrasing pre-empts the writer skill's own Mode 3 interview, which is exactly the judgment call this skill's Steps 7/8 split exists to keep with a human, not hand to a downstream skill as a foregone conclusion.
 
-## Relationship to `/opsx:verify`
+## Relationship to `openspec-verify-change`
 
-This skill borrows `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register deliberately, so a report from either reads as a familiar artifact — but the two check fundamentally different things. `/opsx:verify` runs once, per change, before that change archives: forward-looking, scoped to whether one implementation matches its own `design.md` and `tasks.md`. This skill runs periodically, across the whole archive, after changes have already landed: backward-looking, scoped to whether the archive as a whole still agrees with itself. A change can pass `/opsx:verify` cleanly the day it archives and still surface in a decision-drift finding two years later, once enough later changes touch related capabilities. The two are complementary, not redundant, and neither substitutes for the other.
+This skill borrows `openspec-verify-change`'s CRITICAL/WARNING/SUGGESTION register deliberately, so a report from either reads as a familiar artifact — but the two check fundamentally different things. `openspec-verify-change` runs once, per change, before that change archives: forward-looking, scoped to whether one implementation matches its own `design.md` and `tasks.md`. This skill runs periodically, across the whole archive, after changes have already landed: backward-looking, scoped to whether the archive as a whole still agrees with itself. A change can pass `openspec-verify-change` cleanly the day it archives and still surface in a decision-drift finding two years later, once enough later changes touch related capabilities. The two are complementary, not redundant, and neither substitutes for the other.
 
 ## Workflow Overview
 
@@ -119,7 +113,7 @@ This skill borrows `/opsx:verify`'s CRITICAL/WARNING/SUGGESTION register deliber
 │  5 Structural     Median related-count across specs/INDEX.md,       Candidate │
 │    coupling       flag outliers ≥5 and ≥2× median                   findings  │
 │  6 Compile report Assemble CRITICAL / WARNING / SUGGESTION          Draft     │
-│                   findings, /opsx:verify register                   report    │
+│                   findings, openspec-verify-change register         report    │
 │  7 Human review   Present report; human confirms, dismisses, or     Confirmed │
 │                   defers each finding                               findings  │
 │  8 Route          Update Status, or patch/remove a specs/INDEX.md   Docs +    │
@@ -220,9 +214,9 @@ Compute the median `related:` list length across every row loaded in Step 2. Fla
 
    Worked example: across 22 capability rows, related-counts of `[1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8, 9, 10, 11, 14, 14]` sort to a median of 6 (the 11th and 12th of 22 values, both 6). The floor is `max(5, 2 × 6) = 12`, so only the two rows at 14 clear it — everything from 11 down, including the two rows already at 6, stays unflagged. This is exactly the kind of distribution Verification Task C checks against: if every project's median clustered near 1 or 2 instead, the fixed floor of 5 alone would already flag most of the corpus regardless of the 2× multiplier, which is precisely the mismatch Task C exists to surface.
 
-6. **Compile Report — assemble everything Steps 3, 4, and 5 found into one report, in the same CRITICAL / WARNING / SUGGESTION register `/opsx:verify` already uses, so it reads as a familiar artifact rather than a new report format to learn.**
+6. **Compile Report — assemble everything Steps 3, 4, and 5 found into one report, in the same CRITICAL / WARNING / SUGGESTION register `openspec-verify-change` already uses, so it reads as a familiar artifact rather than a new report format to learn.**
 
-```
+```text
 ## Archive Synthesis Report — <date>
 
 Corpus: <N> archived changes, <M> capabilities, checked back to <last synthesis
@@ -500,19 +494,13 @@ Skill:
 ✓ archive/INDEX.md: add-live-sync row Status → "superseded by
   adopt-notification-gateway (2026-06-18)"
 
-<skill_invocation>
-  <skill>accelint-architecture-doc</skill>
-  <args>
+Invoke the accelint-architecture-doc skill.
+
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
 findings:
 - sync/protocol budget constraint may be stale
-  </args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 
 ✓ Finding 2 confirmed.
 ✓ specs/INDEX.md: cache/layer row patched — related: [cli-core] →
@@ -521,19 +509,13 @@ Pass the skill name ("accelint-architecture-doc") and the args content shown abo
   attribution doesn't move)
 ✓ Finding 3 confirmed.
 
-<skill_invocation>
-  <skill>accelint-architecture-doc</skill>
-  <args>
+Invoke the accelint-architecture-doc skill.
+
 We found the following during periodic archive synthesis. Treat this as known
 context and refresh the affected section(s).
 
 findings:
 - sync/protocol structural coupling, routed to Known Technical Debt review
-  </args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 

--- a/skills/accelint-archive-synthesis/SKILL.md
+++ b/skills/accelint-archive-synthesis/SKILL.md
@@ -87,8 +87,8 @@ findings:
   </args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 ```
 
 The writer skill merges this with its own codebase scan before presenting anything to the human — same Mode 3 Refresh path a manual run would take. Nothing about invoking it here is special-cased for this skill. This interface is used for decision-drift and structural-coupling findings only — index reconciliation findings (Step 4) never route through it, since a stale `specs/INDEX.md` row isn't a hub-doc content gap; see Step 8 for what happens to those instead.
@@ -511,8 +511,8 @@ findings:
   </args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 
 ✓ Finding 2 confirmed.
 ✓ specs/INDEX.md: cache/layer row patched — related: [cli-core] →
@@ -532,8 +532,8 @@ findings:
   </args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("accelint-architecture-doc") and the args content shown above.
 
 Appending checkpoint to openspec/changes/archive/SYNTHESIS-LOG.md...
 

--- a/skills/accelint-onboard-agent/CHANGELOG.md
+++ b/skills/accelint-onboard-agent/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.5.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.4.0] - 2026-07-08

--- a/skills/accelint-onboard-agent/CHANGELOG.md
+++ b/skills/accelint-onboard-agent/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.5.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
 ## [1.4.0] - 2026-07-08
 
 ### Added

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -331,7 +331,7 @@ appropriate.
 
 **Turborepo + PNPM monorepo → suggest confirming:**
 - "I'll assume you want `pnpm -w` (workspace root) for adding shared deps
-  and `pnpm --filter [pkg]` for package-scoped deps; correct?"
+  and `pnpm --filter <pkg>` for package-scoped deps; correct?"
 - "For tasks, I'll default to `pnpm turbo run build --filter=...` rather
   than running package scripts directly; correct?"
 
@@ -501,11 +501,11 @@ Follow Test-Driven Development to ensure the bug is fixed and does not regress:
 - [ ] [check, e.g., `pnpm typecheck`]
 - [ ] [check, e.g., `pnpm lint`]
 - [ ] [check, e.g., `pnpm test`]
-- [ ] *(TypeScript/JavaScript)* Type check test files: `tsc --noEmit [test-file].test.ts`
+- [ ] *(TypeScript/JavaScript)* Type check test files: `tsc --noEmit <test-file>.test.ts`
 
 ### Commit Messages
 Convention: [e.g., Conventional Commits]
-Format: `[type]([scope]): [description]`
+Format: `<type>(<scope>): <description>`
 Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`[, additional types]
 Example: `feat(layer): add WebGPU fallback for Safari`
 
@@ -564,7 +564,7 @@ with placeholder text.
 - **Package manager**: [e.g., always use `pnpm`; never `npm` or `yarn`]
 - **Test runner**: [e.g., `vitest` — never `jest`]
 - **Linting / formatting**: [e.g., `biome` — never `prettier` or `eslint` separately]
-- **Task runner**: [e.g., `pnpm turbo run [task] --filter=[pkg]`]
+- **Task runner**: [e.g., `pnpm turbo run <task> --filter=<pkg>`]
 - **Version control**: [e.g., `git` via CLI — no GUI wrappers]
 
 ### TypeScript/Testing Preferences (if applicable)

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -480,9 +480,9 @@ architectural decisions."]
 
 ### New Features
 [step-by-step procedure, e.g.:]
-1. Start with `<skill_invocation><skill>opsx:propose</skill></skill_invocation>` for any non-trivial change
+1. Start with `<skill_invocation><skill>openspec-propose</skill></skill_invocation>` for any non-trivial change
    *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:propose" — do not attempt to run this as a terminal command.)*
+   Execute the internal skill "openspec-propose" — do not attempt to run this as a terminal command.)*
 2. Get proposal reviewed before writing code
 3. Run `pnpm check` and `pnpm test` after each meaningful change
 4. Open a draft PR early; mark ready only after CI passes
@@ -495,10 +495,10 @@ Follow Test-Driven Development to ensure the bug is fixed and does not regress:
    before touching any production code
 2. **Fix the root cause** — not the symptom
 3. **Confirm the test passes** — validate the fix
-4. **Follow OpenSpec process** — use `<skill_invocation><skill>opsx:explore</skill></skill_invocation>` for investigation if
+4. **Follow OpenSpec process** — use `<skill_invocation><skill>openspec-explore</skill></skill_invocation>` for investigation if
    the root cause is non-obvious
    *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.)*
+   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.)*
 5. Hand off to engineer for PR
 
 ### Pre-Commit Checklist

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -289,7 +289,7 @@ behavioral constraints and confirm rather than asking again.
 - Versioning workflow? (when to bump, who approves changelog?)
 
 **Turn 4 — OpenSpec / Spec-Driven Workflow** *(skip if not using OpenSpec)*
-- When should the agent invoke `opsx:propose`?
+- When should the agent invoke `openspec-propose`?
   *Good default: "for any new feature or non-trivial change".*
 - When is a spec required vs. optional?
 - Should the agent reference existing specs before creating new patterns?
@@ -331,7 +331,7 @@ appropriate.
 
 **Turborepo + PNPM monorepo → suggest confirming:**
 - "I'll assume you want `pnpm -w` (workspace root) for adding shared deps
-  and `pnpm --filter <pkg>` for package-scoped deps; correct?"
+  and `pnpm --filter [pkg]` for package-scoped deps; correct?"
 - "For tasks, I'll default to `pnpm turbo run build --filter=...` rather
   than running package scripts directly; correct?"
 
@@ -347,7 +347,7 @@ appropriate.
   a footer `BREAKING CHANGE:` block?"
 
 **Spec-Driven Development (OpenSpec) → suggest confirming:**
-- "For non-trivial changes, I'll start with `opsx:propose` before writing
+- "For non-trivial changes, I'll start with `openspec-propose` before writing
   any code; should I also require a design artifact for changes touching more
   than N files?"
 - "Should I link task IDs or spec refs in commit messages?"
@@ -393,7 +393,7 @@ to complete, then merge results before Phase 4.
 - Return: migration guardrails if migrations exist, secret handling practices
 
 **Agent E — OpenSpec & Development Workflow**
-- OpenSpec: `openspec/` directory, `openspec/config.yaml`, any `opsx:*` skill references in docs or CLAUDE.md
+- OpenSpec: `openspec/` directory, `openspec/config.yaml`, any `openspec-*` skill references in docs or CLAUDE.md
 - Return: OpenSpec usage status, when to invoke spec workflow
 
 **After all agents complete:** merge their findings into a unified discovery map.
@@ -481,8 +481,8 @@ architectural decisions."]
 ### New Features
 [step-by-step procedure, e.g.:]
 1. Start with `<skill_invocation><skill>openspec-propose</skill></skill_invocation>` for any non-trivial change
-   *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-propose" — do not attempt to run this as a terminal command.)*
+   *(IMPORTANT: Use the Skill tool to invoke this skill directly.
+   Pass the skill name ("openspec-propose") and any args.)*
 2. Get proposal reviewed before writing code
 3. Run `pnpm check` and `pnpm test` after each meaningful change
 4. Open a draft PR early; mark ready only after CI passes
@@ -497,15 +497,15 @@ Follow Test-Driven Development to ensure the bug is fixed and does not regress:
 3. **Confirm the test passes** — validate the fix
 4. **Follow OpenSpec process** — use `<skill_invocation><skill>openspec-explore</skill></skill_invocation>` for investigation if
    the root cause is non-obvious
-   *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.)*
+   *(IMPORTANT: Use the Skill tool to invoke this skill directly.
+   Pass the skill name ("openspec-explore") and any args.)*
 5. Hand off to engineer for PR
 
 ### Pre-Commit Checklist
 - [ ] [check, e.g., `pnpm typecheck`]
 - [ ] [check, e.g., `pnpm lint`]
 - [ ] [check, e.g., `pnpm test`]
-- [ ] *(TypeScript/JavaScript)* Type check test files: `tsc --noEmit <test-file>.test.ts`
+- [ ] *(TypeScript/JavaScript)* Type check test files: `tsc --noEmit [test-file].test.ts`
 
 ### Commit Messages
 Convention: [e.g., Conventional Commits]
@@ -568,7 +568,7 @@ with placeholder text.
 - **Package manager**: [e.g., always use `pnpm`; never `npm` or `yarn`]
 - **Test runner**: [e.g., `vitest` — never `jest`]
 - **Linting / formatting**: [e.g., `biome` — never `prettier` or `eslint` separately]
-- **Task runner**: [e.g., `pnpm turbo run <task> --filter=<pkg>`]
+- **Task runner**: [e.g., `pnpm turbo run [task] --filter=[pkg]`]
 - **Version control**: [e.g., `git` via CLI — no GUI wrappers]
 
 ### TypeScript/Testing Preferences (if applicable)

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -480,9 +480,7 @@ architectural decisions."]
 
 ### New Features
 [step-by-step procedure, e.g.:]
-1. Start with `<skill_invocation><skill>openspec-propose</skill></skill_invocation>` for any non-trivial change
-   *(IMPORTANT: Use the Skill tool to invoke this skill directly.
-   Pass the skill name ("openspec-propose") and any args.)*
+1. Start with the `accelint-qrspi-propose` skill for any non-trivial change
 2. Get proposal reviewed before writing code
 3. Run `pnpm check` and `pnpm test` after each meaningful change
 4. Open a draft PR early; mark ready only after CI passes
@@ -495,10 +493,8 @@ Follow Test-Driven Development to ensure the bug is fixed and does not regress:
    before touching any production code
 2. **Fix the root cause** — not the symptom
 3. **Confirm the test passes** — validate the fix
-4. **Follow OpenSpec process** — use `<skill_invocation><skill>openspec-explore</skill></skill_invocation>` for investigation if
+4. **Follow OpenSpec process** — use the `openspec-explore` skill for investigation if
    the root cause is non-obvious
-   *(IMPORTANT: Use the Skill tool to invoke this skill directly.
-   Pass the skill name ("openspec-explore") and any args.)*
 5. Hand off to engineer for PR
 
 ### Pre-Commit Checklist

--- a/skills/accelint-onboard-agent/SKILL.md
+++ b/skills/accelint-onboard-agent/SKILL.md
@@ -4,7 +4,7 @@ description: Interactively onboard a project to agent-driven development by runn
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Onboard Agents
@@ -289,7 +289,7 @@ behavioral constraints and confirm rather than asking again.
 - Versioning workflow? (when to bump, who approves changelog?)
 
 **Turn 4 — OpenSpec / Spec-Driven Workflow** *(skip if not using OpenSpec)*
-- When should the agent invoke `/opsx:propose`?
+- When should the agent invoke `opsx:propose`?
   *Good default: "for any new feature or non-trivial change".*
 - When is a spec required vs. optional?
 - Should the agent reference existing specs before creating new patterns?
@@ -347,7 +347,7 @@ appropriate.
   a footer `BREAKING CHANGE:` block?"
 
 **Spec-Driven Development (OpenSpec) → suggest confirming:**
-- "For non-trivial changes, I'll start with `/opsx:propose` before writing
+- "For non-trivial changes, I'll start with `opsx:propose` before writing
   any code; should I also require a design artifact for changes touching more
   than N files?"
 - "Should I link task IDs or spec refs in commit messages?"
@@ -393,7 +393,7 @@ to complete, then merge results before Phase 4.
 - Return: migration guardrails if migrations exist, secret handling practices
 
 **Agent E — OpenSpec & Development Workflow**
-- OpenSpec: `openspec/` directory, `openspec/config.yaml`, any `/opsx:*` references in docs or CLAUDE.md
+- OpenSpec: `openspec/` directory, `openspec/config.yaml`, any `opsx:*` skill references in docs or CLAUDE.md
 - Return: OpenSpec usage status, when to invoke spec workflow
 
 **After all agents complete:** merge their findings into a unified discovery map.
@@ -480,7 +480,9 @@ architectural decisions."]
 
 ### New Features
 [step-by-step procedure, e.g.:]
-1. Start with `/opsx:propose` for any non-trivial change
+1. Start with `<skill_invocation><skill>opsx:propose</skill></skill_invocation>` for any non-trivial change
+   *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:propose" — do not attempt to run this as a terminal command.)*
 2. Get proposal reviewed before writing code
 3. Run `pnpm check` and `pnpm test` after each meaningful change
 4. Open a draft PR early; mark ready only after CI passes
@@ -493,8 +495,10 @@ Follow Test-Driven Development to ensure the bug is fixed and does not regress:
    before touching any production code
 2. **Fix the root cause** — not the symptom
 3. **Confirm the test passes** — validate the fix
-4. **Follow OpenSpec process** — use `/opsx:explore` for investigation if
+4. **Follow OpenSpec process** — use `<skill_invocation><skill>opsx:explore</skill></skill_invocation>` for investigation if
    the root cause is non-obvious
+   *(IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.)*
 5. Hand off to engineer for PR
 
 ### Pre-Commit Checklist

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [1.7.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
+## [1.6.0] - 2026-08-24
+
+### Added
+- **File Changes Summary generation** — After verification completes, the skill now automatically generates a structured token-level diff summary
+  - New section: "File Changes Summary" (steps 41-44) runs immediately after verification report
+  - Parses `git diff` and archived change spec to enumerate each code-level change
+  - Output format: `<token_type>   <file_name>:<line_number>   <symbol_name>   <[change_type]>`
+  - Token types: function, constant, type, test, class, interface, enum, etc.
+  - Change types: [added], [modified], [deleted]
+  - Sorting: Grouped by change type (added, then modified, then deleted)
+  - Justification: Perfectly aligned columns with minimum 3 spaces between columns
+  - Source-only filtering: Only lists items from source directory (e.g., `src/`, `lib/`), excludes config files and build artifacts
+  - Test granularity: Lists only `describe` blocks, omits individual `it`/`test` cases to reduce noise
+  - No collapsing: Each token gets its own line (no summarization)
+  - No additional content: Template only, no headers or explanations
+
+### Changed
+- Verification report is no longer the final output — it's followed by the mandatory file changes summary
+- Step numbering extended from 40 to 44 (added steps 41-44 for diff summary generation)
+
+### Rationale
+- **Why generate diff summary**: Provides a scannable, structured overview of all code-level changes without requiring the user to manually parse `git diff` or inspect files
+- **Why after verification**: Verification confirms correctness; diff summary shows what specifically changed
+- **Why token-level granularity**: More useful than file-level (shows what symbols changed) but more concise than line-level (avoids implementation details)
+- **Why source-only**: Config files, build artifacts, and generated files add noise without providing insight into the actual implementation changes
+- **Why test describe blocks only**: Individual test cases create excessive line items; the describe block name captures the testing scope
+- **Why justified columns**: Makes the list scannable — eyes can quickly track down columns to find specific change types or file patterns
+- **Why mandatory**: Ensures every implementation produces a consistent structured summary, making it easier to review what was touched
+
+### Version
+- Bumped from 1.5.0 → 1.6.0
+
 ## [1.5.0] - 2026-07-10
 
 ### Changed

--- a/skills/accelint-qrspi-apply/CHANGELOG.md
+++ b/skills/accelint-qrspi-apply/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.7.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.6.0] - 2026-08-24

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -168,9 +168,9 @@ decisions:
 
 ### Load Project Context
 
-**Goal**: Load project context from `openspec/config.yaml` to inject into sub-agent prompts. This compensates for OpenSpec CLI's limitation where the `apply` command doesn't automatically load project context (unlike artifact creation commands).
+**Goal**: Load project context from `openspec/config.yaml` to inject into sub-agent prompts. This compensates for OpenSpec CLI's limitation where the `apply` skill doesn't automatically load project context (unlike artifact creation skills).
 
-**Background**: OpenSpec's `openspec instructions apply` command does NOT inject the `context` field from `config.yaml` (confirmed via code inspection and testing). This means sub-agents implementing tasks don't receive Stack Facts, coding patterns, testing conventions, or anti-patterns that should guide implementation. We work around this limitation by manually loading and injecting the context.
+**Background**: OpenSpec's `openspec instructions apply` skill does NOT inject the `context` field from `config.yaml` (confirmed via code inspection and testing). This means sub-agents implementing tasks don't receive Stack Facts, coding patterns, testing conventions, or anti-patterns that should guide implementation. We work around this limitation by manually loading and injecting the context.
 
 16. Check if `openspec/config.yaml` exists:
    ```bash
@@ -243,15 +243,15 @@ For each level in the dependency graph (starting from level 0):
      </project_context>
 
      <skill_invocation>
-       <skill>opsx:apply</skill>
+       <skill>openspec-apply-change</skill>
        <args><change-name></args>
      </skill_invocation>
 
      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+     Execute the internal skill "openspec-apply-change" — do not attempt to run this as a terminal command.
 
-     CRITICAL: You MUST use the opsx:apply skill to implement tasks.
-     DO NOT implement tasks directly yourself. The opsx:apply workflow will
+     CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
+     DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
      load context and guide implementation.
 
      IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
@@ -291,15 +291,15 @@ For each level with multiple independent slices:
    </project_context>
 
    <skill_invocation>
-     <skill>opsx:apply</skill>
+     <skill>openspec-apply-change</skill>
      <args><change-name></args>
    </skill_invocation>
 
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-apply-change" — do not attempt to run this as a terminal command.
 
-   CRITICAL: You MUST use the opsx:apply skill to implement tasks.
-   DO NOT implement tasks directly yourself. The opsx:apply workflow will
+   CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
+   DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
    load context and guide implementation.
 
    IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
@@ -639,12 +639,12 @@ decisions:
 36. Call the verify skill:
    ```
    <skill_invocation>
-     <skill>opsx:verify</skill>
+     <skill>openspec-verify-change</skill>
      <args><change-name></args>
    </skill_invocation>
 
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:verify" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-verify-change" — do not attempt to run this as a terminal command.
    ```
 
 37. The verify command will:
@@ -828,7 +828,7 @@ Running verification...
 
 **Next Steps:**
 1. Fix critical issues
-2. Re-run verification: `<skill_invocation><skill>opsx:verify</skill><args>auth-refactor</args></skill_invocation>`
+2. Re-run verification: `<skill_invocation><skill>openspec-verify-change</skill><args>auth-refactor</args></skill_invocation>`
 3. Or re-invoke this skill to retry
 
 Not ready to archive until critical issues are resolved.

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -58,10 +58,10 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    openspec list --json
    ```
    Parse the JSON and use **AskUserQuestion** to let the user select the change
-4. Announce: "Applying change: `<name>`" and how to override (e.g., re-invoke with different name)
+4. Announce: "Applying change: `[name]`" and how to override (e.g., re-invoke with different name)
 5. Check that tasks.md exists:
    ```bash
-   openspec status --change "<name>" --json
+   openspec status --change "[name]" --json
    ```
    If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `opsx:continue` to generate tasks before applying."
 
@@ -69,7 +69,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 
 **Goal**: Mark when implementation begins for telemetry tracking.
 
-6. Read the design.md file from `openspec/changes/<change-name>/design.md` to check if `started_at` timestamp exists in frontmatter
+6. Read the design.md file from `openspec/changes/[change-name]/design.md` to check if `started_at` timestamp exists in frontmatter
 
 7. If `started_at` is NOT present in the frontmatter (first time applying this change):
    - Add the `started_at` timestamp to the frontmatter using ISO 8601 format
@@ -85,15 +85,15 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 **Example frontmatter after adding started_at:**
 ```yaml
 ---
-change: <change-name>
+change: [change-name]
 created_at: "2026-08-17T15:00:00.000Z"
 started_at: "2026-08-17T16:30:00.000Z"
 specs_touched: [capability-a, capability-b]
 decisions:
   - id: D1
-    choice: <decision>
-    rationale: <why>
-    alternatives: [<option>]
+    choice: [decision]
+    rationale: [why]
+    alternatives: [[option]]
 ---
 ```
 
@@ -103,7 +103,7 @@ decisions:
 
 **Goal**: Extract task structure and identify parallel vs sequential execution opportunities. Detect if work has already started and resume from the correct level.
 
-9. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
+9. Read the tasks.md file from `openspec/changes/[change-name]/tasks.md`
 
 10. **Validate checklist format** (CRITICAL for progress tracking):
    - Check that tasks use markdown checklist format: `- [ ] task` or `- [x] task`
@@ -228,14 +228,14 @@ rules:
 
 ### Execute Tasks (Sequential + Parallel)
 
-**Goal**: Implement tasks following the dependency graph, spawning parallel sub-agents where possible.
+**Goal**: Implement tasks following the dependency graph, spawning parallel sub-agents where possible using the Agent tool.
 
 **Sequential execution** (when tasks have dependencies):
 
 For each level in the dependency graph (starting from level 0):
 
 21. If the level has only one slice:
-   - Spawn a single sub-agent with this prompt (inject project context loaded in step 16):
+   - Use the Agent tool to spawn a single sub-agent with this prompt (inject project context loaded in step 16):
      ```
      <project_context>
      <!-- Background constraints for your implementation. Do NOT copy into code. -->
@@ -244,11 +244,12 @@ For each level in the dependency graph (starting from level 0):
 
      <skill_invocation>
        <skill>openspec-apply-change</skill>
-       <args><change-name></args>
+       <args>[change-name]</args>
      </skill_invocation>
 
-     IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "openspec-apply-change" — do not attempt to run this as a terminal command.
+     IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
+     in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill
+     tool internally to pass the skill name ("openspec-apply-change"") and any args.
 
      CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
      DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -283,7 +284,7 @@ For each level in the dependency graph (starting from level 0):
 
 For each level with multiple independent slices:
 
-23. Spawn all sub-agents in parallel in a single turn (one per slice, inject project context from earlier steps):
+23. Use the Agent tool to spawn all sub-agents in parallel in a single turn (one per slice, inject project context from earlier steps):
    ```
    <project_context>
    <!-- Background constraints for your implementation. Do NOT copy into code. -->
@@ -292,11 +293,12 @@ For each level with multiple independent slices:
 
    <skill_invocation>
      <skill>openspec-apply-change</skill>
-     <args><change-name></args>
+     <args>[change-name]</args>
    </skill_invocation>
 
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-apply-change" — do not attempt to run this as a terminal command.
+   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
+   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
+   internally to pass the skill name ("openspec-apply-change") and any args.
 
    CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
    DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -358,8 +360,8 @@ For each level with multiple independent slices:
 
 **Slice targeting approach**: OpenSpec's `opsx:apply` skill does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
 
-1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `opsx:apply <change-name>`, which:
-   - Runs `openspec instructions apply --change "<name>" --json` to get context
+1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `opsx:apply [change-name]`, which:
+   - Runs `openspec instructions apply --change "[name]" --json` to get context
    - Loads all context files (proposal, design, specs, tasks)
    - Provides dynamic instructions based on current state
    - Handles task progress tracking and status checks
@@ -400,23 +402,23 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
    **Step 3a: Check if update is needed first**
    - Read the change artifacts to understand what was implemented:
-     * `openspec/changes/<change-name>/proposal.md`
-     * `openspec/changes/<change-name>/design.md`
+     * `openspec/changes/[change-name]/proposal.md`
+     * `openspec/changes/[change-name]/design.md`
    - Assess whether this change introduces content that would affect the document
    - If the change is trivial (typos, comments) or doesn't touch the document's scope, skip to the next document
 
    **Step 3b: Update the document if needed**
 
-   **For OpenSpec config** (`<repo-root>/openspec/config.yaml`):
+   **For OpenSpec config** (`[repo-root]/openspec/config.yaml`):
    - Check if `accelint-onboard-openspec` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
      <skill_invocation>
        <skill>accelint-onboard-openspec</skill>
-       <args>We have just completed the change spec openspec/changes/<change-name>.
+       <args>We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact, e.g., "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"]
@@ -424,14 +426,14 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      ...</args>
      </skill_invocation>
 
-     IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "accelint-onboard-openspec" — do not attempt to run this as a terminal command.
+     IMPORTANT: Use the Skill tool to invoke this skill directly.
+     Pass the skill name ("accelint-onboard-openspec") and any args.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/<change-name>/proposal.md`
-     - `openspec/changes/<change-name>/design.md`
+     - `openspec/changes/[change-name]/proposal.md`
+     - `openspec/changes/[change-name]/design.md`
 
      Then read `openspec/config.yaml` and update manually focusing on **project DNA (WHAT the project is)**:
      - **Tech Stack section**: Add new dependencies, frameworks, or libraries introduced by this change with versions
@@ -442,16 +444,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Per-artifact rules** (`rules:` section): Update if this change affects proposal/design/tasks/spec requirements
      - **DO NOT** add agent behavior (commit conventions, workflow steps, tool preferences belong in AGENTS.md)
 
-   **For ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
+   **For ARCHITECTURE.md** (`[repo-root]/ARCHITECTURE.md`) — IF it exists:
    - Check if `accelint-architecture-doc` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
      <skill_invocation>
        <skill>accelint-architecture-doc</skill>
-       <args>We have just completed the change spec openspec/changes/<change-name>.
+       <args>We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -459,14 +461,14 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      ...</args>
      </skill_invocation>
 
-     IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
+     IMPORTANT: Use the Skill tool to invoke this skill directly.
+     Pass the skill name ("accelint-architecture-doc") and any args.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/<change-name>/proposal.md`
-     - `openspec/changes/<change-name>/design.md`
+     - `openspec/changes/[change-name]/proposal.md`
+     - `openspec/changes/[change-name]/design.md`
 
      Then read `ARCHITECTURE.md` and update manually focusing on **system structure (HOW components relate)**:
      - **Section 1 (Project Structure)**: Update directory tree if new top-level directories or significant reorganization occurred
@@ -478,16 +480,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Section 8 (Technology Stack)**: Update if this change introduced new runtime dependencies or frameworks
      - **DO NOT** add coding patterns, testing conventions, or agent behavior (those belong in config.yaml or AGENTS.md)
 
-   **For AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
+   **For AGENTS.md** (`[repo-root]/AGENTS.md`) — IF it exists:
    - Check if `accelint-onboard-agent` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
      <skill_invocation>
        <skill>accelint-onboard-agent</skill>
-       <args>We have just completed the change spec openspec/changes/<change-name>.
+       <args>We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -495,14 +497,14 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      ...</args>
      </skill_invocation>
 
-     IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "accelint-onboard-agent" — do not attempt to run this as a terminal command.
+     IMPORTANT: Use the Skill tool to invoke this skill directly.
+     Pass the skill name ("accelint-onboard-agent") and any args.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/<change-name>/proposal.md`
-     - `openspec/changes/<change-name>/design.md`
+     - `openspec/changes/[change-name]/proposal.md`
+     - `openspec/changes/[change-name]/design.md`
 
      Then read `AGENTS.md` and update manually focusing on **agent behavior (HOW agents should act)**:
      - **Workflow Procedures section**: Update if this change introduces new workflow steps (e.g., new pre-commit checks, new PR requirements)
@@ -513,16 +515,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Commit Messages section**: Update if commit convention changed
      - **DO NOT** add tech stack facts, domain concepts, or coding patterns (those belong in config.yaml)
 
-   **For README.md** (`<repo-root>/README.md`) — IF it exists:
+   **For README.md** (`[repo-root]/README.md`) — IF it exists:
    - Check if `accelint-readme-writer` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
      <skill_invocation>
        <skill>accelint-readme-writer</skill>
-       <args>We have just completed the change spec openspec/changes/<change-name>.
+       <args>We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -530,14 +532,14 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      ...</args>
      </skill_invocation>
 
-     IMPORTANT: This is a skill invocation directive, NOT a shell command.
-     Execute the internal skill "accelint-readme-writer" — do not attempt to run this as a terminal command.
+     IMPORTANT: Use the Skill tool to invoke this skill directly.
+     Pass the skill name ("accelint-readme-writer") and any args.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/<change-name>/proposal.md`
-     - `openspec/changes/<change-name>/design.md`
+     - `openspec/changes/[change-name]/proposal.md`
+     - `openspec/changes/[change-name]/design.md`
 
      Then read `README.md` and update manually focusing on **user-facing documentation**:
      - **Installation section**: Update commands if new dependencies or setup steps were added
@@ -600,7 +602,7 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
 **IMPORTANT**: This step runs immediately after living document updates and before verification. Do not wait for user input.
 
-33. Read the design.md file from `openspec/changes/<change-name>/design.md`
+33. Read the design.md file from `openspec/changes/[change-name]/design.md`
 
 34. Add the `completed_at` timestamp to the frontmatter using ISO 8601 format:
    - Use current timestamp: `new Date().toISOString()` (e.g., "2026-08-17T17:45:00.000Z")
@@ -613,16 +615,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 **Example frontmatter after adding completed_at:**
 ```yaml
 ---
-change: <change-name>
+change: [change-name]
 created_at: "2026-08-17T15:00:00.000Z"
 started_at: "2026-08-17T16:30:00.000Z"
 completed_at: "2026-08-17T17:45:00.000Z"
 specs_touched: [capability-a, capability-b]
 decisions:
   - id: D1
-    choice: <decision>
-    rationale: <why>
-    alternatives: [<option>]
+    choice: [decision]
+    rationale: [why]
+    alternatives: [[option]]
 ---
 ```
 
@@ -640,11 +642,11 @@ decisions:
    ```
    <skill_invocation>
      <skill>openspec-verify-change</skill>
-     <args><change-name></args>
+     <args>[change-name]</args>
    </skill_invocation>
 
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-verify-change" — do not attempt to run this as a terminal command.
+   IMPORTANT: Use the Skill tool to invoke this skill directly.
+   Pass the skill name ("openspec-verify-change") and any args.
    ```
 
 37. The verify command will:
@@ -873,7 +875,7 @@ After verification completes, generate a structured diff summary for the user. T
 
 41. Run `git diff` to capture all changes made during this implementation
 
-42. Parse the archived change spec from `openspec/archive/<change-name>/` to understand the change's scope
+42. Parse the archived change spec from `openspec/archive/[change-name]/` to understand the change's scope
 
 43. Generate a structured token-level change list following this exact format:
 

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -58,10 +58,10 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    openspec list --json
    ```
    Parse the JSON and use **AskUserQuestion** to let the user select the change
-4. Announce: "Applying change: `[name]`" and how to override (e.g., re-invoke with different name)
+4. Announce: "Applying change: `<name>`" and how to override (e.g., re-invoke with different name)
 5. Check that tasks.md exists:
    ```bash
-   openspec status --change "[name]" --json
+   openspec status --change "<name>" --json
    ```
    If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `openspec-continue-change` to generate tasks before applying."
 
@@ -69,7 +69,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 
 **Goal**: Mark when implementation begins for telemetry tracking.
 
-6. Read the design.md file from `openspec/changes/[change-name]/design.md` to check if `started_at` timestamp exists in frontmatter
+6. Read the design.md file from `openspec/changes/<change-name>/design.md` to check if `started_at` timestamp exists in frontmatter
 
 7. If `started_at` is NOT present in the frontmatter (first time applying this change):
    - Add the `started_at` timestamp to the frontmatter using ISO 8601 format
@@ -85,15 +85,15 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 **Example frontmatter after adding started_at:**
 ```yaml
 ---
-change: [change-name]
+change: <change-name>
 created_at: "2026-08-17T15:00:00.000Z"
 started_at: "2026-08-17T16:30:00.000Z"
-specs_touched: [capability-a, capability-b]
+specs_touched: [<capability-a>, <capability-b>]
 decisions:
   - id: D1
-    choice: [decision]
-    rationale: [why]
-    alternatives: [[option]]
+    choice: <decision>
+    rationale: <why>
+    alternatives: [<option>]
 ---
 ```
 
@@ -103,7 +103,7 @@ decisions:
 
 **Goal**: Extract task structure and identify parallel vs sequential execution opportunities. Detect if work has already started and resume from the correct level.
 
-9. Read the tasks.md file from `openspec/changes/[change-name]/tasks.md`
+9. Read the tasks.md file from `openspec/changes/<change-name>/tasks.md`
 
 10. **Validate checklist format** (CRITICAL for progress tracking):
    - Check that tasks use markdown checklist format: `- [ ] task` or `- [x] task`
@@ -244,7 +244,7 @@ For each level in the dependency graph (starting from level 0):
 
      Invoke the openspec-apply-change skill.
 
-     [change-name]
+     <change-name>
 
      CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
      DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -288,7 +288,7 @@ For each level with multiple independent slices:
 
    Invoke the openspec-apply-change skill.
 
-   [change-name]
+   <change-name>
 
    CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
    DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -325,8 +325,8 @@ For each level with multiple independent slices:
    ✅ Level N complete
 
    Completed slices:
-   - Slice X: [summary]
-   - Slice Y: [summary]
+   - Slice X: <summary>
+   - Slice Y: <summary>
 
    Next: Level N+1 has M slice(s) to run [list slices]
 
@@ -350,8 +350,8 @@ For each level with multiple independent slices:
 
 **Slice targeting approach**: OpenSpec's `openspec-apply-change` skill does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
 
-1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `opsx:apply [change-name]`, which:
-   - Runs `openspec instructions apply --change "[name]" --json` to get context
+1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `openspec-apply-change <change-name>`, which:
+   - Runs `openspec instructions apply --change "<name>" --json` to get context
    - Loads all context files (proposal, design, specs, tasks)
    - Provides dynamic instructions based on current state
    - Handles task progress tracking and status checks
@@ -392,23 +392,23 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
    **Step 3a: Check if update is needed first**
    - Read the change artifacts to understand what was implemented:
-     * `openspec/changes/[change-name]/proposal.md`
-     * `openspec/changes/[change-name]/design.md`
+     * `openspec/changes/<change-name>/proposal.md`
+     * `openspec/changes/<change-name>/design.md`
    - Assess whether this change introduces content that would affect the document
    - If the change is trivial (typos, comments) or doesn't touch the document's scope, skip to the next document
 
    **Step 3b: Update the document if needed**
 
-   **For OpenSpec config** (`[repo-root]/openspec/config.yaml`):
+   **For OpenSpec config** (`<repo-root>/openspec/config.yaml`):
    - Check if `accelint-onboard-openspec` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```text
      Invoke the accelint-onboard-openspec skill.
 
-     We have just completed the change spec openspec/changes/[change-name].
+     We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact, e.g., "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"]
@@ -418,8 +418,8 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/[change-name]/proposal.md`
-     - `openspec/changes/[change-name]/design.md`
+     - `openspec/changes/<change-name>/proposal.md`
+     - `openspec/changes/<change-name>/design.md`
 
      Then read `openspec/config.yaml` and update manually focusing on **project DNA (WHAT the project is)**:
      - **Tech Stack section**: Add new dependencies, frameworks, or libraries introduced by this change with versions
@@ -430,16 +430,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Per-artifact rules** (`rules:` section): Update if this change affects proposal/design/tasks/spec requirements
      - **DO NOT** add agent behavior (commit conventions, workflow steps, tool preferences belong in AGENTS.md)
 
-   **For ARCHITECTURE.md** (`[repo-root]/ARCHITECTURE.md`) — IF it exists:
+   **For ARCHITECTURE.md** (`<repo-root>/ARCHITECTURE.md`) — IF it exists:
    - Check if `accelint-architecture-doc` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```text
      Invoke the accelint-architecture-doc skill.
 
-     We have just completed the change spec openspec/changes/[change-name].
+     We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -449,8 +449,8 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/[change-name]/proposal.md`
-     - `openspec/changes/[change-name]/design.md`
+     - `openspec/changes/<change-name>/proposal.md`
+     - `openspec/changes/<change-name>/design.md`
 
      Then read `ARCHITECTURE.md` and update manually focusing on **system structure (HOW components relate)**:
      - **Section 1 (Project Structure)**: Update directory tree if new top-level directories or significant reorganization occurred
@@ -462,16 +462,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Section 8 (Technology Stack)**: Update if this change introduced new runtime dependencies or frameworks
      - **DO NOT** add coding patterns, testing conventions, or agent behavior (those belong in config.yaml or AGENTS.md)
 
-   **For AGENTS.md** (`[repo-root]/AGENTS.md`) — IF it exists:
+   **For AGENTS.md** (`<repo-root>/AGENTS.md`) — IF it exists:
    - Check if `accelint-onboard-agent` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```text
      Invoke the accelint-onboard-agent skill.
 
-     We have just completed the change spec openspec/changes/[change-name].
+     We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -481,8 +481,8 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/[change-name]/proposal.md`
-     - `openspec/changes/[change-name]/design.md`
+     - `openspec/changes/<change-name>/proposal.md`
+     - `openspec/changes/<change-name>/design.md`
 
      Then read `AGENTS.md` and update manually focusing on **agent behavior (HOW agents should act)**:
      - **Workflow Procedures section**: Update if this change introduces new workflow steps (e.g., new pre-commit checks, new PR requirements)
@@ -493,16 +493,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      - **Commit Messages section**: Update if commit convention changed
      - **DO NOT** add tech stack facts, domain concepts, or coding patterns (those belong in config.yaml)
 
-   **For README.md** (`[repo-root]/README.md`) — IF it exists:
+   **For README.md** (`<repo-root>/README.md`) — IF it exists:
    - Check if `accelint-readme-writer` skill is installed
    - If skill is available:
-     1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
+     1. Read `openspec/changes/<change-name>/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```text
      Invoke the accelint-readme-writer skill.
 
-     We have just completed the change spec openspec/changes/[change-name].
+     We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
@@ -512,8 +512,8 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
    - If skill is NOT available, read the change artifacts:
-     - `openspec/changes/[change-name]/proposal.md`
-     - `openspec/changes/[change-name]/design.md`
+     - `openspec/changes/<change-name>/proposal.md`
+     - `openspec/changes/<change-name>/design.md`
 
      Then read `README.md` and update manually focusing on **user-facing documentation**:
      - **Installation section**: Update commands if new dependencies or setup steps were added
@@ -576,7 +576,7 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
 **IMPORTANT**: This step runs immediately after living document updates and before verification. Do not wait for user input.
 
-33. Read the design.md file from `openspec/changes/[change-name]/design.md`
+33. Read the design.md file from `openspec/changes/<change-name>/design.md`
 
 34. Add the `completed_at` timestamp to the frontmatter using ISO 8601 format:
    - Use current timestamp: `new Date().toISOString()` (e.g., "2026-08-17T17:45:00.000Z")
@@ -589,16 +589,16 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 **Example frontmatter after adding completed_at:**
 ```yaml
 ---
-change: [change-name]
+change: <change-name>
 created_at: "2026-08-17T15:00:00.000Z"
 started_at: "2026-08-17T16:30:00.000Z"
 completed_at: "2026-08-17T17:45:00.000Z"
-specs_touched: [capability-a, capability-b]
+specs_touched: [<capability-a>, <capability-b>]
 decisions:
   - id: D1
-    choice: [decision]
-    rationale: [why]
-    alternatives: [[option]]
+    choice: <decision>
+    rationale: <why>
+    alternatives: [<option>]
 ---
 ```
 
@@ -616,7 +616,7 @@ decisions:
    ```text
    Invoke the openspec-verify-change skill.
 
-   [change-name]
+   <change-name>
    ```
 
 37. The verify command will:
@@ -845,7 +845,7 @@ After verification completes, generate a structured diff summary for the user. T
 
 41. Run `git diff` to capture all changes made during this implementation
 
-42. Parse the archived change spec from `openspec/archive/[change-name]/` to understand the change's scope
+42. Parse the archived change spec from `openspec/archive/<change-name>/` to understand the change's scope
 
 43. Generate a structured token-level change list following this exact format:
 

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -27,7 +27,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 - Sub-agent support (for parallel execution)
 - The expanded OpenSpec workflows (`explore`, `new`, `continue`) enabled
 
-**Important**: This skill is specifically designed for QRSPI-planned changes. Standard OpenSpec changes without parallelization strategies should use the regular `opsx:apply` skill directly.
+**Important**: This skill is specifically designed for QRSPI-planned changes. Standard OpenSpec changes without parallelization strategies should use the regular `openspec-apply-change` skill directly.
 
 ## Workflow Overview
 
@@ -63,7 +63,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    ```bash
    openspec status --change "[name]" --json
    ```
-   If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `opsx:continue` to generate tasks before applying."
+   If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `openspec-continue-change` to generate tasks before applying."
 
 ### Record Implementation Start
 
@@ -236,20 +236,15 @@ For each level in the dependency graph (starting from level 0):
 
 21. If the level has only one slice:
    - Use the Agent tool to spawn a single sub-agent with this prompt (inject project context loaded in step 16):
-     ```
+     ```text
      <project_context>
      <!-- Background constraints for your implementation. Do NOT copy into code. -->
      {INJECTED_CONFIG_CONTEXT}
      </project_context>
 
-     <skill_invocation>
-       <skill>openspec-apply-change</skill>
-       <args>[change-name]</args>
-     </skill_invocation>
+     Invoke the openspec-apply-change skill.
 
-     IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
-     in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill
-     tool internally to pass the skill name ("openspec-apply-change"") and any args.
+     [change-name]
 
      CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
      DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -285,20 +280,15 @@ For each level in the dependency graph (starting from level 0):
 For each level with multiple independent slices:
 
 23. Use the Agent tool to spawn all sub-agents in parallel in a single turn (one per slice, inject project context from earlier steps):
-   ```
+   ```text
    <project_context>
    <!-- Background constraints for your implementation. Do NOT copy into code. -->
    {INJECTED_CONFIG_CONTEXT}
    </project_context>
 
-   <skill_invocation>
-     <skill>openspec-apply-change</skill>
-     <args>[change-name]</args>
-   </skill_invocation>
+   Invoke the openspec-apply-change skill.
 
-   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
-   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
-   internally to pass the skill name ("openspec-apply-change") and any args.
+   [change-name]
 
    CRITICAL: You MUST use the openspec-apply-change skill to implement tasks.
    DO NOT implement tasks directly yourself. The openspec-apply-change workflow will
@@ -331,7 +321,7 @@ For each level with multiple independent slices:
 24. Track completion as each sub-agent finishes
 
 25. **Context management decision point** - When all slices in the level are done, pause and offer context management:
-   ```
+   ```text
    ✅ Level N complete
 
    Completed slices:
@@ -347,18 +337,18 @@ For each level with multiple independent slices:
    ```
 
 26. If user chooses (b), instruct them:
-   ```
+   ```text
    Run `/clear` to reset context, then re-invoke this skill.
    I'll detect that Level N is complete and resume from Level N+1.
    ```
 
 27. If user chooses (c), exit and remind them how to resume:
-   ```
+   ```text
    Paused at Level N+1. To resume, re-invoke this skill.
    Progress is tracked in tasks.md checkboxes.
    ```
 
-**Slice targeting approach**: OpenSpec's `opsx:apply` skill does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
+**Slice targeting approach**: OpenSpec's `openspec-apply-change` skill does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
 
 1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `opsx:apply [change-name]`, which:
    - Runs `openspec instructions apply --change "[name]" --json` to get context
@@ -415,19 +405,15 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
-     ```
-     <skill_invocation>
-       <skill>accelint-onboard-openspec</skill>
-       <args>We have just completed the change spec openspec/changes/[change-name].
+     ```text
+     Invoke the accelint-onboard-openspec skill.
+
+     We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact, e.g., "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"]
      - [Decision 2 rephrased as fact]
-     ...</args>
-     </skill_invocation>
-
-     IMPORTANT: Use the Skill tool to invoke this skill directly.
-     Pass the skill name ("accelint-onboard-openspec") and any args.
+     ...
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -450,19 +436,15 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
-     ```
-     <skill_invocation>
-       <skill>accelint-architecture-doc</skill>
-       <args>We have just completed the change spec openspec/changes/[change-name].
+     ```text
+     Invoke the accelint-architecture-doc skill.
+
+     We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...</args>
-     </skill_invocation>
-
-     IMPORTANT: Use the Skill tool to invoke this skill directly.
-     Pass the skill name ("accelint-architecture-doc") and any args.
+     ...
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -486,19 +468,15 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
-     ```
-     <skill_invocation>
-       <skill>accelint-onboard-agent</skill>
-       <args>We have just completed the change spec openspec/changes/[change-name].
+     ```text
+     Invoke the accelint-onboard-agent skill.
+
+     We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...</args>
-     </skill_invocation>
-
-     IMPORTANT: Use the Skill tool to invoke this skill directly.
-     Pass the skill name ("accelint-onboard-agent") and any args.
+     ...
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -521,19 +499,15 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      1. Read `openspec/changes/[change-name]/design.md` frontmatter to extract the `decisions` field
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
-     ```
-     <skill_invocation>
-       <skill>accelint-readme-writer</skill>
-       <args>We have just completed the change spec openspec/changes/[change-name].
+     ```text
+     Invoke the accelint-readme-writer skill.
+
+     We have just completed the change spec openspec/changes/[change-name].
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...</args>
-     </skill_invocation>
-
-     IMPORTANT: Use the Skill tool to invoke this skill directly.
-     Pass the skill name ("accelint-readme-writer") and any args.
+     ...
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -567,7 +541,7 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 32. Present summary (then immediately continue to recording completion timestamp):
 
    - If no updates were needed:
-     ```
+     ```text
      📝 Living documents checked — no updates needed for this change
 
      Checked documents:
@@ -580,7 +554,7 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      ```
 
    - If updates were made:
-     ```
+     ```text
      📝 Living documents updated
 
      Updated documents:
@@ -639,14 +613,10 @@ decisions:
 **CRITICAL**: This is the FINAL step. Verification is MANDATORY and produces a comprehensive report as the final output. Do NOT add additional reporting after this step.
 
 36. Call the verify skill:
-   ```
-   <skill_invocation>
-     <skill>openspec-verify-change</skill>
-     <args>[change-name]</args>
-   </skill_invocation>
+   ```text
+   Invoke the openspec-verify-change skill.
 
-   IMPORTANT: Use the Skill tool to invoke this skill directly.
-   Pass the skill name ("openspec-verify-change") and any args.
+   [change-name]
    ```
 
 37. The verify command will:
@@ -681,7 +651,7 @@ The skill supports pause/clear/resume workflow at dependency level boundaries:
 - **Progress tracking**: Task completion is tracked in tasks.md via checkboxes, making progress durable across context clears
 - **Rationale**: Sub-agents can accumulate significant context. Between dependency levels, the orchestrating agent can clear context while preserving work progress via task checkboxes.
 
-**Why this matters**: Long implementations with many slices can bloat context. By offering pause points between levels, users maintain the flexibility to clear context (like in serial `opsx:apply`) while still benefiting from parallelization within each level.
+**Why this matters**: Long implementations with many slices can bloat context. By offering pause points between levels, users maintain the flexibility to clear context (like in serial `openspec-apply-change`) while still benefiting from parallelization within each level.
 
 ### Intelligent Parallelization
 
@@ -693,7 +663,7 @@ If no parallelization strategy is found, the skill runs tasks sequentially. This
 
 ### Verification Before Archive
 
-The skill always runs `opsx:verify` as the final step. This catches incomplete tasks, broken references, or schema violations before the user archives. The verification report serves as the completion summary.
+The skill always runs `openspec-verify-change` as the final step. This catches incomplete tasks, broken references, or schema violations before the user archives. The verification report serves as the completion summary.
 
 ### Human-in-the-Loop
 
@@ -737,9 +707,9 @@ If the environment doesn't support sub-agents (e.g., Claude.ai):
 
 **NEVER stop between living document updates and verification waiting for user confirmation** — Once living document updates (Steps 28-32) complete successfully, immediately proceed to recording the completion timestamp (Steps 33-35), then to verification (Step 36). These steps are a continuous workflow. The only legitimate stopping points are: (1) an error that requires user input to resolve, (2) preflight failing (Steps 1-5), or (3) the user-controlled context management decision points between dependency levels (Step 25). Do not treat completion of living document updates or timestamp recording as signals to stop and wait — they are signals to continue to the next step.
 
-**NEVER implement tasks directly** — Always delegate to `opsx:apply` skill via sub-agents. The opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
+**NEVER implement tasks directly** — Always delegate to `openspec-apply-change` skill via sub-agents. The opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
 
-**NEVER skip verification** — Verification using `opsx:verify` (Step 36) is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
+**NEVER skip verification** — Verification using `openspec-verify-change` (Step 36) is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
 
 **NEVER proceed with invalid task format** — This skill depends on markdown checklist format (`- [ ] task`) for progress tracking and resumption detection. If tasks.md uses numbered lists or plain bullets, exit early with an error. Do not attempt to work around the format issue — the user must fix tasks.md first.
 
@@ -800,7 +770,7 @@ All requirements implemented. No critical issues found.
 ### Next Steps
 1. Review the changes: `git diff`
 2. Run tests: `pnpm test`
-3. Archive this change: `<skill_invocation><skill>accelint-qrspi-archive</skill><args>remove-security-ruleset</args></skill_invocation>`
+3. Archive this change: Invoke the `accelint-qrspi-archive` skill with `remove-security-ruleset`
 
 Ready to archive!
 ```
@@ -830,7 +800,7 @@ Running verification...
 
 **Next Steps:**
 1. Fix critical issues
-2. Re-run verification: `<skill_invocation><skill>openspec-verify-change</skill><args>auth-refactor</args></skill_invocation>`
+2. Re-run verification: Invoke the `openspec-verify-change` skill with `auth-refactor`
 3. Or re-invoke this skill to retry
 
 Not ready to archive until critical issues are resolved.

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -72,9 +72,12 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 6. Read the design.md file from `openspec/changes/<change-name>/design.md` to check if `started_at` timestamp exists in frontmatter
 
 7. If `started_at` is NOT present in the frontmatter (first time applying this change):
-   - Add the `started_at` timestamp to the frontmatter using ISO 8601 format
-   - Use current timestamp: `new Date().toISOString()` (e.g., "2026-08-17T15:23:45.123Z")
-   - CRITICAL: Insert `started_at` immediately after the `created_at` field to keep all timestamps grouped together
+   - Add the `started_at` timestamp to the frontmatter using ISO 8601 format with Z suffix
+   - CRITICAL: Generate the timestamp deterministically using this command:
+     ```bash
+     python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z'))"
+     ```
+   - Insert `started_at` immediately after the `created_at` field to keep all timestamps grouped together
    - Preserve all other frontmatter fields (change, created_at, specs_touched, decisions) in their original order
    - Inform user: "Recording implementation start time..."
 
@@ -578,9 +581,12 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
 
 33. Read the design.md file from `openspec/changes/<change-name>/design.md`
 
-34. Add the `completed_at` timestamp to the frontmatter using ISO 8601 format:
-   - Use current timestamp: `new Date().toISOString()` (e.g., "2026-08-17T17:45:00.000Z")
-   - CRITICAL: Insert `completed_at` immediately after the `started_at` field to keep all timestamps grouped together
+34. Add the `completed_at` timestamp to the frontmatter using ISO 8601 format with Z suffix:
+   - CRITICAL: Generate the timestamp deterministically using this command:
+     ```bash
+     python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z'))"
+     ```
+   - Insert `completed_at` immediately after the `started_at` field to keep all timestamps grouped together
    - Preserve all other frontmatter fields (change, created_at, started_at, specs_touched, decisions) in their original order
    - This marks the moment implementation finished, right before verification begins
 

--- a/skills/accelint-qrspi-apply/SKILL.md
+++ b/skills/accelint-qrspi-apply/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires openspec CLI, sub-agent support, and QRSPI-generated changes.
 metadata:
   author: accelint
-  version: "1.5.0"
+  version: "1.7.0"
 ---
 
 # Accelint QRSPI Apply
@@ -27,7 +27,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
 - Sub-agent support (for parallel execution)
 - The expanded OpenSpec workflows (`explore`, `new`, `continue`) enabled
 
-**Important**: This skill is specifically designed for QRSPI-planned changes. Standard OpenSpec changes without parallelization strategies should use the regular `/opsx:apply` command directly.
+**Important**: This skill is specifically designed for QRSPI-planned changes. Standard OpenSpec changes without parallelization strategies should use the regular `opsx:apply` skill directly.
 
 ## Workflow Overview
 
@@ -63,7 +63,7 @@ Implement OpenSpec changes with intelligent parallelization. This skill orchestr
    ```bash
    openspec status --change "<name>" --json
    ```
-   If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `/opsx:continue` to generate tasks before applying."
+   If `state: "blocked"` (missing tasks), exit with: "Tasks artifact is missing. Run `opsx:continue` to generate tasks before applying."
 
 ### Record Implementation Start
 
@@ -242,10 +242,16 @@ For each level in the dependency graph (starting from level 0):
      {INJECTED_CONFIG_CONTEXT}
      </project_context>
 
-     /opsx:apply <change-name>
+     <skill_invocation>
+       <skill>opsx:apply</skill>
+       <args><change-name></args>
+     </skill_invocation>
 
-     CRITICAL: You MUST use the /opsx:apply command to implement tasks.
-     DO NOT implement tasks directly yourself. The /opsx:apply workflow will
+     IMPORTANT: This is a skill invocation directive, NOT a shell command.
+     Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+
+     CRITICAL: You MUST use the opsx:apply skill to implement tasks.
+     DO NOT implement tasks directly yourself. The opsx:apply workflow will
      load context and guide implementation.
 
      IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
@@ -284,10 +290,16 @@ For each level with multiple independent slices:
    {INJECTED_CONFIG_CONTEXT}
    </project_context>
 
-   /opsx:apply <change-name>
+   <skill_invocation>
+     <skill>opsx:apply</skill>
+     <args><change-name></args>
+   </skill_invocation>
 
-   CRITICAL: You MUST use the /opsx:apply command to implement tasks.
-   DO NOT implement tasks directly yourself. The /opsx:apply workflow will
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:apply" — do not attempt to run this as a terminal command.
+
+   CRITICAL: You MUST use the opsx:apply skill to implement tasks.
+   DO NOT implement tasks directly yourself. The opsx:apply workflow will
    load context and guide implementation.
 
    IMPORTANT: This is Slice N of a parallelized QRSPI implementation.
@@ -344,9 +356,9 @@ For each level with multiple independent slices:
    Progress is tracked in tasks.md checkboxes.
    ```
 
-**Slice targeting approach**: OpenSpec's `/opsx:apply` command does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
+**Slice targeting approach**: OpenSpec's `opsx:apply` skill does not have native "slice targeting" (no `--slice N` flag). This skill achieves parallelization by:
 
-1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `/opsx:apply <change-name>`, which:
+1. **Using the full OpenSpec CLI workflow**: Each sub-agent invokes `opsx:apply <change-name>`, which:
    - Runs `openspec instructions apply --change "<name>" --json` to get context
    - Loads all context files (proposal, design, specs, tasks)
    - Provides dynamic instructions based on current state
@@ -402,13 +414,18 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
-     /accelint-onboard-openspec
-     We have just completed the change spec openspec/changes/<change-name>.
+     <skill_invocation>
+       <skill>accelint-onboard-openspec</skill>
+       <args>We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact, e.g., "config.yaml's Anti-Patterns section says to avoid polling, but this change chose polling for stated reasons"]
      - [Decision 2 rephrased as fact]
-     ...
+     ...</args>
+     </skill_invocation>
+
+     IMPORTANT: This is a skill invocation directive, NOT a shell command.
+     Execute the internal skill "accelint-onboard-openspec" — do not attempt to run this as a terminal command.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -432,13 +449,18 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
-     /accelint-architecture-doc
-     We have just completed the change spec openspec/changes/<change-name>.
+     <skill_invocation>
+       <skill>accelint-architecture-doc</skill>
+       <args>We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...
+     ...</args>
+     </skill_invocation>
+
+     IMPORTANT: This is a skill invocation directive, NOT a shell command.
+     Execute the internal skill "accelint-architecture-doc" — do not attempt to run this as a terminal command.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -463,13 +485,18 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
-     /accelint-onboard-agent
-     We have just completed the change spec openspec/changes/<change-name>.
+     <skill_invocation>
+       <skill>accelint-onboard-agent</skill>
+       <args>We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...
+     ...</args>
+     </skill_invocation>
+
+     IMPORTANT: This is a skill invocation directive, NOT a shell command.
+     Execute the internal skill "accelint-onboard-agent" — do not attempt to run this as a terminal command.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -493,13 +520,18 @@ The slice boundaries are clearly marked in tasks.md (e.g., "## Slice 1: Remove C
      2. For each decision, rephrase as a plain factual statement (not an instruction)
      3. Invoke the skill with findings:
      ```
-     /accelint-readme-writer
-     We have just completed the change spec openspec/changes/<change-name>.
+     <skill_invocation>
+       <skill>accelint-readme-writer</skill>
+       <args>We have just completed the change spec openspec/changes/<change-name>.
 
      findings:
      - [Decision 1 rephrased as fact]
      - [Decision 2 rephrased as fact]
-     ...
+     ...</args>
+     </skill_invocation>
+
+     IMPORTANT: This is a skill invocation directive, NOT a shell command.
+     Execute the internal skill "accelint-readme-writer" — do not attempt to run this as a terminal command.
      ```
      The skill will merge these findings with its own codebase scan before presenting to the human.
 
@@ -604,9 +636,15 @@ decisions:
 
 **CRITICAL**: This is the FINAL step. Verification is MANDATORY and produces a comprehensive report as the final output. Do NOT add additional reporting after this step.
 
-36. Call the verify command:
+36. Call the verify skill:
    ```
-   /opsx:verify <change-name>
+   <skill_invocation>
+     <skill>opsx:verify</skill>
+     <args><change-name></args>
+   </skill_invocation>
+
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:verify" — do not attempt to run this as a terminal command.
    ```
 
 37. The verify command will:
@@ -653,7 +691,7 @@ If no parallelization strategy is found, the skill runs tasks sequentially. This
 
 ### Verification Before Archive
 
-The skill always runs `/opsx:verify` as the final step. This catches incomplete tasks, broken references, or schema violations before the user archives. The verification report serves as the completion summary.
+The skill always runs `opsx:verify` as the final step. This catches incomplete tasks, broken references, or schema violations before the user archives. The verification report serves as the completion summary.
 
 ### Human-in-the-Loop
 
@@ -697,9 +735,9 @@ If the environment doesn't support sub-agents (e.g., Claude.ai):
 
 **NEVER stop between living document updates and verification waiting for user confirmation** — Once living document updates (Steps 28-32) complete successfully, immediately proceed to recording the completion timestamp (Steps 33-35), then to verification (Step 36). These steps are a continuous workflow. The only legitimate stopping points are: (1) an error that requires user input to resolve, (2) preflight failing (Steps 1-5), or (3) the user-controlled context management decision points between dependency levels (Step 25). Do not treat completion of living document updates or timestamp recording as signals to stop and wait — they are signals to continue to the next step.
 
-**NEVER implement tasks directly** — Always delegate to `/opsx:apply` command via sub-agents. The /opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
+**NEVER implement tasks directly** — Always delegate to `opsx:apply` skill via sub-agents. The opsx:apply workflow loads context files (proposal, design, specs, tasks) and provides dynamic instructions based on OpenSpec's state management. If you implement tasks directly, you bypass OpenSpec's progress tracking and context loading.
 
-**NEVER skip verification** — Verification using `/opsx:verify` (Step 36) is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
+**NEVER skip verification** — Verification using `opsx:verify` (Step 36) is mandatory as the final step. Verification catches incomplete tasks, unimplemented requirements, and design divergences. The verification report serves as the completion summary. Skipping verification risks archiving incomplete or incorrect implementations.
 
 **NEVER proceed with invalid task format** — This skill depends on markdown checklist format (`- [ ] task`) for progress tracking and resumption detection. If tasks.md uses numbered lists or plain bullets, exit early with an error. Do not attempt to work around the format issue — the user must fix tasks.md first.
 
@@ -760,7 +798,7 @@ All requirements implemented. No critical issues found.
 ### Next Steps
 1. Review the changes: `git diff`
 2. Run tests: `pnpm test`
-3. Archive this change: `/accelint-qrspi-archive remove-security-ruleset`
+3. Archive this change: `<skill_invocation><skill>accelint-qrspi-archive</skill><args>remove-security-ruleset</args></skill_invocation>`
 
 Ready to archive!
 ```
@@ -790,7 +828,7 @@ Running verification...
 
 **Next Steps:**
 1. Fix critical issues
-2. Re-run verification: `/opsx:verify auth-refactor`
+2. Re-run verification: `<skill_invocation><skill>opsx:verify</skill><args>auth-refactor</args></skill_invocation>`
 3. Or re-invoke this skill to retry
 
 Not ready to archive until critical issues are resolved.
@@ -826,3 +864,56 @@ Running verification...
 **Change:** update-readme
 All tasks complete. Ready to archive!
 ```
+
+## File Changes Summary
+
+After verification completes, generate a structured diff summary for the user. This summary provides a scannable overview of all code-level changes without descriptions.
+
+**CRITICAL**: This summary is MANDATORY after the verification report. Do not skip it.
+
+41. Run `git diff` to capture all changes made during this implementation
+
+42. Parse the archived change spec from `openspec/archive/<change-name>/` to understand the change's scope
+
+43. Generate a structured token-level change list following this exact format:
+
+   **Template:**
+   ```
+   File Changes Made In This Change:
+   <token_type>   <file_name>:<line_number>   <symbol_name>   <[change_type]>
+   ```
+
+   **Rules:**
+   - **Token Types**: function, constant, type, test, class, interface, enum, etc.
+   - **Change Types**: [added], [modified], [deleted]
+   - **Line Numbers**: Use "Ln " prefix (e.g., "Ln 234")
+   - **Source Directory Only**: Only list items from the source directory (e.g., `src/`, `lib/`). Exclude config files, build artifacts, and generated files.
+   - **Test Granularity**: For test changes, list only the `describe` block token. Do NOT list individual `it` or `test` cases — they add noise without value.
+   - **No Collapsing**: DO NOT summarize or collapse multiple changes into one line. Each token gets its own line.
+   - **Sorting**: Sort by change type (added, then modified, then deleted)
+   - **Justification**: Perfectly align columns with minimum 3 spaces between columns
+   - **No Additional Content**: ONLY provide the template above — no headers, no summary paragraphs, no explanations
+
+   **Example output:**
+   ```
+   File Changes Made In This Change:
+   test       index.test.ts:Ln 234      ensureGrammar                [added]
+   test       index.test.ts:Ln 291      ensureGrammars               [added]
+   constant   language-constants.ts     EXTENSION_TO_LANGUAGE        [added]
+   constant   language-constants.ts     LANGUAGE_EXTENSIONS          [added]
+   function   index.ts:Ln 89            ensureGrammar                [added]
+   function   index.ts:Ln 112           ensureGrammars               [added]
+   function   scan.ts:Ln 45             detectLanguagesInFiles       [added]
+   type       errors.ts:Ln 12           AuditKitError                [modified]
+   function   errors.ts:Ln 65           formatError                  [modified]
+   function   index.test.ts:Ln 23       expectErrWithType            [modified]
+   constant   index.ts:Ln 15            LANGUAGE_MAP                 [modified]
+   constant   index.ts:Ln 28            SUPPORTED_EXTENSIONS         [modified]
+   function   index.ts:Ln 156           getWasmPath                  [modified]
+   function   scan.ts:Ln 632            executeScan                  [modified]
+   function   language-detection.ts     EXTENSION_TO_LANGUAGE        [deleted]
+   ```
+
+44. Present the file changes summary immediately after the verification report
+
+**Output**: Justified, sorted token-level change list showing all additions, modifications, and deletions in source code

--- a/skills/accelint-qrspi-archive/CHANGELOG.md
+++ b/skills/accelint-qrspi-archive/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
 ## [1.3.1] - 2026-08-21
 
 ### Fixed

--- a/skills/accelint-qrspi-archive/CHANGELOG.md
+++ b/skills/accelint-qrspi-archive/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.4.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.3.1] - 2026-08-21

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -157,390 +157,45 @@ This does give something up: openspec-archive's own internal work — comparing 
 
 9. Run the appropriate skill invocation:
 
-   For single change:
-   ```xml
-   <skill_invocation>
-     <skill>openspec-archive-change</skill>
-     <args>[change-name]</args>
-   </skill_invocation>
+  For single change:
+   ```text
+   Invoke the openspec-archive-change skill.
 
-   IMPORTANT: Use the Skill tool to invoke this skill directly.
-   Pass the skill name ("openspec-archive-change") and any args.
+   [change-name]
    ```
 
-   For bulk archive:
-   ```xml
-   <skill_invocation>
-     <skill>openspec-bulk-archive-change</skill>
-   </skill_invocation>
+  For bulk archive:
+   ```text
+   Invoke the openspec-bulk-archive-change skill.
 
-   IMPORTANT: Use the Skill tool to invoke this skill directly.
-   Pass the skill name ("openspec-bulk-archive-change").
-   ```
+   add-live-sync
 
-10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
+   Sync now? (y/n) → yes
+   ✓ Synced delta specs, resuming openspec-archive's remaining steps...
+   ✓ openspec-archive add-live-sync merged, archived to
+     openspec/changes/archive/2026-03-02-add-live-sync/
+   ✓ Extracted: specs_touched, decisions from design.md frontmatter
 
-11. **If any other interactive prompt comes up** — most commonly openspec-bulk-archive asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
+   Computing new co-touch pairs...
+   - sync/protocol ↔ ui/status-indicator (new pair)
 
-12. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
+   [spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
+   ✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
+   ✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
 
-13. If ANY merge reports unresolved conflicts, STOP immediately. Do not attempt to resolve it, and do not proceed to step 14 for ANY change in this batch — a partial extraction is worse than none, since there's no way to tell a stalled batch from a clean one otherwise. Report the conflict verbatim to the user and stop. Do not proceed to validation — parsing anything out of a partially-merged batch would propagate garbage into every capability the batch touches.
+   Updating openspec/specs/INDEX.md... (2 rows patched, 12 rows untouched)
+   Appending to openspec/changes/archive/INDEX.md... (1 row)
 
-14. For each change that archived successfully, read its `design.md` frontmatter from its new archived path (e.g. `openspec/changes/archive/2026-03-02-add-live-sync/design.md`) and build one record:
-
-   ```
-   {
-     change: "add-live-sync",
-     date: "2026-03-02",           // from the archive folder's own
-                                    // YYYY-MM-DD prefix, NEVER from
-                                    // anything inside design.md
-     archivePath: "openspec/changes/archive/2026-03-02-add-live-sync/",
-     specsTouched: ["sync/protocol", "ui/status-indicator"],
-     decisions: [{ id: "D1", choice: "polling with 5s interval", ... }]
-   }
-   ```
-
-15. Keep the list of records from step 14, grouped by change, for validation — plus an explicit note to yourself that no unresolved conflicts remain.
-
-**Output**: one record per archived change (`change`, `date`, `archivePath`, `specsTouched`, `decisions`), held in this context and passed straight to the validation step.
-
-**Validate Extracted Records**
-
-**Goal**: confirm archive records are structurally sound before cross-link computation depends on them — a sanity check on what was extracted, not a re-verification of the source data (preflight Task A already confirmed the source `design.md` frontmatter was well-formed before archive ran).
-
-16. Confirm every record has a non-empty `specsTouched` and at least one `decisions` entry with `choice` populated. If a record is missing either, something went wrong building it during archive (not in the original data, which Task A already validated) — re-run archive for that change rather than proceeding with a partial record.
-
-17. Keep records grouped **by change**, exactly as returned. Cross-link computation computes pairs within a single change's own `specsTouched` — two unrelated changes archived in the same bulk-archive batch don't imply their capabilities co-touch each other, even though they landed at the same moment.
-
-**Output**: the same record set from archive, confirmed structurally complete and ready for cross-link computation and INDEX appending.
-
-**Compute Cross-Links (All-Pairs Union)**
-
-**Goal**: for each change, compute the symmetric co-touch pairs within its own `specs_touched`, and combine those pairs across every change in this archive operation into one set of newly-contributed partners per capability. This step touches zero files — it only combines the `specsTouched` lists already sitting in the validated records. Merging those new partners with whatever `related:` entries a spec already has (never dropping any of them) happens during spec writing, inside the subagent that's already opening that file — there's no reason for the parent to read spec frontmatter just to seed a union that spec writing can do in the same breath as its own file read.
-
-18. For a change with `specs_touched: [A, B, C]`, the contributed pairs are all 2-combinations excluding self: `(A,B)`, `(A,C)`, `(B,C)`. Co-touch has no direction — pairing `(A,B)` means A gains B as a related partner **and** B gains A in the same step.
-
-19. This is a pure computation with no dependency on file I/O, so it's worth writing as a small pure function rather than eyeballing it per capability:
-
-   ```typescript
-   type ChangeLink = {
-     readonly change: string;
-     readonly specsTouched: readonly string[];
-   };
-
-   // All 2-combinations within one change's specs_touched. Pure, no self-pairs,
-   // no directionality — a co-touch relationship reads the same both ways.
-   const pairsFromChange = (
-     link: ChangeLink,
-   ): ReadonlyArray<readonly [string, string]> =>
-     link.specsTouched.flatMap((a, i) =>
-       link.specsTouched.slice(i + 1).map((b) => [a, b] as const),
-     );
-
-   // Fold every change's pairs into one partner-set-per-capability map. This
-   // starts from an empty map every time — it combines pairs ACROSS the
-   // changes in this batch, not against a spec's on-disk related: list. That
-   // merge is deliberately left to spec writing, which is the step that opens the file.
-   const accumulateNewPartners = (
-     pairsByChange: ReadonlyArray<ReadonlyArray<readonly [string, string]>>,
-   ): ReadonlyMap<string, ReadonlySet<string>> => {
-     const next = new Map<string, Set<string>>();
-     for (const pairs of pairsByChange) {
-       for (const [a, b] of pairs) {
-         next.set(a, (next.get(a) ?? new Set()).add(b));
-         next.set(b, (next.get(b) ?? new Set()).add(a));
-       }
-     }
-     return next;
-   };
-   ```
-
-20. Fold every change's pairs into the same accumulating map, starting from empty — a bulk-archive batch of three changes touching overlapping capabilities should have all three changes' pairs combined before spec writing ever touches a file, so each capability's subagent is invoked once with a complete new-partner list rather than three times with partial data.
-
-21. Hand this map to spec writing as-is — unsorted and unmerged with any spec's existing `related:` list. The spec-writing subagent is responsible for both the merge (union with whatever's already in the file) and the final alphabetical sort, since it's the one that actually reads the file this all depends on.
-
-**Output**: a map of `capability -> newly contributed partner names`, not yet merged with any spec's existing `related:` list and not yet sorted — both of those happen during spec writing.
-
-**Write Spec Frontmatter and Body (Subagent, Always)**
-
-**Goal**: merge newly contributed partners into each touched spec's existing `related:` list, persist that plus provenance into frontmatter, and regenerate the `## Related Specs` section to match.
-
-Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once the new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in cross-link computation.
-
-22. For each touched capability, use the Agent tool to spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from cross-link computation — not a final list; the subagent is the one that merges those against whatever the file already has):
-
-   ```
-   Update openspec/specs/[capability]/spec.md only. Do not touch any other file.
-
-   Read this file's current related: value from its frontmatter (treat it as
-   empty if the file has no frontmatter yet — this may be a brand-new
-   capability). Union it with these newly contributed partners:
-   [[partner], [partner], ...]. Never drop an entry that was already there.
-   Sort the resulting full set alphabetically and write it in flow style on
-   one line — that's what keeps a no-op run byte-identical and a genuine
-   addition a clean one-line diff.
-
-   Also set:
-     last_touched_by: [change-name]
-     last_touched_on: [date]
-   as plain overwrites of whatever was there before, not an accumulated
-   history.
-
-   Do NOT add capability or purpose fields. The capability name is this
-   file's own path; purpose already lives in its ## Purpose or ### Purpose heading.
-
-   Then regenerate the ## Related Specs section in the body from the same
-   final, sorted related: list (replace any existing ## Related Specs
-   content entirely — this section is never hand-maintained).
-
-   For each partner in the sorted related: list, read its spec.md file to
-   extract the purpose heading text. Check for these headings in order:
-   - ## Purpose or ### Purpose
-   - ## Overview or ### Overview
-
-   Use whichever is found first (Overview and Purpose are semantically equivalent).
-   Format each line as:
-
-     - [[partner]](../[partner]/spec.md) - <Purpose or Overview heading text>
-
-   Example format (one entry per line, alphabetically sorted by partner name):
-
-     ## Related Specs
-
-     - [auth-session-store](../auth-session-store/spec.md) - Secure session token storage and retrieval
-     - [sync-protocol](../sync-protocol/spec.md) - Defines the live-sync wire protocol for real-time updates
-
-   The format is: markdown link with partner name as link text, relative
-   path to its spec.md, then space-dash-space (not em-dash), then the
-   first sentence or paragraph from that partner's purpose heading (## Purpose, ### Purpose, ## Overview, or ### Overview).
-
-   If no ## Related Specs heading exists, insert one at the end of the file.
-
-   Report back ONLY: the file path, whether the write was a no-op
-   (byte-identical to what was already there) or an actual change, the
-   final related: list you wrote, and the capability's current purpose
-   heading text (from ## Purpose, ### Purpose, ## Overview, or ### Overview
-   — whichever exists, a sentence or short paragraph — you're not writing
-   this, just reading it back so the parent doesn't have to reopen this
-   file for index updates). Do not return the file's full contents.
-   ```
-
-23. If the capability has no prior `spec.md` (a brand-new capability per preflight step 4), the subagent starts from an empty frontmatter block instead of reading an existing one — same prompt otherwise.
-
-24. Collect each subagent's short report (file, no-op vs. changed, final `related:` list, and Purpose heading text) for index updates and reporting. Index updates reuse the `related:` and Purpose values directly from this report instead of reopening the file; the final report draws only on the no-op/changed status. Nothing else about the write needs to enter the parent's context — a reported no-op is the expected signal that this capability wasn't actually affected by this batch, not something to double-check by re-reading the file.
-
-**Output**: every touched capability's `spec.md` updated in place (existing `related:` entries preserved, new ones unioned in and sorted), or confirmed unchanged, with only a short status line plus its `related:`/Purpose values — the small payload for index updates — entering the parent's context.
-
-**Update openspec/specs/INDEX.md**
-
-**Goal**: keep `openspec/specs/INDEX.md` in sync with what was just written, at the cost of touching only the lines that actually changed — not a re-scan of every capability's `spec.md`, and not even a full read of `specs/INDEX.md` itself. The spec-writing subagents already read each touched capability's current `related:`, `last_touched_by`, and `## Purpose`/`### Purpose` heading as part of doing their own write, and report those values back — index updates reuse that data directly instead of paying for a second full scan of `openspec/specs/`. The only time this step looks at capabilities beyond the ones this batch touched, or reads more than a single targeted line of `specs/INDEX.md`, is when the file doesn't exist yet at all — there's no existing state to patch, and a one-time full build is the right move, not a routine one.
-
-25. **The common case — `specs/INDEX.md` already exists.** Don't read the whole file into context to do this — locate and edit only the lines that actually change:
-
-   - **Existing capability**: grep for the line whose first cell exactly matches the capability name (anchored between the leading `| ` and the next `|`, not a loose substring match — `sync/protocol` must not match `sync/protocol-v2`). Replace that single line with the row built from the spec-writing report for that capability (`Purpose`, `related:`, `last_touched_by`). Nothing else in the file is read or touched.
-   - **Brand-new capability** (per preflight step 4): grep for capability-name cells to find the first existing row that sorts after the new one alphabetically, and insert the new row immediately before it (or append at the end if it sorts last) with no blank line before or after the insertion. All data rows must remain contiguous with no blank lines between them. This still only touches one new line — locating the insertion point doesn't require loading row content, just the capability-name column.
-   - Every row for every untouched capability is never opened, matched, or rewritten — not just "left identical" as an outcome of a full rebuild, but literally never touched by this operation.
-
-26. Build each row without cross-row padding — single-space cell separation (`| sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |`), not aligned to the widest value in each column:
-
-   ```markdown
-   | Capability | Purpose | Related | Last touched by |
-   | --- | --- | --- | --- |
-   | sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |
-   | ui/status-indicator | Renders connection state in UI | sync/protocol | add-live-sync |
-   ```
-
-   Markdown tables render correctly regardless of padding — only the header separator's dash count matters, not whitespace consistency across data rows. Keeping cross-row alignment would mean every row's padding depends on every other row's content length, which forces a full-table rewrite the instant any single row's text changes length — exactly the cost this design exists to avoid. A patched row and its untouched neighbors will look slightly ragged in a raw diff; that's the trade for the diff actually being one line.
-
-27. **The bootstrap case — `specs/INDEX.md` doesn't exist yet.** There's no prior state to patch, and patching only the touched rows would permanently omit every untouched capability until each happens to be touched by some future change. List every directory under `openspec/specs/`, and for each one, read its `## Purpose` or `### Purpose` heading, `related:` frontmatter, and `last_touched_by` directly — a full scan. This runs at most once per project, the first time this skill archives anything against it; every archive after that goes through step 25 instead.
-
-28. **Bootstrap case only**: write `openspec/specs/INDEX.md` from the full scan gathered in step 27, using the row format from step 26, with all data rows contiguous and no blank lines between them. If the file already carries a project-specific title or preamble above the table, preserve it. The common case (step 25) has already written its edit directly — there's no separate write step for it.
-
-**Output**: `openspec/specs/INDEX.md`, with one line changed or inserted per capability this batch touched (with no blank lines added) and every other line untouched, or built once from every capability project-wide if the file didn't exist yet, with all data rows contiguous and no blank lines between them.
-
-A patched `specs/INDEX.md` can still drift from reality for reasons outside this skill's control — a `spec.md` hand-edited outside the archive workflow, a capability directory renamed or deleted directly. This skill doesn't re-derive the whole index every run to catch that. Nothing else currently does either: `accelint-archive-synthesis`'s two checks (decision-drift, structural-coupling) both read `specs/INDEX.md` as ground truth rather than auditing it against the `spec.md` files it summarizes. Catching this kind of drift would mean adding an index-reconciliation check to `accelint-archive-synthesis` — a natural fit for a skill that already exists to do periodic, corpus-wide checks — but that check doesn't exist yet. Until it does, this is an accepted, narrow gap rather than a covered one.
-
-**Append to openspec/changes/archive/INDEX.md**
-
-**Goal**: log one durable row per archived change, inserted at the end of the table's existing data rows — never blindly at the end of the file. Unlike specs INDEX updating, this file is history, and history is append-only — never regenerated, never reordered.
-
-29. For each change from validation, construct one row:
-
-   ```markdown
-   | Change | Date | Decision | Specs touched | Status |
-   | --- | --- | --- | --- | --- |
-   | add-live-sync | 2026-03-02 | polling with 5s interval | sync/protocol, ui/status-indicator | current |
-   ```
-
-   - `Date` is the archive folder's `YYYY-MM-DD` prefix — the same source used in validation, never anything read out of `design.md`.
-   - `Decision` is a one-line summary of `decisions[].choice`. If a change recorded more than one decision, concatenate the choices with semicolons (e.g. `polling with 5s interval; client-side dedup on reconnect`) rather than picking just one — every decision the design phase made deserves to survive into the permanent record, even compressed to a phrase.
-   - `Status` is written as `current` and this skill never touches that column again after this initial write, for this row or any other. Transitions like `current` → `superseded` belong to `accelint-archive-synthesis`, which has the cross-change context needed to know when a decision has actually been superseded — this skill only ever sees one archive operation at a time and can't safely make that call.
-
-30. **Locate the insertion point — the end of the table data rows, with no blank lines between rows.** Find the header row (`| Change | Date | ... |`), its separator (`| --- | --- | ... |`), and the contiguous block of data rows that follows. Insert the new row(s) immediately after the last of those data rows, with no blank line before the new row. All data rows must be contiguous with no blank lines between them — blank lines between entries corrupt the table structure and must never be written. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
-
-31. **Never write metadata or summary content after either INDEX.md table.** Both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a markdown header/preamble before the table (e.g., "# Capability Specifications Index" or "# Archive Index" followed by a brief description), which must be preserved if present. After the preamble comes the table (header row, separator row, and data rows), and the file ends immediately after the last data row. Do not write any of these common but forbidden trailing elements after the table:
-   - "**Total Changes:** N" or similar row counts
-   - "**Generated:** YYYY-MM-DD" or similar timestamps
-   - "**Status Legend:**" or similar explanatory text
-   - Horizontal rules (`---`) after the table
-   - Any other prose, metadata, or summary content
-
-   If such trailing content exists in either file from a prior run, delete it. The canonical INDEX.md format is: optional preamble, then table, then end-of-file. Nothing may appear after the last data row.
-
-32. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row and separator row (and no trailing content) if missing.
-
-33. Do not re-sort, reformat, or otherwise touch any existing row. The append-only discipline here is what makes this file a reliable audit trail; reordering past rows would make it impossible for anyone to use git blame to see when a decision was recorded relative to the others around it.
-
-**Output**: `openspec/changes/archive/INDEX.md`, with one new row per archived change inserted immediately after the last data row with no blank line before it, every prior row untouched, all data rows contiguous with no blank lines between them, and no metadata or summary content after the table — the file ends immediately after the last data row.
-
-**Report**
-
-34. Summarize what changed:
-
-   ```
    ✅ Archive complete: add-live-sync
 
-   Specs updated:
-   - sync/protocol        (+ui/status-indicator)
-   - ui/status-indicator  (+sync/protocol)
-
-   openspec/specs/INDEX.md updated (2 rows patched)
-   openspec/changes/archive/INDEX.md: 1 row appended
-
    Next steps:
-   - Review the diff on touched specs before committing
-   - related: entries are additive only here — if one looks wrong,
-     pruning is accelint-archive-synthesis's job, not this skill's
+   - Review the diff on the two updated specs before committing
+   - related: entries are additive only — pruning is accelint-archive-synthesis's job
    ```
-
-35. If any capability was left with a placeholder purpose or skipped entirely because preflight Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
-
-**Output**: a human-readable summary of every file this skill touched.
-
-## Key Principles
-
-A quick-reference summary — each of these is explained in full where it's actually applied (Implementation Steps) or enforced (NEVER Do This); this is just the index.
-
-- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until openspec-bulk-archive resolves conflicts in order; only the merged, archived spec is worth indexing.
-- **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
-- **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
-- **Every write is idempotent.** Flow-style sorted `related:` and row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
-- **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
-- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: openspec-archive/openspec-bulk-archive are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
-
-## Explicitly Out of Scope
-
-- **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/[capability]/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
-- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the openspec-archive/openspec-bulk-archive skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
-- **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
-- **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
-- **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
-- **No corpus-wide drift detection in `specs/INDEX.md`.** Index updates only ever patch the rows for capabilities this batch's changes declared in `specs_touched`. If some capability's `spec.md` was edited outside this skill and its `INDEX.md` row has gone stale as a result, this skill's hot path doesn't catch that — and neither, currently, does `accelint-archive-synthesis`: its decision-drift and structural-coupling checks both read `specs/INDEX.md` as ground truth rather than verifying it against `spec.md`. This is a real, accepted gap, not a job this skill should absorb into its own per-archive cost.
-- **No metadata or summary content after either INDEX.md table.** Both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a preamble before the table (preserved if present), then the table (header, separator, and data rows), then end-of-file. No trailing content after the table is permitted. Common forbidden trailing elements include "**Total Changes:**", "**Generated:**", "**Status Legend:**", and horizontal rules. If such content exists from a prior run, it must be deleted — the canonical format is optional-preamble-then-table-then-EOF for both files.
-
-## Error Handling
-
-**Missing or malformed design.md frontmatter (Task A)**: derive a candidate `specs_touched`/`decisions` from the change's own `proposal.md` and delta spec directories, present it to the user for explicit confirmation, and write the confirmed value back into `design.md` before archive runs for that change. Stop before archive for that change, with the field named, only if the user chooses to pause and fix it themselves, or if nothing in the change's own files supports a candidate at all.
-
-**Missing `## Purpose` or `### Purpose` heading (Task B)**: don't block archive, validation, or cross-link computation (they don't touch spec bodies), but stop before spec writing reaches that capability and ask the user to either add a placeholder or fix the spec first.
-
-**A change touches only one capability**: `specs_touched` with a single entry produces zero pairs — that's expected, not an error. Still run spec writing for that capability (write `last_touched_by`/`last_touched_on`, regenerate `## Related Specs` even if its list is unchanged) and still add its row to `changes/archive/INDEX.md` in the changelog step.
-
-**Brand-new capability with no prior spec.md**: handled explicitly in preflight checks (step 4) and spec writing (step 19 substep 2) — the subagent starts from an empty frontmatter block rather than treating the missing file as an error.
-
-**Native command reports unresolved conflicts**: the archive step stops and reports the conflict verbatim to the user immediately without proceeding to extraction (archive step 8); do not proceed to validation.
-
-**openspec-archive or openspec-bulk-archive branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
-
-**No subagent support available for spec writing** (e.g. an environment without sub-agent support): fall back to performing spec-writing steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for spec writing only, not the intended default there, and normal operation should always prefer subagents for spec writing. This has no bearing on the archive step, which already runs in this context unconditionally by design regardless of sub-agent availability — see the Archive and Extract section.
-
-**`specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist yet**: expected on a project's first-ever archive. Create `changes/archive/INDEX.md` fresh with a header row and separator row only — no trailing content of any kind (step 32); `specs/INDEX.md` is built fresh from every capability in the index update bootstrap case (step 27), and patched row-by-row on every archive after that.
-
-**Either INDEX.md file has forbidden content after the table** (a total row count, a `Generated:` date, a status legend, horizontal rules, or similar): delete all such trailing content from both `changes/archive/INDEX.md` and `specs/INDEX.md` — the canonical format for both files is optional-preamble-then-table-then-EOF, ending immediately after the last data row with no blank lines or metadata following it. See steps 30-31.
-
-## NEVER Do This
-
-**NEVER stop between workflow steps and wait for user confirmation unless an error occurs** — this is a continuous workflow from preflight through final report. Once archive completes successfully, immediately proceed to validation, then cross-linking, and so on through the final report. The only legitimate stopping points are: (1) an error that requires user input to resolve, or (2) preflight failing. Do not treat the completion of the archive skill as a signal to stop and wait — it's a signal to continue to validation.
-
-**NEVER run validation through reporting once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
-
-**NEVER prune a `related:` entry** — this skill only unions. Removing an entry that looks stale is `accelint-archive-synthesis`'s job, and it requires human confirmation even there.
-
-**NEVER write a derived `specs_touched` or `decisions` candidate into a change's `design.md` without the author's explicit confirmation** — deriving a candidate from `proposal.md` and delta specs (Task A's recovery path) is a convenience for getting unblocked, not a substitute for the author's own call on which capabilities a change actually touched.
-
-**NEVER re-pad or realign existing rows in `specs/INDEX.md` when patching one row** — cell padding is per-row, not aligned to the table's widest value. Touching every row's whitespace to keep columns visually lined up defeats the entire point of a targeted line edit and turns a one-line diff back into a full-file rewrite.
-
-**NEVER change an existing `Status` value in `changes/archive/INDEX.md`** — write `current` once, at creation, and never touch that column again for that row. Transitions belong to `accelint-archive-synthesis`.
-
-**NEVER read `Date` from `design.md`** — always use the archive folder's own `YYYY-MM-DD` prefix. A change can sit in review for weeks before it's archived, so anything `design.md` says about dates will be stale by the time this skill runs.
-
-**NEVER duplicate `capability` or `purpose` into a spec's frontmatter** — both already exist as the file's own path and its `## Purpose` or `### Purpose` heading. Restating either creates a second source of truth that will eventually disagree with the first.
-
-**NEVER hand-maintain `## Related Specs`** — always regenerate it wholesale from the `related:` frontmatter that was just written. Treating it as independently editable content invites drift between what the frontmatter says and what the body shows.
-
-**NEVER reorder or rewrite existing rows in `changes/archive/INDEX.md`** — append only. This file's value as an audit trail depends entirely on past rows staying exactly as they were written.
-
-**NEVER append a new row to either INDEX.md by writing to the end of the file** — locate the end of the table's existing data rows and insert there with no blank line before the new row. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
-
-**NEVER add blank lines between data rows in either INDEX.md file** — all data rows must be contiguous with no blank lines separating them. A blank line between entries corrupts the table structure. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
-
-**NEVER write metadata or summary content after either INDEX.md table** — both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a preamble before the table (preserve if present), then the table (header, separator, and data rows), then end-of-file. Never write "**Total Changes:**", "**Generated:**", "**Status Legend:**", horizontal rules (`---`), or any other trailing content after the table. If such content exists from a prior run, delete it. Each file must end immediately after its last data row.
-
-**NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
-
-**NEVER decline, skip, or second-guess a sync prompt during openspec-archive or openspec-bulk-archive** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
-
-**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run openspec-archive or openspec-bulk-archive directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
-
-**NEVER run spec writing directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
-
-**NEVER treat a mid-run branch in openspec-archive/openspec-bulk-archive (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
-
-## Example Usage
-
-**Scenario 1: Single-change archive**
-
-```
-User: Archive the add-live-sync change with cross-linking
-
-Skill: Running preflight checks...
-✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
-✓ Both capabilities have a ## Purpose/### Purpose heading
-
-<skill_invocation>
-  <skill>openspec-archive-change</skill>
-  <args>add-live-sync</args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("openspec-archive-change") and any args.
-
-Sync now? (y/n) → yes
-✓ Synced delta specs, resuming openspec-archive's remaining steps...
-✓ openspec-archive add-live-sync merged, archived to
-  openspec/changes/archive/2026-03-02-add-live-sync/
-✓ Extracted: specs_touched, decisions from design.md frontmatter
-
-Computing new co-touch pairs...
-- sync/protocol ↔ ui/status-indicator (new pair)
-
-[spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
-✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
-✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
-
-Updating openspec/specs/INDEX.md... (2 rows patched, 12 rows untouched)
-Appending to openspec/changes/archive/INDEX.md... (1 row)
-
-✅ Archive complete: add-live-sync
-
-Next steps:
-- Review the diff on the two updated specs before committing
-- related: entries are additive only — pruning is accelint-archive-synthesis's job
-```
 
 **Scenario 2: Bulk archive touching an already-linked capability**
 
-```
+```text
 User: Run bulk-archive on the pending changes
 
 Skill: Running preflight checks across 3 pending changes...
@@ -559,7 +214,7 @@ then re-invoke this skill to continue.
 
 **Scenario 3: Missing design.md frontmatter, recovered from the change's own files**
 
-```
+```text
 User: Archive the enhance-mock-consistency-rule change
 
 Skill: Running preflight checks...
@@ -584,13 +239,9 @@ User: (a)
 
 Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
 
-<skill_invocation>
-  <skill>openspec-archive-change</skill>
-  <args>enhance-mock-consistency-rule</args>
-</skill_invocation>
+Invoke the openspec-archive-change skill.
 
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("openspec-archive-change") and any args.
+enhance-mock-consistency-rule
 
 ✓ openspec-archive enhance-mock-consistency-rule merged, archived to
   openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
@@ -599,18 +250,13 @@ Pass the skill name ("openspec-archive-change") and any args.
 
 **Scenario 4: Bulk archive raises a non-routine prompt (surfaced to the user, not answered by the skill)**
 
-```
+```text
 User: Run bulk-archive on the pending changes
 
 Skill: Running preflight checks across 2 pending changes...
 ✓ All design.md frontmatter valid
 
-<skill_invocation>
-  <skill>openspec-bulk-archive-change</skill>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("openspec-bulk-archive-change").
+Invoke the openspec-bulk-archive-change skill.
 
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accelint-qrspi-archive
-description: Archive an OpenSpec change end-to-end. This skill invokes openspec-archive or openspec-bulk-archive itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run openspec-archive", "run openspec-bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
+description: Archive an OpenSpec change end-to-end. This skill invokes openspec-archive-change or openspec-bulk-archive-change itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run openspec-archive-change", "run openspec-bulk-archive-change", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
 license: Apache-2.0
 compatibility: Requires the OpenSpec CLI. Per-capability spec writes require sub-agent support — see the skill body for the degraded fallback if unavailable. Native archive always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but preflight Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose or ### Purpose heading in its body.
 metadata:
@@ -10,13 +10,13 @@ metadata:
 
 # Accelint QRSPI Archive
 
-Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes openspec-archive or openspec-bulk-archive itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
+Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes openspec-archive-change or openspec-bulk-archive-change itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
 
-Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/[slug]/specs/` is still provisional — openspec-bulk-archive may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
+Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/<slug>/specs/` is still provisional — openspec-bulk-archive-change may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
 
 ## What This Skill Does
 
-**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking openspec-archive or openspec-bulk-archive itself, then immediately following up with cross-capability linking and index maintenance.
+**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking openspec-archive-change or openspec-bulk-archive-change itself, then immediately following up with cross-capability linking and index maintenance.
 **Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself during archive and extraction; it does not wait for the merge to have happened some other way first.
 **Output**: the change(s) archived via OpenSpec's own merge, plus updated `related:` frontmatter and a regenerated `## Related Specs` section on every touched spec, an updated `openspec/specs/INDEX.md` (patched for the capabilities this batch touched, or built fresh project-wide the first time the file doesn't exist yet), and one appended row per archived change in `openspec/changes/archive/INDEX.md`.
 **Does NOT**: implement the merge or conflict-resolution logic itself (that's OpenSpec's own, which this skill invokes via the native command rather than reimplementing), prune any `related:` entry, change a change's `Status` column after its initial write, reorder existing changelog rows, or shell out to the OpenSpec CLI to read local spec files (plain file reads are sufficient — see Explicitly Out of Scope).
@@ -25,8 +25,8 @@ Cross-linking has to happen after the merge resolves, not before it, which is ex
 
 - OpenSpec CLI installed and initialized, with one or more changes ready to archive.
 - Sub-agent support, for per-capability spec writes only — those always run as subagents, unconditionally, and this is a hard requirement for normal operation there, not an optional speedup for large batches (see Error Handling for the degraded fallback if unavailable). Archive and extraction never uses a subagent, regardless of whether sub-agent support exists — see the Archive and Extract section for why.
-- Each change's `openspec/changes/[slug]/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
-- Every capability named in any `specs_touched` list already has `openspec/specs/[capability]/spec.md` with a `## Purpose` or `### Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in preflight checks, Task B).
+- Each change's `openspec/changes/<slug>/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
+- Every capability named in any `specs_touched` list already has `openspec/specs/<capability>/spec.md` with a `## Purpose` or `### Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in preflight checks, Task B).
 
 If any of these are missing, report the gap and guide the user to resolve it before proceeding — do not silently substitute a guessed default for a missing field. This applies as-is to spec writing's sub-agent support and a touched spec's missing `## Purpose` or `### Purpose` heading. A change's missing `specs_touched`/`decisions` frontmatter is handled differently: preflight Task A derives a candidate from the change's own files and gets the author's explicit confirmation before writing it, rather than stopping outright — see Task A below for why a hard stop isn't actually necessary here, and why it still isn't a silent guess.
 
@@ -38,12 +38,12 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 ├────────────────────────────────────────────────────────────────────────┤
 │  0 Preflight        Verify frontmatter + Purpose         Go / no-go    │
 │                     headings before touching anything                  │
-│  1 Archive+Extract  Run openspec-archive or openspec-bulk-  Change     │
-│                     archive yourself, in this context      records     │
-│                     (never a subagent); stay with any                  │
-│                     internal sync branch until archive's               │
-│                     own steps finish, then read back                   │
-│                     specs_touched + decisions                          │
+│  1 Archive+Extract  Run openspec-archive-change or          Change     │
+│                     openspec-bulk-archive-change yourself,  records    │
+│                     in this context (never a subagent);                │
+│                     stay with any internal sync branch                 │
+│                     until archive's own steps finish,                  │
+│                     then read back specs_touched + decisions           │
 │  2 Validate         Confirm archive records are             Checked    │
 │                     structurally complete                  records     │
 │  3 Link             Combine new co-touch pairs across         New      │
@@ -61,7 +61,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 │  7 Report           Summarize what changed                 Summary     │
 └────────────────────────────────────────────────────────────────────────┘
 
-Critical: for openspec-bulk-archive, validation through reporting run exactly ONCE, after every
+Critical: for openspec-bulk-archive-change, validation through reporting run exactly ONCE, after every
 merge in the batch has resolved — never once per intermediate merge. Running
 early would compute pairs against a specs_touched set that hasn't finished
 accumulating cross-change conflicts, and would patch INDEX.md against a
@@ -74,9 +74,9 @@ out of the parent's context on every run, the same pattern
 accelint-qrspi-propose and accelint-qrspi-apply use.
 
 Archive and extraction is the mirror image: it never delegates to a subagent, regardless of
-batch size or whether sub-agent support is even available. openspec-archive and
-openspec-bulk-archive are themselves agent-driven, multi-step skills — not a
-single deterministic CLI call — and a subagent handed instructions to run openspec-archive
+batch size or whether sub-agent support is even available. openspec-archive-change and
+openspec-bulk-archive-change are themselves agent-driven, multi-step skills — not a
+single deterministic CLI call — and a subagent handed instructions to run openspec-archive-change
 has no reliable way to resume that skill's own remaining steps once it
 branches internally into something like a separate sync skill, and no way
 to surface an interactive prompt back to the user if one comes up. Both of
@@ -92,9 +92,9 @@ Execute these steps in order without stopping between them unless an error occur
 
 Goal: confirm the archive operation's inputs are shaped correctly before touching any spec or index file. Task A is a narrow exception: once the author confirms a derived `specs_touched`/`decisions` candidate, it writes that back into `design.md` — that's filling in an input step 7 expects to already be there.
 
-1. Determine scope: a single-change archive (openspec-archive with a change name) or a bulk archive (openspec-bulk-archive) spanning several pending changes.
+1. Determine scope: a single-change archive (openspec-archive-change with a change name) or a bulk archive (openspec-bulk-archive-change) spanning several pending changes.
 
-2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/[slug]/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
+2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/<slug>/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
 
    ```yaml
    ---
@@ -112,13 +112,13 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
    If frontmatter is missing or malformed for a change, this skill still does not silently substitute a guessed value — the change's author has to make that call explicitly, not this skill. But a hard stop with no path forward isn't the only way to get that explicit confirmation, and most of the time the missing field is recoverable from material the change's own author already wrote:
 
-   - **Derive a candidate.** For `specs_touched`, look at the change's `proposal.md` capability declarations and the delta spec directories under `openspec/changes/[slug]/specs/`. For `decisions`, look at any Decisions section in `proposal.md` or decision prose already present in `design.md`.
+   - **Derive a candidate.** For `specs_touched`, look at the change's `proposal.md` capability declarations and the delta spec directories under `openspec/changes/<slug>/specs/`. For `decisions`, look at any Decisions section in `proposal.md` or decision prose already present in `design.md`.
    - **Present it for confirmation — don't write it yet.** Show the derived candidate to the user and ask them to (a) confirm it as written, (b) edit it first, or (c) pause so they can fix `design.md` themselves and re-invoke this skill later. Only once the user picks (a) or (b) does the candidate become the value this skill writes into `design.md`'s frontmatter — at that point it's the same explicit author confirmation the well-formed case gets for free, just captured one step later than at propose time.
    - **Stop outright, with no candidate offered**, only when there's nothing in the change's own files to derive from — e.g. an empty delta specs directory and no capability declarations anywhere in `proposal.md`. In that case, report exactly which change and which field is missing, the same as before.
 
    This is evaluated per change in a bulk-archive batch — one change needing confirmation doesn't block preflight for the others.
 
-3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, check whether `openspec/specs/[capability]/spec.md` contains a heading that describes its purpose:
+3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, check whether `openspec/specs/<capability>/spec.md` contains a heading that describes its purpose:
 
    **Acceptable headings (check in this order, first match wins):**
    - `## Purpose` or `### Purpose`
@@ -134,9 +134,9 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
    Option (c) is usually best when the spec has meaningful content — the agent can synthesize a purpose statement from what's already documented. Option (b) is better for specs that are stubs or need domain expertise to describe accurately. Option (a) is a last resort when you need to unblock immediately but will need to come back and fix it later.
 
-   **Note:** This check applies only to capabilities that already have MAIN specs at `openspec/specs/[capability]/spec.md`. Brand-new capabilities (per step 4) don't have MAIN specs yet, so skip this check for them — they'll get their Purpose heading when their spec is created during archive.
+   **Note:** This check applies only to capabilities that already have MAIN specs at `openspec/specs/<capability>/spec.md`. Brand-new capabilities (per step 4) don't have MAIN specs yet, so skip this check for them — they'll get their Purpose heading when their spec is created during archive.
 
-4. For any capability in `specs_touched` that has no `openspec/specs/[capability]/` directory yet — a brand-new capability introduced by this change — note it separately. Step 19 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and step 20's Purpose column will need the user to supply a value manually since nothing exists yet to read.
+4. For any capability in `specs_touched` that has no `openspec/specs/<capability>/` directory yet — a brand-new capability introduced by this change — note it separately. Step 19 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and step 20's Purpose column will need the user to supply a value manually since nothing exists yet to read.
 
 5. Report the preflight summary before proceeding: changes in scope, capabilities touched, and any Task A or Task B outcomes. If Task A ends in a stop for any change — the user chose to pause and fix `design.md` themselves, or no candidate could be derived at all — do not proceed to step 6 for that change. A Task A candidate the user confirmed counts as passing, the same as frontmatter that was already well-formed. If Task B fails for some capability, that's fine to resolve later — steps 6-17 don't touch spec bodies, so only flag it as blocking once step 18 is about to reach that capability.
 
@@ -146,14 +146,14 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
 This step never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
 
-- **openspec-archive and openspec-bulk-archive are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent given instructions to run openspec-archive has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued the instruction is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
-- **A subagent can't surface an interactive prompt to the user.** openspec-archive and openspec-bulk-archive may raise more than the routine sync y/n — openspec-bulk-archive in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
+- **openspec-archive-change and openspec-bulk-archive-change are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent given instructions to run openspec-archive-change has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued the instruction is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
+- **A subagent can't surface an interactive prompt to the user.** openspec-archive-change and openspec-bulk-archive-change may raise more than the routine sync y/n — openspec-bulk-archive-change in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
 
-This does give something up: openspec-archive's own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the openspec-archive/openspec-bulk-archive skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
+This does give something up: openspec-archive-change's own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec-archive-change`/`openspec bulk-archive` directly instead of the openspec-archive-change/openspec-bulk-archive-change skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
 
-7. Determine scope: a single-change archive (openspec-archive with a change name) or a bulk archive (openspec-bulk-archive) spanning several pending changes.
+7. Determine scope: a single-change archive (openspec-archive-change with a change name) or a bulk archive (openspec-bulk-archive-change) spanning several pending changes.
 
-8. **Known interactive prompt — always sync.** openspec-archive and openspec-bulk-archive will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
+8. **Known interactive prompt — always sync.** openspec-archive-change and openspec-bulk-archive-change will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
 
 9. Run the appropriate skill invocation:
 
@@ -161,41 +161,370 @@ This does give something up: openspec-archive's own internal work — comparing 
    ```text
    Invoke the openspec-archive-change skill.
 
-   [change-name]
+   <change-name>
    ```
 
   For bulk archive:
    ```text
    Invoke the openspec-bulk-archive-change skill.
+   ```
 
-   add-live-sync
+10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
 
-   Sync now? (y/n) → yes
-   ✓ Synced delta specs, resuming openspec-archive's remaining steps...
-   ✓ openspec-archive add-live-sync merged, archived to
-     openspec/changes/archive/2026-03-02-add-live-sync/
-   ✓ Extracted: specs_touched, decisions from design.md frontmatter
+11. **If any other interactive prompt comes up** — most commonly `openspec-bulk-archive-change` asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
 
-   Computing new co-touch pairs...
-   - sync/protocol ↔ ui/status-indicator (new pair)
+12. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
 
-   [spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
-   ✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
-   ✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
+13. If ANY merge reports unresolved conflicts, STOP immediately. Do not attempt to resolve it, and do not proceed to step 14 for ANY change in this batch — a partial extraction is worse than none, since there's no way to tell a stalled batch from a clean one otherwise. Report the conflict verbatim to the user and stop. Do not proceed to validation — parsing anything out of a partially-merged batch would propagate garbage into every capability the batch touches.
 
-   Updating openspec/specs/INDEX.md... (2 rows patched, 12 rows untouched)
-   Appending to openspec/changes/archive/INDEX.md... (1 row)
+14. For each change that archived successfully, read its `design.md` frontmatter from its new archived path (e.g. `openspec/changes/archive/2026-03-02-add-live-sync/design.md`) and build one record:
 
+   ```
+   {
+     change: "add-live-sync",
+     date: "2026-03-02",           // from the archive folder's own
+                                    // YYYY-MM-DD prefix, NEVER from
+                                    // anything inside design.md
+     archivePath: "openspec/changes/archive/2026-03-02-add-live-sync/",
+     specsTouched: ["sync/protocol", "ui/status-indicator"],
+     decisions: [{ id: "D1", choice: "polling with 5s interval", ... }]
+   }
+   ```
+
+15. Keep the list of records from step 14, grouped by change, for validation — plus an explicit note to yourself that no unresolved conflicts remain.
+
+**Output**: one record per archived change (`change`, `date`, `archivePath`, `specsTouched`, `decisions`), held in this context and passed straight to the validation step.
+
+**Validate Extracted Records**
+
+**Goal**: confirm archive records are structurally sound before cross-link computation depends on them — a sanity check on what was extracted, not a re-verification of the source data (preflight Task A already confirmed the source `design.md` frontmatter was well-formed before archive ran).
+
+16. Confirm every record has a non-empty `specsTouched` and at least one `decisions` entry with `choice` populated. If a record is missing either, something went wrong building it during archive (not in the original data, which Task A already validated) — re-run archive for that change rather than proceeding with a partial record.
+
+17. Keep records grouped **by change**, exactly as returned. Cross-link computation computes pairs within a single change's own `specsTouched` — two unrelated changes archived in the same bulk-archive batch don't imply their capabilities co-touch each other, even though they landed at the same moment.
+
+**Output**: the same record set from archive, confirmed structurally complete and ready for cross-link computation and INDEX appending.
+
+**Compute Cross-Links (All-Pairs Union)**
+
+**Goal**: for each change, compute the symmetric co-touch pairs within its own `specs_touched`, and combine those pairs across every change in this archive operation into one set of newly-contributed partners per capability. This step touches zero files — it only combines the `specsTouched` lists already sitting in the validated records. Merging those new partners with whatever `related:` entries a spec already has (never dropping any of them) happens during spec writing, inside the subagent that's already opening that file — there's no reason for the parent to read spec frontmatter just to seed a union that spec writing can do in the same breath as its own file read.
+
+18. For a change with `specs_touched: [A, B, C]`, the contributed pairs are all 2-combinations excluding self: `(A,B)`, `(A,C)`, `(B,C)`. Co-touch has no direction — pairing `(A,B)` means A gains B as a related partner **and** B gains A in the same step.
+
+19. This is a pure computation with no dependency on file I/O, so it's worth writing as a small pure function rather than eyeballing it per capability:
+
+   ```typescript
+   type ChangeLink = {
+     readonly change: string;
+     readonly specsTouched: readonly string[];
+   };
+
+   // All 2-combinations within one change's specs_touched. Pure, no self-pairs,
+   // no directionality — a co-touch relationship reads the same both ways.
+   const pairsFromChange = (
+     link: ChangeLink,
+   ): ReadonlyArray<readonly [string, string]> =>
+     link.specsTouched.flatMap((a, i) =>
+       link.specsTouched.slice(i + 1).map((b) => [a, b] as const),
+     );
+
+   // Fold every change's pairs into one partner-set-per-capability map. This
+   // starts from an empty map every time — it combines pairs ACROSS the
+   // changes in this batch, not against a spec's on-disk related: list. That
+   // merge is deliberately left to spec writing, which is the step that opens the file.
+   const accumulateNewPartners = (
+     pairsByChange: ReadonlyArray<ReadonlyArray<readonly [string, string]>>,
+   ): ReadonlyMap<string, ReadonlySet<string>> => {
+     const next = new Map<string, Set<string>>();
+     for (const pairs of pairsByChange) {
+       for (const [a, b] of pairs) {
+         next.set(a, (next.get(a) ?? new Set()).add(b));
+         next.set(b, (next.get(b) ?? new Set()).add(a));
+       }
+     }
+     return next;
+   };
+   ```
+
+20. Fold every change's pairs into the same accumulating map, starting from empty — a bulk-archive batch of three changes touching overlapping capabilities should have all three changes' pairs combined before spec writing ever touches a file, so each capability's subagent is invoked once with a complete new-partner list rather than three times with partial data.
+
+21. Hand this map to spec writing as-is — unsorted and unmerged with any spec's existing `related:` list. The spec-writing subagent is responsible for both the merge (union with whatever's already in the file) and the final alphabetical sort, since it's the one that actually reads the file this all depends on.
+
+**Output**: a map of `capability -> newly contributed partner names`, not yet merged with any spec's existing `related:` list and not yet sorted — both of those happen during spec writing.
+
+**Write Spec Frontmatter and Body (Subagent, Always)**
+
+**Goal**: merge newly contributed partners into each touched spec's existing `related:` list, persist that plus provenance into frontmatter, and regenerate the `## Related Specs` section to match.
+
+Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once the new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in cross-link computation.
+
+22. For each touched capability, spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from cross-link computation — not a final list; the subagent is the one that merges those against whatever the file already has):
+
+   ```text
+   Update openspec/specs/<capability>/spec.md only. Do not touch any other file.
+
+   Read this file's current related: value from its frontmatter (treat it as
+   empty if the file has no frontmatter yet — this may be a brand-new
+   capability). Union it with these newly contributed partners:
+   [<partner>, <partner>, ...]. Never drop an entry that was already there.
+   Sort the resulting full set alphabetically and write it in flow style on
+   one line — that's what keeps a no-op run byte-identical and a genuine
+   addition a clean one-line diff.
+
+   Also set:
+     last_touched_by: <change-name>
+     last_touched_on: <date>
+   as plain overwrites of whatever was there before, not an accumulated
+   history.
+
+   Do NOT add capability or purpose fields. The capability name is this
+   file's own path; purpose already lives in its ## Purpose or ### Purpose heading.
+
+   Then regenerate the ## Related Specs section in the body from the same
+   final, sorted related: list (replace any existing ## Related Specs
+   content entirely — this section is never hand-maintained).
+
+   For each partner in the sorted related: list, read its spec.md file to
+   extract the purpose heading text. Check for these headings in order:
+   - ## Purpose or ### Purpose
+   - ## Overview or ### Overview
+
+   Use whichever is found first (Overview and Purpose are semantically equivalent).
+   Format each line as:
+
+     - [<partner>](../<partner>/spec.md) - <Purpose or Overview heading text>
+
+   Example format (one entry per line, alphabetically sorted by partner name):
+
+     ## Related Specs
+
+     - [auth-session-store](../auth-session-store/spec.md) - Secure session token storage and retrieval
+     - [sync-protocol](../sync-protocol/spec.md) - Defines the live-sync wire protocol for real-time updates
+
+   The format is: markdown link with partner name as link text, relative
+   path to its spec.md, then space-dash-space (not em-dash), then the
+   first sentence or paragraph from that partner's purpose heading (## Purpose, ### Purpose, ## Overview, or ### Overview).
+
+   If no ## Related Specs heading exists, insert one at the end of the file.
+
+   Report back ONLY: the file path, whether the write was a no-op
+   (byte-identical to what was already there) or an actual change, the
+   final related: list you wrote, and the capability's current purpose
+   heading text (from ## Purpose, ### Purpose, ## Overview, or ### Overview
+   — whichever exists, a sentence or short paragraph — you're not writing
+   this, just reading it back so the parent doesn't have to reopen this
+   file for index updates). Do not return the file's full contents.
+   ```
+
+23. If the capability has no prior `spec.md` (a brand-new capability per preflight step 4), the subagent starts from an empty frontmatter block instead of reading an existing one — same prompt otherwise.
+
+24. Collect each subagent's short report (file, no-op vs. changed, final `related:` list, and Purpose heading text) for index updates and reporting. Index updates reuse the `related:` and Purpose values directly from this report instead of reopening the file; the final report draws only on the no-op/changed status. Nothing else about the write needs to enter the parent's context — a reported no-op is the expected signal that this capability wasn't actually affected by this batch, not something to double-check by re-reading the file.
+
+**Output**: every touched capability's `spec.md` updated in place (existing `related:` entries preserved, new ones unioned in and sorted), or confirmed unchanged, with only a short status line plus its `related:`/Purpose values — the small payload for index updates — entering the parent's context.
+
+**Update openspec/specs/INDEX.md**
+
+**Goal**: keep `openspec/specs/INDEX.md` in sync with what was just written, at the cost of touching only the lines that actually changed — not a re-scan of every capability's `spec.md`, and not even a full read of `specs/INDEX.md` itself. The spec-writing subagents already read each touched capability's current `related:`, `last_touched_by`, and `## Purpose`/`### Purpose` heading as part of doing their own write, and report those values back — index updates reuse that data directly instead of paying for a second full scan of `openspec/specs/`. The only time this step looks at capabilities beyond the ones this batch touched, or reads more than a single targeted line of `specs/INDEX.md`, is when the file doesn't exist yet at all — there's no existing state to patch, and a one-time full build is the right move, not a routine one.
+
+25. **The common case — `specs/INDEX.md` already exists.** Don't read the whole file into context to do this — locate and edit only the lines that actually change:
+
+   - **Existing capability**: grep for the line whose first cell exactly matches the capability name (anchored between the leading `| ` and the next `|`, not a loose substring match — `sync/protocol` must not match `sync/protocol-v2`). Replace that single line with the row built from the spec-writing report for that capability (`Purpose`, `related:`, `last_touched_by`). Nothing else in the file is read or touched.
+   - **Brand-new capability** (per preflight step 4): grep for capability-name cells to find the first existing row that sorts after the new one alphabetically, and insert the new row immediately before it (or append at the end if it sorts last) with no blank line before or after the insertion. All data rows must remain contiguous with no blank lines between them. This still only touches one new line — locating the insertion point doesn't require loading row content, just the capability-name column.
+   - Every row for every untouched capability is never opened, matched, or rewritten — not just "left identical" as an outcome of a full rebuild, but literally never touched by this operation.
+
+26. Build each row without cross-row padding — single-space cell separation (`| sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |`), not aligned to the widest value in each column:
+
+   ```markdown
+   | Capability | Purpose | Related | Last touched by |
+   | --- | --- | --- | --- |
+   | sync/protocol | Defines the live-sync wire proto | ui/status-indicator | add-live-sync |
+   | ui/status-indicator | Renders connection state in UI | sync/protocol | add-live-sync |
+   ```
+
+   Markdown tables render correctly regardless of padding — only the header separator's dash count matters, not whitespace consistency across data rows. Keeping cross-row alignment would mean every row's padding depends on every other row's content length, which forces a full-table rewrite the instant any single row's text changes length — exactly the cost this design exists to avoid. A patched row and its untouched neighbors will look slightly ragged in a raw diff; that's the trade for the diff actually being one line.
+
+27. **The bootstrap case — `specs/INDEX.md` doesn't exist yet.** There's no prior state to patch, and patching only the touched rows would permanently omit every untouched capability until each happens to be touched by some future change. List every directory under `openspec/specs/`, and for each one, read its `## Purpose` or `### Purpose` heading, `related:` frontmatter, and `last_touched_by` directly — a full scan. This runs at most once per project, the first time this skill archives anything against it; every archive after that goes through step 25 instead.
+
+28. **Bootstrap case only**: write `openspec/specs/INDEX.md` from the full scan gathered in step 27, using the row format from step 26, with all data rows contiguous and no blank lines between them. If the file already carries a project-specific title or preamble above the table, preserve it. The common case (step 25) has already written its edit directly — there's no separate write step for it.
+
+**Output**: `openspec/specs/INDEX.md`, with one line changed or inserted per capability this batch touched (with no blank lines added) and every other line untouched, or built once from every capability project-wide if the file didn't exist yet, with all data rows contiguous and no blank lines between them.
+
+A patched `specs/INDEX.md` can still drift from reality for reasons outside this skill's control — a `spec.md` hand-edited outside the archive workflow, a capability directory renamed or deleted directly. This skill doesn't re-derive the whole index every run to catch that. Nothing else currently does either: `accelint-archive-synthesis`'s two checks (decision-drift, structural-coupling) both read `specs/INDEX.md` as ground truth rather than auditing it against the `spec.md` files it summarizes. Catching this kind of drift would mean adding an index-reconciliation check to `accelint-archive-synthesis` — a natural fit for a skill that already exists to do periodic, corpus-wide checks — but that check doesn't exist yet. Until it does, this is an accepted, narrow gap rather than a covered one.
+
+**Append to openspec/changes/archive/INDEX.md**
+
+**Goal**: log one durable row per archived change, inserted at the end of the table's existing data rows — never blindly at the end of the file. Unlike specs INDEX updating, this file is history, and history is append-only — never regenerated, never reordered.
+
+29. For each change from validation, construct one row:
+
+   ```markdown
+   | Change | Date | Decision | Specs touched | Status |
+   | --- | --- | --- | --- | --- |
+   | add-live-sync | 2026-03-02 | polling with 5s interval | sync/protocol, ui/status-indicator | current |
+   ```
+
+   - `Date` is the archive folder's `YYYY-MM-DD` prefix — the same source used in validation, never anything read out of `design.md`.
+   - `Decision` is a one-line summary of `decisions[].choice`. If a change recorded more than one decision, concatenate the choices with semicolons (e.g. `polling with 5s interval; client-side dedup on reconnect`) rather than picking just one — every decision the design phase made deserves to survive into the permanent record, even compressed to a phrase.
+   - `Status` is written as `current` and this skill never touches that column again after this initial write, for this row or any other. Transitions like `current` → `superseded` belong to `accelint-archive-synthesis`, which has the cross-change context needed to know when a decision has actually been superseded — this skill only ever sees one archive operation at a time and can't safely make that call.
+
+30. **Locate the insertion point — the end of the table data rows, with no blank lines between rows.** Find the header row (`| Change | Date | ... |`), its separator (`| --- | --- | ... |`), and the contiguous block of data rows that follows. Insert the new row(s) immediately after the last of those data rows, with no blank line before the new row. All data rows must be contiguous with no blank lines between them — blank lines between entries corrupt the table structure and must never be written. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
+
+31. **Never write metadata or summary content after either INDEX.md table.** Both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a markdown header/preamble before the table (e.g., "# Capability Specifications Index" or "# Archive Index" followed by a brief description), which must be preserved if present. After the preamble comes the table (header row, separator row, and data rows), and the file ends immediately after the last data row. Do not write any of these common but forbidden trailing elements after the table:
+   - "**Total Changes:** N" or similar row counts
+   - "**Generated:** YYYY-MM-DD" or similar timestamps
+   - "**Status Legend:**" or similar explanatory text
+   - Horizontal rules (`---`) after the table
+   - Any other prose, metadata, or summary content
+
+   If such trailing content exists in either file from a prior run, delete it. The canonical INDEX.md format is: optional preamble, then table, then end-of-file. Nothing may appear after the last data row.
+
+32. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row and separator row (and no trailing content) if missing.
+
+33. Do not re-sort, reformat, or otherwise touch any existing row. The append-only discipline here is what makes this file a reliable audit trail; reordering past rows would make it impossible for anyone to use git blame to see when a decision was recorded relative to the others around it.
+
+**Output**: `openspec/changes/archive/INDEX.md`, with one new row per archived change inserted immediately after the last data row with no blank line before it, every prior row untouched, all data rows contiguous with no blank lines between them, and no metadata or summary content after the table — the file ends immediately after the last data row.
+
+**Report**
+
+34. Summarize what changed:
+
+   ```
    ✅ Archive complete: add-live-sync
 
+   Specs updated:
+   - sync/protocol        (+ui/status-indicator)
+   - ui/status-indicator  (+sync/protocol)
+
+   openspec/specs/INDEX.md updated (2 rows patched)
+   openspec/changes/archive/INDEX.md: 1 row appended
+
    Next steps:
-   - Review the diff on the two updated specs before committing
-   - related: entries are additive only — pruning is accelint-archive-synthesis's job
+   - Review the diff on touched specs before committing
+   - related: entries are additive only here — if one looks wrong,
+     pruning is accelint-archive-synthesis's job, not this skill's
    ```
+
+35. If any capability was left with a placeholder purpose or skipped entirely because preflight Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
+
+**Output**: a human-readable summary of every file this skill touched.
+
+## Key Principles
+
+A quick-reference summary — each of these is explained in full where it's actually applied (Implementation Steps) or enforced (NEVER Do This); this is just the index.
+
+- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until `/openspec-bulk-archive-change` resolves conflicts in order; only the merged, archived spec is worth indexing.
+- **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
+- **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
+- **Every write is idempotent.** Flow-style sorted `related:` and row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
+- **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
+- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: `openspec-archive-change`/`/openspec-bulk-archive-change` are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
+
+## Explicitly Out of Scope
+
+- **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/<capability>/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
+- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the `openspec-archive-change`/`openspec-bulk-archive-change` skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
+- **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
+- **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
+- **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
+- **No corpus-wide drift detection in `specs/INDEX.md`.** Index updates only ever patch the rows for capabilities this batch's changes declared in `specs_touched`. If some capability's `spec.md` was edited outside this skill and its `INDEX.md` row has gone stale as a result, this skill's hot path doesn't catch that — and neither, currently, does `accelint-archive-synthesis`: its decision-drift and structural-coupling checks both read `specs/INDEX.md` as ground truth rather than verifying it against `spec.md`. This is a real, accepted gap, not a job this skill should absorb into its own per-archive cost.
+- **No metadata or summary content after either INDEX.md table.** Both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a preamble before the table (preserved if present), then the table (header, separator, and data rows), then end-of-file. No trailing content after the table is permitted. Common forbidden trailing elements include "**Total Changes:**", "**Generated:**", "**Status Legend:**", and horizontal rules. If such content exists from a prior run, it must be deleted — the canonical format is optional-preamble-then-table-then-EOF for both files.
+
+## Error Handling
+
+**Missing or malformed design.md frontmatter (Task A)**: derive a candidate `specs_touched`/`decisions` from the change's own `proposal.md` and delta spec directories, present it to the user for explicit confirmation, and write the confirmed value back into `design.md` before archive runs for that change. Stop before archive for that change, with the field named, only if the user chooses to pause and fix it themselves, or if nothing in the change's own files supports a candidate at all.
+
+**Missing `## Purpose` or `### Purpose` heading (Task B)**: don't block archive, validation, or cross-link computation (they don't touch spec bodies), but stop before spec writing reaches that capability and ask the user to either add a placeholder or fix the spec first.
+
+**A change touches only one capability**: `specs_touched` with a single entry produces zero pairs — that's expected, not an error. Still run spec writing for that capability (write `last_touched_by`/`last_touched_on`, regenerate `## Related Specs` even if its list is unchanged) and still add its row to `changes/archive/INDEX.md` in the changelog step.
+
+**Brand-new capability with no prior spec.md**: handled explicitly in preflight checks (step 4) and spec writing (step 19 substep 2) — the subagent starts from an empty frontmatter block rather than treating the missing file as an error.
+
+**Native command reports unresolved conflicts**: the archive step stops and reports the conflict verbatim to the user immediately without proceeding to extraction (archive step 8); do not proceed to validation.
+
+**`openspec-archive-change` or `openspec-bulk-archive-change` branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
+
+**No subagent support available for spec writing** (e.g. an environment without sub-agent support): fall back to performing spec-writing steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for spec writing only, not the intended default there, and normal operation should always prefer subagents for spec writing. This has no bearing on the archive step, which already runs in this context unconditionally by design regardless of sub-agent availability — see the Archive and Extract section.
+
+**`specs/INDEX.md` or `changes/archive/INDEX.md` doesn't exist yet**: expected on a project's first-ever archive. Create `changes/archive/INDEX.md` fresh with a header row and separator row only — no trailing content of any kind (step 32); `specs/INDEX.md` is built fresh from every capability in the index update bootstrap case (step 27), and patched row-by-row on every archive after that.
+
+**Either INDEX.md file has forbidden content after the table** (a total row count, a `Generated:` date, a status legend, horizontal rules, or similar): delete all such trailing content from both `changes/archive/INDEX.md` and `specs/INDEX.md` — the canonical format for both files is optional-preamble-then-table-then-EOF, ending immediately after the last data row with no blank lines or metadata following it. See steps 30-31.
+
+## NEVER Do This
+
+**NEVER stop between workflow steps and wait for user confirmation unless an error occurs** — this is a continuous workflow from preflight through final report. Once archive completes successfully, immediately proceed to validation, then cross-linking, and so on through the final report. The only legitimate stopping points are: (1) an error that requires user input to resolve, or (2) preflight failing. Do not treat the completion of `openspec-archive-change` as a signal to stop and wait — it's a signal to continue to validation.
+
+**NEVER run validation through reporting once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
+
+**NEVER prune a `related:` entry** — this skill only unions. Removing an entry that looks stale is `accelint-archive-synthesis`'s job, and it requires human confirmation even there.
+
+**NEVER write a derived `specs_touched` or `decisions` candidate into a change's `design.md` without the author's explicit confirmation** — deriving a candidate from `proposal.md` and delta specs (Task A's recovery path) is a convenience for getting unblocked, not a substitute for the author's own call on which capabilities a change actually touched.
+
+**NEVER re-pad or realign existing rows in `specs/INDEX.md` when patching one row** — cell padding is per-row, not aligned to the table's widest value. Touching every row's whitespace to keep columns visually lined up defeats the entire point of a targeted line edit and turns a one-line diff back into a full-file rewrite.
+
+**NEVER change an existing `Status` value in `changes/archive/INDEX.md`** — write `current` once, at creation, and never touch that column again for that row. Transitions belong to `accelint-archive-synthesis`.
+
+**NEVER read `Date` from `design.md`** — always use the archive folder's own `YYYY-MM-DD` prefix. A change can sit in review for weeks before it's archived, so anything `design.md` says about dates will be stale by the time this skill runs.
+
+**NEVER duplicate `capability` or `purpose` into a spec's frontmatter** — both already exist as the file's own path and its `## Purpose` or `### Purpose` heading. Restating either creates a second source of truth that will eventually disagree with the first.
+
+**NEVER hand-maintain `## Related Specs`** — always regenerate it wholesale from the `related:` frontmatter that was just written. Treating it as independently editable content invites drift between what the frontmatter says and what the body shows.
+
+**NEVER reorder or rewrite existing rows in `changes/archive/INDEX.md`** — append only. This file's value as an audit trail depends entirely on past rows staying exactly as they were written.
+
+**NEVER append a new row to either INDEX.md by writing to the end of the file** — locate the end of the table's existing data rows and insert there with no blank line before the new row. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
+
+**NEVER add blank lines between data rows in either INDEX.md file** — all data rows must be contiguous with no blank lines separating them. A blank line between entries corrupts the table structure. This applies to both `changes/archive/INDEX.md` and `specs/INDEX.md`.
+
+**NEVER write metadata or summary content after either INDEX.md table** — both `openspec/changes/archive/INDEX.md` and `openspec/specs/INDEX.md` may have a preamble before the table (preserve if present), then the table (header, separator, and data rows), then end-of-file. Never write "**Total Changes:**", "**Generated:**", "**Status Legend:**", horizontal rules (`---`), or any other trailing content after the table. If such content exists from a prior run, delete it. Each file must end immediately after its last data row.
+
+**NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
+
+**NEVER decline, skip, or second-guess a sync prompt during `openspec-archive-change` or `openspec-bulk-archive-change`** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
+
+**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always invoke `openspec-archive-change` or `openspec-bulk-archive-change` directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
+
+**NEVER run spec writing directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
+
+**NEVER treat a mid-run branch in `openspec-archive-change`/`openspec-bulk-archive-change` (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
+
+## Example Usage
+
+**Scenario 1: Single-change archive**
+
+```
+User: Archive the add-live-sync change with cross-linking
+
+Skill: Running preflight checks...
+✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
+✓ Both capabilities have a ## Purpose/### Purpose heading
+
+Running openspec-archive-change add-live-sync directly (archive never uses a subagent)...
+Sync now? (y/n) → yes
+✓ Synced delta specs, resuming openspec-archive-change's remaining steps...
+✓ openspec-archive-change add-live-sync merged, archived to
+  openspec/changes/archive/2026-03-02-add-live-sync/
+✓ Extracted: specs_touched, decisions from design.md frontmatter
+
+Computing new co-touch pairs...
+- sync/protocol ↔ ui/status-indicator (new pair)
+
+[spawns subagent: sync/protocol]  [spawns subagent: ui/status-indicator]
+✓ sync/protocol/spec.md: related: [ui/status-indicator] (merged, was empty)
+✓ ui/status-indicator/spec.md: related: [sync/protocol] (merged, was empty)
+
+Updating openspec/specs/INDEX.md... (2 rows patched, 12 rows untouched)
+Appending to openspec/changes/archive/INDEX.md... (1 row)
+
+✅ Archive complete: add-live-sync
+
+Next steps:
+- Review the diff on the two updated specs before committing
+- related: entries are additive only — pruning is accelint-archive-synthesis's job
+```
 
 **Scenario 2: Bulk archive touching an already-linked capability**
 
-```text
+```
 User: Run bulk-archive on the pending changes
 
 Skill: Running preflight checks across 3 pending changes...
@@ -214,7 +543,7 @@ then re-invoke this skill to continue.
 
 **Scenario 3: Missing design.md frontmatter, recovered from the change's own files**
 
-```text
+```
 User: Archive the enhance-mock-consistency-rule change
 
 Skill: Running preflight checks...
@@ -238,26 +567,21 @@ Derived from this change's own files:
 User: (a)
 
 Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
-
-Invoke the openspec-archive-change skill.
-
-enhance-mock-consistency-rule
-
-✓ openspec-archive enhance-mock-consistency-rule merged, archived to
+Running openspec-archive-change enhance-mock-consistency-rule directly...
+✓ openspec-archive-change enhance-mock-consistency-rule merged, archived to
   openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
 ...
 ```
 
 **Scenario 4: Bulk archive raises a non-routine prompt (surfaced to the user, not answered by the skill)**
 
-```text
+```
 User: Run bulk-archive on the pending changes
 
 Skill: Running preflight checks across 2 pending changes...
 ✓ All design.md frontmatter valid
 
-Invoke the openspec-bulk-archive-change skill.
-
+Running openspec-bulk-archive-change directly (archive never uses a subagent)...
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,
   merging in chronological order? (y/n)
@@ -272,4 +596,4 @@ Skill: ✓ Archived add-dark-mode, then update-footer, specs/ui/ merged in that 
 ...
 ```
 
-This is the scenario archive running inline actually unlocks: a subagent handed instructions to run openspec-bulk-archive has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.
+This is the scenario archive running inline actually unlocks: a subagent handed `openspec-bulk-archive-change` has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -160,22 +160,22 @@ This does give something up: opsx:archive's own internal work — comparing delt
    For single change:
    ```xml
    <skill_invocation>
-     <skill>opsx:archive</skill>
+     <skill>openspec-archive-change</skill>
      <args>change-name</args>
    </skill_invocation>
    
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
    ```
 
    For bulk archive:
    ```xml
    <skill_invocation>
-     <skill>opsx:bulk-archive</skill>
+     <skill>openspec-bulk-archive-change</skill>
    </skill_invocation>
    
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-bulk-archive-change" — do not attempt to run this as a terminal command.
    ```
 
 10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
@@ -508,12 +508,12 @@ Skill: Running preflight checks...
 ✓ Both capabilities have a ## Purpose/### Purpose heading
 
 <skill_invocation>
-  <skill>opsx:archive</skill>
+  <skill>openspec-archive-change</skill>
   <args>add-live-sync</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
 
 Sync now? (y/n) → yes
 ✓ Synced delta specs, resuming opsx:archive's remaining steps...
@@ -585,12 +585,12 @@ User: (a)
 Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
 
 <skill_invocation>
-  <skill>opsx:archive</skill>
+  <skill>openspec-archive-change</skill>
   <args>enhance-mock-consistency-rule</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
 
 ✓ opsx:archive enhance-mock-consistency-rule merged, archived to
   openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
@@ -606,11 +606,11 @@ Skill: Running preflight checks across 2 pending changes...
 ✓ All design.md frontmatter valid
 
 <skill_invocation>
-  <skill>opsx:bulk-archive</skill>
+  <skill>openspec-bulk-archive-change</skill>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+Execute the internal skill "openspec-bulk-archive-change" — do not attempt to run this as a terminal command.
 
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: accelint-qrspi-archive
-description: Archive an OpenSpec change end-to-end. This skill invokes `/opsx:archive` or `/opsx:bulk-archive` itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run opsx:archive", "run opsx:bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
+description: Archive an OpenSpec change end-to-end. This skill invokes opsx:archive or opsx:bulk-archive itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run opsx:archive", "run opsx:bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
 license: Apache-2.0
 compatibility: Requires the OpenSpec CLI. Per-capability spec writes require sub-agent support — see the skill body for the degraded fallback if unavailable. Native archive always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but preflight Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose or ### Purpose heading in its body.
 metadata:
   author: accelint
-  version: "1.3.1"
+  version: "1.4.0"
 ---
 
 # Accelint QRSPI Archive
 
-Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes `/opsx:archive` or `/opsx:bulk-archive` itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
+Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes opsx:archive or opsx:bulk-archive itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
 
-Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/<slug>/specs/` is still provisional — `/opsx:bulk-archive` may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
+Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/<slug>/specs/` is still provisional — opsx:bulk-archive may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
 
 ## What This Skill Does
 
-**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking `/opsx:archive` or `/opsx:bulk-archive` itself, then immediately following up with cross-capability linking and index maintenance.
+**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking opsx:archive or opsx:bulk-archive itself, then immediately following up with cross-capability linking and index maintenance.
 **Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself during archive and extraction; it does not wait for the merge to have happened some other way first.
 **Output**: the change(s) archived via OpenSpec's own merge, plus updated `related:` frontmatter and a regenerated `## Related Specs` section on every touched spec, an updated `openspec/specs/INDEX.md` (patched for the capabilities this batch touched, or built fresh project-wide the first time the file doesn't exist yet), and one appended row per archived change in `openspec/changes/archive/INDEX.md`.
 **Does NOT**: implement the merge or conflict-resolution logic itself (that's OpenSpec's own, which this skill invokes via the native command rather than reimplementing), prune any `related:` entry, change a change's `Status` column after its initial write, reorder existing changelog rows, or shell out to the OpenSpec CLI to read local spec files (plain file reads are sufficient — see Explicitly Out of Scope).
@@ -38,7 +38,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 ├────────────────────────────────────────────────────────────────────────┤
 │  0 Preflight        Verify frontmatter + Purpose         Go / no-go    │
 │                     headings before touching anything                  │
-│  1 Archive+Extract  Run /opsx:archive or /opsx:bulk-        Change     │
+│  1 Archive+Extract  Run opsx:archive or opsx:bulk-         Change     │
 │                     archive yourself, in this context      records     │
 │                     (never a subagent); stay with any                  │
 │                     internal sync branch until archive's               │
@@ -61,7 +61,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 │  7 Report           Summarize what changed                 Summary     │
 └────────────────────────────────────────────────────────────────────────┘
 
-Critical: for /opsx:bulk-archive, validation through reporting run exactly ONCE, after every
+Critical: for opsx:bulk-archive, validation through reporting run exactly ONCE, after every
 merge in the batch has resolved — never once per intermediate merge. Running
 early would compute pairs against a specs_touched set that hasn't finished
 accumulating cross-change conflicts, and would patch INDEX.md against a
@@ -74,9 +74,9 @@ out of the parent's context on every run, the same pattern
 accelint-qrspi-propose and accelint-qrspi-apply use.
 
 Archive and extraction is the mirror image: it never delegates to a subagent, regardless of
-batch size or whether sub-agent support is even available. /opsx:archive and
-/opsx:bulk-archive are themselves agent-driven, multi-step skills — not a
-single deterministic CLI call — and a subagent handed "run /opsx:archive"
+batch size or whether sub-agent support is even available. opsx:archive and
+opsx:bulk-archive are themselves agent-driven, multi-step skills — not a
+single deterministic CLI call — and a subagent handed instructions to run opsx:archive
 has no reliable way to resume that skill's own remaining steps once it
 branches internally into something like a separate sync skill, and no way
 to surface an interactive prompt back to the user if one comes up. Both of
@@ -92,7 +92,7 @@ Execute these steps in order without stopping between them unless an error occur
 
 Goal: confirm the archive operation's inputs are shaped correctly before touching any spec or index file. Task A is a narrow exception: once the author confirms a derived `specs_touched`/`decisions` candidate, it writes that back into `design.md` — that's filling in an input step 7 expects to already be there.
 
-1. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
+1. Determine scope: a single-change archive (opsx:archive with a change name) or a bulk archive (opsx:bulk-archive) spanning several pending changes.
 
 2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/<slug>/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
 
@@ -146,20 +146,41 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
 This step never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
 
-- **`/opsx:archive` and `/opsx:bulk-archive` are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent hand-fed the instruction "run `/opsx:archive`" has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued "run `/opsx:archive`" is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
-- **A subagent can't surface an interactive prompt to the user.** `/opsx:archive` and `/opsx:bulk-archive` may raise more than the routine sync y/n — `/opsx:bulk-archive` in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
+- **opsx:archive and opsx:bulk-archive are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent given instructions to run opsx:archive has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued the instruction is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
+- **A subagent can't surface an interactive prompt to the user.** opsx:archive and opsx:bulk-archive may raise more than the routine sync y/n — opsx:bulk-archive in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
 
-This does give something up: `/opsx:archive`'s own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the `/opsx:archive`/`/opsx:bulk-archive` skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
+This does give something up: opsx:archive's own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the opsx:archive/opsx:bulk-archive skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
 
-7. Determine scope: a single-change archive (`/opsx:archive <name>`) or a bulk archive (`/opsx:bulk-archive`) spanning several pending changes.
+7. Determine scope: a single-change archive (opsx:archive with a change name) or a bulk archive (opsx:bulk-archive) spanning several pending changes.
 
-8. **Known interactive prompt — always sync.** `/opsx:archive` and `/opsx:bulk-archive` will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
+8. **Known interactive prompt — always sync.** opsx:archive and opsx:bulk-archive will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
 
-9. Run `/opsx:archive <change-name>` (single change) or `/opsx:bulk-archive` (all pending changes) directly, exactly as if the user had typed the slash command themselves.
+9. Run the appropriate skill invocation:
+
+   For single change:
+   ```xml
+   <skill_invocation>
+     <skill>opsx:archive</skill>
+     <args>change-name</args>
+   </skill_invocation>
+   
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+   ```
+
+   For bulk archive:
+   ```xml
+   <skill_invocation>
+     <skill>opsx:bulk-archive</skill>
+   </skill_invocation>
+   
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+   ```
 
 10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
 
-11. **If any other interactive prompt comes up** — most commonly `/opsx:bulk-archive` asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
+11. **If any other interactive prompt comes up** — most commonly opsx:bulk-archive asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
 
 12. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
 
@@ -400,17 +421,17 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
 
 A quick-reference summary — each of these is explained in full where it's actually applied (Implementation Steps) or enforced (NEVER Do This); this is just the index.
 
-- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until `/opsx:bulk-archive` resolves conflicts in order; only the merged, archived spec is worth indexing.
+- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until opsx:bulk-archive resolves conflicts in order; only the merged, archived spec is worth indexing.
 - **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
 - **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
 - **Every write is idempotent.** Flow-style sorted `related:` and row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
 - **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
-- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: `/opsx:archive`/`/opsx:bulk-archive` are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
+- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: opsx:archive/opsx:bulk-archive are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
 
 ## Explicitly Out of Scope
 
 - **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/<capability>/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
-- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the `/opsx:archive`/`/opsx:bulk-archive` skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
+- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the opsx:archive/opsx:bulk-archive skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
 - **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
 - **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
 - **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
@@ -429,7 +450,7 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 **Native command reports unresolved conflicts**: the archive step stops and reports the conflict verbatim to the user immediately without proceeding to extraction (archive step 8); do not proceed to validation.
 
-**`/opsx:archive` or `/opsx:bulk-archive` branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
+**opsx:archive or opsx:bulk-archive branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
 
 **No subagent support available for spec writing** (e.g. an environment without sub-agent support): fall back to performing spec-writing steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for spec writing only, not the intended default there, and normal operation should always prefer subagents for spec writing. This has no bearing on the archive step, which already runs in this context unconditionally by design regardless of sub-agent availability — see the Archive and Extract section.
 
@@ -439,7 +460,7 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 ## NEVER Do This
 
-**NEVER stop between workflow steps and wait for user confirmation unless an error occurs** — this is a continuous workflow from preflight through final report. Once archive completes successfully, immediately proceed to validation, then cross-linking, and so on through the final report. The only legitimate stopping points are: (1) an error that requires user input to resolve, or (2) preflight failing. Do not treat the completion of `/opsx:archive` as a signal to stop and wait — it's a signal to continue to validation.
+**NEVER stop between workflow steps and wait for user confirmation unless an error occurs** — this is a continuous workflow from preflight through final report. Once archive completes successfully, immediately proceed to validation, then cross-linking, and so on through the final report. The only legitimate stopping points are: (1) an error that requires user input to resolve, or (2) preflight failing. Do not treat the completion of the archive skill as a signal to stop and wait — it's a signal to continue to validation.
 
 **NEVER run validation through reporting once per intermediate merge during a bulk-archive** — run them exactly once, after the entire batch resolves. Running early computes pairs against a `specs_touched` set that hasn't finished accumulating conflicts, and patches `INDEX.md` against a half-finished batch's incomplete rows.
 
@@ -467,13 +488,13 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 **NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
 
-**NEVER decline, skip, or second-guess a sync prompt during `/opsx:archive` or `/opsx:bulk-archive`** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
+**NEVER decline, skip, or second-guess a sync prompt during opsx:archive or opsx:bulk-archive** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
 
-**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run `/opsx:archive` or `/opsx:bulk-archive` directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
+**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run opsx:archive or opsx:bulk-archive directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
 
 **NEVER run spec writing directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
 
-**NEVER treat a mid-run branch in `/opsx:archive`/`/opsx:bulk-archive` (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
+**NEVER treat a mid-run branch in opsx:archive/opsx:bulk-archive (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
 
 ## Example Usage
 
@@ -486,10 +507,17 @@ Skill: Running preflight checks...
 ✓ design.md frontmatter valid (specs_touched: sync/protocol, ui/status-indicator)
 ✓ Both capabilities have a ## Purpose/### Purpose heading
 
-Running /opsx:archive add-live-sync directly (archive never uses a subagent)...
+<skill_invocation>
+  <skill>opsx:archive</skill>
+  <args>add-live-sync</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+
 Sync now? (y/n) → yes
-✓ Synced delta specs, resuming /opsx:archive's remaining steps...
-✓ /opsx:archive add-live-sync merged, archived to
+✓ Synced delta specs, resuming opsx:archive's remaining steps...
+✓ opsx:archive add-live-sync merged, archived to
   openspec/changes/archive/2026-03-02-add-live-sync/
 ✓ Extracted: specs_touched, decisions from design.md frontmatter
 
@@ -555,8 +583,16 @@ Derived from this change's own files:
 User: (a)
 
 Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
-Running /opsx:archive enhance-mock-consistency-rule directly...
-✓ /opsx:archive enhance-mock-consistency-rule merged, archived to
+
+<skill_invocation>
+  <skill>opsx:archive</skill>
+  <args>enhance-mock-consistency-rule</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "opsx:archive" — do not attempt to run this as a terminal command.
+
+✓ opsx:archive enhance-mock-consistency-rule merged, archived to
   openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
 ...
 ```
@@ -569,7 +605,13 @@ User: Run bulk-archive on the pending changes
 Skill: Running preflight checks across 2 pending changes...
 ✓ All design.md frontmatter valid
 
-Running /opsx:bulk-archive directly (archive never uses a subagent)...
+<skill_invocation>
+  <skill>opsx:bulk-archive</skill>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "opsx:bulk-archive" — do not attempt to run this as a terminal command.
+
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,
   merging in chronological order? (y/n)
@@ -584,4 +626,4 @@ Skill: ✓ Archived add-dark-mode, then update-footer, specs/ui/ merged in that 
 ...
 ```
 
-This is the scenario archive running inline actually unlocks: a subagent handed `/opsx:bulk-archive` has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.
+This is the scenario archive running inline actually unlocks: a subagent handed instructions to run opsx:bulk-archive has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accelint-qrspi-archive
-description: Archive an OpenSpec change end-to-end. This skill invokes opsx:archive or opsx:bulk-archive itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run opsx:archive", "run opsx:bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
+description: Archive an OpenSpec change end-to-end. This skill invokes openspec-archive or openspec-bulk-archive itself to perform the native merge, then immediately follows up with the cross-capability linking and running indices OpenSpec doesn't build on its own — linking every capability a change touched via a shared `related:` frontmatter list, keeping `openspec/specs/INDEX.md` current, and appending a row to `openspec/changes/archive/INDEX.md`. Use this skill whenever the user wants to archive a change, says "archive this change", "bulk archive these changes", "run openspec-archive", "run openspec-bulk-archive", "update the specs index", "cross-link the specs", or wants the archived-change changelog kept current. This skill is purely additive on the linking side — it never prunes a `related:` entry and never changes a change's `Status` column after the initial write; that pruning/synthesis work belongs to `accelint-archive-synthesis`.
 license: Apache-2.0
 compatibility: Requires the OpenSpec CLI. Per-capability spec writes require sub-agent support — see the skill body for the degraded fallback if unavailable. Native archive always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but preflight Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose or ### Purpose heading in its body.
 metadata:
@@ -10,13 +10,13 @@ metadata:
 
 # Accelint QRSPI Archive
 
-Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes opsx:archive or opsx:bulk-archive itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
+Archive an OpenSpec change and follow it with the cross-capability linking and index bookkeeping OpenSpec doesn't do on its own. This skill invokes openspec-archive or openspec-bulk-archive itself — it's the entry point for archiving a change, not a step that reacts after someone has already archived one — waits for the merge to fully resolve, and then links every pair of capabilities the change touched via a shared `related:` frontmatter list, keeps a single running index of all specs up to date, and appends to an append-only changelog of every archived change.
 
-Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/<slug>/specs/` is still provisional — opsx:bulk-archive may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
+Cross-linking has to happen after the merge resolves, not before it, which is exactly why this skill runs the native command itself as its own first phase rather than treating "a merge happened" as some external event to watch for. A delta spec in `openspec/changes/[slug]/specs/` is still provisional — openspec-bulk-archive may resolve conflicts across several changes in chronological order before a capability's spec reaches its final shape. Only the merged, archived spec is worth indexing; anything computed earlier would be linking against content that might still change underneath it.
 
 ## What This Skill Does
 
-**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking opsx:archive or opsx:bulk-archive itself, then immediately following up with cross-capability linking and index maintenance.
+**Automates**: the full archive operation for one or more OpenSpec changes in a single invocation — invoking openspec-archive or openspec-bulk-archive itself, then immediately following up with cross-capability linking and index maintenance.
 **Scope**: everything from "archive this change" through updated indices. This skill calls the native command itself during archive and extraction; it does not wait for the merge to have happened some other way first.
 **Output**: the change(s) archived via OpenSpec's own merge, plus updated `related:` frontmatter and a regenerated `## Related Specs` section on every touched spec, an updated `openspec/specs/INDEX.md` (patched for the capabilities this batch touched, or built fresh project-wide the first time the file doesn't exist yet), and one appended row per archived change in `openspec/changes/archive/INDEX.md`.
 **Does NOT**: implement the merge or conflict-resolution logic itself (that's OpenSpec's own, which this skill invokes via the native command rather than reimplementing), prune any `related:` entry, change a change's `Status` column after its initial write, reorder existing changelog rows, or shell out to the OpenSpec CLI to read local spec files (plain file reads are sufficient — see Explicitly Out of Scope).
@@ -25,8 +25,8 @@ Cross-linking has to happen after the merge resolves, not before it, which is ex
 
 - OpenSpec CLI installed and initialized, with one or more changes ready to archive.
 - Sub-agent support, for per-capability spec writes only — those always run as subagents, unconditionally, and this is a hard requirement for normal operation there, not an optional speedup for large batches (see Error Handling for the degraded fallback if unavailable). Archive and extraction never uses a subagent, regardless of whether sub-agent support exists — see the Archive and Extract section for why.
-- Each change's `openspec/changes/<slug>/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
-- Every capability named in any `specs_touched` list already has `openspec/specs/<capability>/spec.md` with a `## Purpose` or `### Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in preflight checks, Task B).
+- Each change's `openspec/changes/[slug]/design.md` has YAML frontmatter including `specs_touched` (a non-empty list of capability names) and `decisions` (a list of `{id, choice, rationale, alternatives}` entries).
+- Every capability named in any `specs_touched` list already has `openspec/specs/[capability]/spec.md` with a `## Purpose` or `### Purpose` heading in its body — this skill reads that heading rather than duplicating purpose text into frontmatter, and rewriting the correct behavior depends on that heading actually being there (verified in preflight checks, Task B).
 
 If any of these are missing, report the gap and guide the user to resolve it before proceeding — do not silently substitute a guessed default for a missing field. This applies as-is to spec writing's sub-agent support and a touched spec's missing `## Purpose` or `### Purpose` heading. A change's missing `specs_touched`/`decisions` frontmatter is handled differently: preflight Task A derives a candidate from the change's own files and gets the author's explicit confirmation before writing it, rather than stopping outright — see Task A below for why a hard stop isn't actually necessary here, and why it still isn't a silent guess.
 
@@ -38,7 +38,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 ├────────────────────────────────────────────────────────────────────────┤
 │  0 Preflight        Verify frontmatter + Purpose         Go / no-go    │
 │                     headings before touching anything                  │
-│  1 Archive+Extract  Run opsx:archive or opsx:bulk-         Change     │
+│  1 Archive+Extract  Run openspec-archive or openspec-bulk-  Change     │
 │                     archive yourself, in this context      records     │
 │                     (never a subagent); stay with any                  │
 │                     internal sync branch until archive's               │
@@ -61,7 +61,7 @@ If any of these are missing, report the gap and guide the user to resolve it bef
 │  7 Report           Summarize what changed                 Summary     │
 └────────────────────────────────────────────────────────────────────────┘
 
-Critical: for opsx:bulk-archive, validation through reporting run exactly ONCE, after every
+Critical: for openspec-bulk-archive, validation through reporting run exactly ONCE, after every
 merge in the batch has resolved — never once per intermediate merge. Running
 early would compute pairs against a specs_touched set that hasn't finished
 accumulating cross-change conflicts, and would patch INDEX.md against a
@@ -74,9 +74,9 @@ out of the parent's context on every run, the same pattern
 accelint-qrspi-propose and accelint-qrspi-apply use.
 
 Archive and extraction is the mirror image: it never delegates to a subagent, regardless of
-batch size or whether sub-agent support is even available. opsx:archive and
-opsx:bulk-archive are themselves agent-driven, multi-step skills — not a
-single deterministic CLI call — and a subagent handed instructions to run opsx:archive
+batch size or whether sub-agent support is even available. openspec-archive and
+openspec-bulk-archive are themselves agent-driven, multi-step skills — not a
+single deterministic CLI call — and a subagent handed instructions to run openspec-archive
 has no reliable way to resume that skill's own remaining steps once it
 branches internally into something like a separate sync skill, and no way
 to surface an interactive prompt back to the user if one comes up. Both of
@@ -92,9 +92,9 @@ Execute these steps in order without stopping between them unless an error occur
 
 Goal: confirm the archive operation's inputs are shaped correctly before touching any spec or index file. Task A is a narrow exception: once the author confirms a derived `specs_touched`/`decisions` candidate, it writes that back into `design.md` — that's filling in an input step 7 expects to already be there.
 
-1. Determine scope: a single-change archive (opsx:archive with a change name) or a bulk archive (opsx:bulk-archive) spanning several pending changes.
+1. Determine scope: a single-change archive (openspec-archive with a change name) or a bulk archive (openspec-bulk-archive) spanning several pending changes.
 
-2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/<slug>/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
+2. **Verification Task A — design.md frontmatter.** For every change about to be archived, read `openspec/changes/[slug]/design.md` and confirm its frontmatter contains a non-empty `specs_touched` list and a `decisions` list where each entry has at least `id` and `choice`:
 
    ```yaml
    ---
@@ -112,31 +112,31 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
    If frontmatter is missing or malformed for a change, this skill still does not silently substitute a guessed value — the change's author has to make that call explicitly, not this skill. But a hard stop with no path forward isn't the only way to get that explicit confirmation, and most of the time the missing field is recoverable from material the change's own author already wrote:
 
-   - **Derive a candidate.** For `specs_touched`, look at the change's `proposal.md` capability declarations and the delta spec directories under `openspec/changes/<slug>/specs/`. For `decisions`, look at any Decisions section in `proposal.md` or decision prose already present in `design.md`.
+   - **Derive a candidate.** For `specs_touched`, look at the change's `proposal.md` capability declarations and the delta spec directories under `openspec/changes/[slug]/specs/`. For `decisions`, look at any Decisions section in `proposal.md` or decision prose already present in `design.md`.
    - **Present it for confirmation — don't write it yet.** Show the derived candidate to the user and ask them to (a) confirm it as written, (b) edit it first, or (c) pause so they can fix `design.md` themselves and re-invoke this skill later. Only once the user picks (a) or (b) does the candidate become the value this skill writes into `design.md`'s frontmatter — at that point it's the same explicit author confirmation the well-formed case gets for free, just captured one step later than at propose time.
    - **Stop outright, with no candidate offered**, only when there's nothing in the change's own files to derive from — e.g. an empty delta specs directory and no capability declarations anywhere in `proposal.md`. In that case, report exactly which change and which field is missing, the same as before.
 
    This is evaluated per change in a bulk-archive batch — one change needing confirmation doesn't block preflight for the others.
 
-3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, check whether `openspec/specs/<capability>/spec.md` contains a heading that describes its purpose:
-   
+3. **Verification Task B — Purpose heading convention.** For every capability named across all `specs_touched` lists in this batch, check whether `openspec/specs/[capability]/spec.md` contains a heading that describes its purpose:
+
    **Acceptable headings (check in this order, first match wins):**
    - `## Purpose` or `### Purpose`
    - `## Overview` or `### Overview`
-   
+
    Treat Overview and Purpose as semantically equivalent — both describe what the capability does and why it exists, which is what index updates and spec writing need.
-   
+
    **If none of these headings exist:**
    Ask the user how to handle it:
    - (a) Add a placeholder `## Purpose` heading with text `_Purpose not yet documented_` for now
    - (b) Pause so they can add the heading themselves first
    - (c) Read the spec content and generate a `## Purpose` heading based on what the spec describes
-   
-   Option (c) is usually best when the spec has meaningful content — the agent can synthesize a purpose statement from what's already documented. Option (b) is better for specs that are stubs or need domain expertise to describe accurately. Option (a) is a last resort when you need to unblock immediately but will need to come back and fix it later.
-   
-   **Note:** This check applies only to capabilities that already have MAIN specs at `openspec/specs/<capability>/spec.md`. Brand-new capabilities (per step 4) don't have MAIN specs yet, so skip this check for them — they'll get their Purpose heading when their spec is created during archive.
 
-4. For any capability in `specs_touched` that has no `openspec/specs/<capability>/` directory yet — a brand-new capability introduced by this change — note it separately. Step 19 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and step 20's Purpose column will need the user to supply a value manually since nothing exists yet to read.
+   Option (c) is usually best when the spec has meaningful content — the agent can synthesize a purpose statement from what's already documented. Option (b) is better for specs that are stubs or need domain expertise to describe accurately. Option (a) is a last resort when you need to unblock immediately but will need to come back and fix it later.
+
+   **Note:** This check applies only to capabilities that already have MAIN specs at `openspec/specs/[capability]/spec.md`. Brand-new capabilities (per step 4) don't have MAIN specs yet, so skip this check for them — they'll get their Purpose heading when their spec is created during archive.
+
+4. For any capability in `specs_touched` that has no `openspec/specs/[capability]/` directory yet — a brand-new capability introduced by this change — note it separately. Step 19 will need to create its `spec.md` frontmatter from scratch rather than editing an existing file, and step 20's Purpose column will need the user to supply a value manually since nothing exists yet to read.
 
 5. Report the preflight summary before proceeding: changes in scope, capabilities touched, and any Task A or Task B outcomes. If Task A ends in a stop for any change — the user chose to pause and fix `design.md` themselves, or no candidate could be derived at all — do not proceed to step 6 for that change. A Task A candidate the user confirmed counts as passing, the same as frontmatter that was already well-formed. If Task B fails for some capability, that's fine to resolve later — steps 6-17 don't touch spec bodies, so only flag it as blocking once step 18 is about to reach that capability.
 
@@ -146,14 +146,14 @@ Goal: confirm the archive operation's inputs are shaped correctly before touchin
 
 This step never runs as a subagent, regardless of batch size and regardless of whether sub-agent support is available at all. That's a reversal of this skill's `1.0.0` behavior, made after running into two concrete failure modes in practice:
 
-- **opsx:archive and opsx:bulk-archive are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent given instructions to run opsx:archive has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued the instruction is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
-- **A subagent can't surface an interactive prompt to the user.** opsx:archive and opsx:bulk-archive may raise more than the routine sync y/n — opsx:bulk-archive in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
+- **openspec-archive and openspec-bulk-archive are agent-driven skills, not a single deterministic CLI call.** They read project state, decide what needs syncing, and — when a sync is needed — hand off internally to a separate sync skill before returning to finish the rest of the archive workflow (merging delta specs, moving the change into `openspec/changes/archive/`). A subagent given instructions to run openspec-archive has no reliable way to tell "I finished the sync skill this archive step referred me to" apart from "I finished the thing I was actually asked to do" — there's no caller to check back with mid-task. In practice this showed up exactly that way: the subagent ran the sync step, considered its job done, and returned control without ever reaching the merge. Running archive directly in this context means the same agent that issued the instruction is the one watching it branch into sync, so it can recognize the branch for what it is and carry on to archive's remaining steps once sync finishes — the same continuity a person would have running the command themselves.
+- **A subagent can't surface an interactive prompt to the user.** openspec-archive and openspec-bulk-archive may raise more than the routine sync y/n — openspec-bulk-archive in particular can prompt for confirmation before merging changes that touch overlapping specs (see step 2 below). A subagent that hits a prompt like that is stuck: it can't hand the question to the user and get a real answer, and guessing on the user's behalf is worse than not proceeding. Running archive inline means any such prompt lands in the same conversation the user is already in.
 
-This does give something up: opsx:archive's own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the opsx:archive/opsx:bulk-archive skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
+This does give something up: openspec-archive's own internal work — comparing delta specs against main specs, resolving bulk-archive's cross-change ordering — now happens directly in this context instead of being absorbed by an isolated subagent, so more of it enters context than the `1.0.0` design intended. That's an accepted cost of correctness over context economy, not an oversight; spec writing still isolates its own, typically larger, per-capability file content in a subagent exactly as before, so this cost is confined to the archive step's own scope. Do **not** work around this by shelling out to `openspec archive`/`openspec bulk-archive` directly instead of the openspec-archive/openspec-bulk-archive skill — the skill is where OpenSpec's own delta-spec comparison and edge-case judgment actually live (bulk-archive's conflict resolution isn't reproducible with a bare CLI flag), and bypassing it back to a raw CLI call would throw away the same hybrid-agent judgment this skill exists to keep.
 
-7. Determine scope: a single-change archive (opsx:archive with a change name) or a bulk archive (opsx:bulk-archive) spanning several pending changes.
+7. Determine scope: a single-change archive (openspec-archive with a change name) or a bulk archive (openspec-bulk-archive) spanning several pending changes.
 
-8. **Known interactive prompt — always sync.** opsx:archive and opsx:bulk-archive will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
+8. **Known interactive prompt — always sync.** openspec-archive and openspec-bulk-archive will, more often than not, pause mid-run to ask whether to sync. Always answer yes, every time it comes up — this is a routine part of the archive operation completing, not a decision point that needs the user's input. This is the one interactive prompt you always answer yourself.
 
 9. Run the appropriate skill invocation:
 
@@ -161,11 +161,11 @@ This does give something up: opsx:archive's own internal work — comparing delt
    ```xml
    <skill_invocation>
      <skill>openspec-archive-change</skill>
-     <args>change-name</args>
+     <args>[change-name]</args>
    </skill_invocation>
-   
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
+
+   IMPORTANT: Use the Skill tool to invoke this skill directly.
+   Pass the skill name ("openspec-archive-change") and any args.
    ```
 
    For bulk archive:
@@ -173,14 +173,14 @@ This does give something up: opsx:archive's own internal work — comparing delt
    <skill_invocation>
      <skill>openspec-bulk-archive-change</skill>
    </skill_invocation>
-   
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-bulk-archive-change" — do not attempt to run this as a terminal command.
+
+   IMPORTANT: Use the Skill tool to invoke this skill directly.
+   Pass the skill name ("openspec-bulk-archive-change").
    ```
 
 10. **If the run branches internally** — most commonly by handing off to a separate sync skill partway through — that's normal, expected shape for this command, not a sign that anything has gone wrong or that the task is finished. Stay with it: once the branch completes, pick back up with archive's own remaining steps (merging delta specs into the main specs, moving the change into `openspec/changes/archive/`) rather than treating the branch's completion as the end of this section.
 
-11. **If any other interactive prompt comes up** — most commonly opsx:bulk-archive asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
+11. **If any other interactive prompt comes up** — most commonly openspec-bulk-archive asking for confirmation before merging changes that touch overlapping specs — that's a real question only the user can answer, unlike the routine sync prompt in step 8. Surface it to the user directly and wait for their answer before continuing.
 
 12. Wait until every merge in this operation has fully resolved. For a bulk archive, this means ALL changes in the batch, not just the first.
 
@@ -267,22 +267,22 @@ This does give something up: opsx:archive's own internal work — comparing delt
 
 Always spawn one subagent per touched capability to do this — every time, not conditionally on how many capabilities are involved. Each capability's edit is fully independent once the new-partner map is fixed (the same independence `accelint-qrspi-apply` relies on to parallelize slices), and doing the read/merge/write inside a subagent keeps that spec's full contents out of the parent's context whether this is a one-capability archive or a forty-capability bulk-archive. Making this a threshold-based judgment call ("parallelize if there are many capabilities, otherwise just edit inline") means the parent's context cost varies run to run for no good reason; delegating unconditionally makes it flat. It also means this subagent, not the parent, is the one place that ever reads a spec's current `related:` value — which is exactly why the merge-with-existing-entries logic belongs here rather than in cross-link computation.
 
-22. For each touched capability, spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from cross-link computation — not a final list; the subagent is the one that merges those against whatever the file already has):
+22. For each touched capability, use the Agent tool to spawn a subagent with this prompt (the parent supplies only the *newly contributed* partner names from cross-link computation — not a final list; the subagent is the one that merges those against whatever the file already has):
 
    ```
-   Update openspec/specs/<capability>/spec.md only. Do not touch any other file.
+   Update openspec/specs/[capability]/spec.md only. Do not touch any other file.
 
    Read this file's current related: value from its frontmatter (treat it as
    empty if the file has no frontmatter yet — this may be a brand-new
    capability). Union it with these newly contributed partners:
-   [<partner>, <partner>, ...]. Never drop an entry that was already there.
+   [[partner], [partner], ...]. Never drop an entry that was already there.
    Sort the resulting full set alphabetically and write it in flow style on
    one line — that's what keeps a no-op run byte-identical and a genuine
    addition a clean one-line diff.
 
    Also set:
-     last_touched_by: <change-name>
-     last_touched_on: <date>
+     last_touched_by: [change-name]
+     last_touched_on: [date]
    as plain overwrites of whatever was there before, not an accumulated
    history.
 
@@ -297,11 +297,11 @@ Always spawn one subagent per touched capability to do this — every time, not 
    extract the purpose heading text. Check for these headings in order:
    - ## Purpose or ### Purpose
    - ## Overview or ### Overview
-   
+
    Use whichever is found first (Overview and Purpose are semantically equivalent).
    Format each line as:
 
-     - [<partner>](../<partner>/spec.md) - <Purpose or Overview heading text>
+     - [[partner]](../[partner]/spec.md) - <Purpose or Overview heading text>
 
    Example format (one entry per line, alphabetically sorted by partner name):
 
@@ -384,7 +384,7 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
    - "**Status Legend:**" or similar explanatory text
    - Horizontal rules (`---`) after the table
    - Any other prose, metadata, or summary content
-   
+
    If such trailing content exists in either file from a prior run, delete it. The canonical INDEX.md format is: optional preamble, then table, then end-of-file. Nothing may appear after the last data row.
 
 32. This is the one file in this skill's output that may not exist yet before the very first archive — create it with a header row and separator row (and no trailing content) if missing.
@@ -421,17 +421,17 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
 
 A quick-reference summary — each of these is explained in full where it's actually applied (Implementation Steps) or enforced (NEVER Do This); this is just the index.
 
-- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until opsx:bulk-archive resolves conflicts in order; only the merged, archived spec is worth indexing.
+- **Cross-linking happens at archive time, not propose time.** A delta spec is provisional until openspec-bulk-archive resolves conflicts in order; only the merged, archived spec is worth indexing.
 - **`specs_touched`/`decisions` frontmatter belongs to propose time, not archive time.** `accelint-qrspi-propose` is where this is supposed to get written, as part of the change's own design work. Task A's derive-and-confirm path exists for changes that didn't go through that flow — a fallback with the author's confirmation still required, not this skill's primary way of getting that data.
 - **This skill only adds.** Pruning a `related:` entry or changing an existing `Status` value is `accelint-archive-synthesis`'s job — both need cross-change judgment and human confirmation this skill doesn't have.
 - **Every write is idempotent.** Flow-style sorted `related:` and row-level patching of `specs/INDEX.md` mean a re-run against unchanged inputs is byte-identical, so retrying after a partial failure never duplicates entries or rows.
 - **`specs/INDEX.md` is patched row-by-row for the capabilities touched this run (built wholesale only on first bootstrap); `changes/archive/INDEX.md` is append-only.** One describes current state, the other describes history — treating either the other way corrupts history or lets the index drift. Verifying `specs/INDEX.md` against every `spec.md` on disk, corpus-wide, isn't something this skill does, and isn't currently something `accelint-archive-synthesis` does either — its existing checks read the index as ground truth rather than auditing it. That's a gap worth closing there someday, not a job for this skill's per-archive hot path.
-- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: opsx:archive/opsx:bulk-archive are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
+- **Spec writing always delegates to subagents, never conditionally; archive and extraction never does, unconditionally.** Unconditional delegation for spec writing keeps the parent's context cost flat regardless of batch size, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` use for every file-touching operation. Archive runs inline for the opposite reason: openspec-archive/openspec-bulk-archive are agent-driven and can branch or prompt mid-run, and only the context the user is actually in can follow that branch through or answer that prompt.
 
 ## Explicitly Out of Scope
 
-- **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/<capability>/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
-- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the opsx:archive/opsx:bulk-archive skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
+- **No OpenSpec CLI dependency for reading local specs.** `openspec/specs/[capability]/spec.md` is a normal file at a known path; plain file reads are sufficient; no need to shell out to the CLI for something this direct.
+- **No shelling out to `openspec archive`/`openspec bulk-archive` as a substitute for the openspec-archive/openspec-bulk-archive skill.** The bare CLI command isn't an equivalent shortcut — the skill is where OpenSpec's own delta-spec comparison and bulk-archive conflict resolution actually happen. Archive always goes through the skill, never the raw CLI, even though running it inline (see the Archive and Extract section) already gives up some of the context-isolation the old subagent design had; trading that isolation for a CLI call that skips real judgment would be a worse trade, not a better one.
 - **No per-edge relationship metadata.** A `related:` entry doesn't carry a reason or a timestamp of its own — that context already lives in the originating change's `design.md` and its row in `changes/archive/INDEX.md`, reachable by grepping if ever needed.
 - **No automatic pruning of `related:`.** Only additive. Removal is `accelint-archive-synthesis`'s job, and only with human confirmation.
 - **No directionality in the relation.** Co-touch is inherently symmetric, so it's always computed as all-pairs, never as a dependency direction — "A depends on B" is a different kind of edge this skill doesn't model at all.
@@ -450,7 +450,7 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 **Native command reports unresolved conflicts**: the archive step stops and reports the conflict verbatim to the user immediately without proceeding to extraction (archive step 8); do not proceed to validation.
 
-**opsx:archive or opsx:bulk-archive branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
+**openspec-archive or openspec-bulk-archive branches internally mid-run** (most commonly into a separate sync skill): this is normal, expected shape for the command, not a failure — see archive section steps 4-5. Stay with it and resume archive's own remaining steps once the branch completes; if the branch (or anything else during the run) raises a prompt beyond the routine sync y/n, surface it to the user and wait for their answer rather than guessing.
 
 **No subagent support available for spec writing** (e.g. an environment without sub-agent support): fall back to performing spec-writing steps directly in this context instead of one subagent per capability. Warn the user explicitly that this run will hold full `spec.md` contents in context as a result — this is a degraded fallback for spec writing only, not the intended default there, and normal operation should always prefer subagents for spec writing. This has no bearing on the archive step, which already runs in this context unconditionally by design regardless of sub-agent availability — see the Archive and Extract section.
 
@@ -488,13 +488,13 @@ A quick-reference summary — each of these is explained in full where it's actu
 
 **NEVER unsort or use block-style YAML for `related:`** — flow style, single line, alphabetically sorted. This is what keeps a no-op run byte-identical and makes a genuine addition show up as a clean, reviewable diff.
 
-**NEVER decline, skip, or second-guess a sync prompt during opsx:archive or opsx:bulk-archive** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
+**NEVER decline, skip, or second-guess a sync prompt during openspec-archive or openspec-bulk-archive** — always answer yes. It comes up more often than not, and it's a routine part of the archive operation completing, not a decision point that needs the parent's or the user's input.
 
-**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run opsx:archive or opsx:bulk-archive directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
+**NEVER spawn a subagent for archive and extraction, even when sub-agent support is available** — always run openspec-archive or openspec-bulk-archive directly in this context. A subagent handed that instruction has no reliable way to resume the command's own remaining steps after it branches internally (e.g. into a separate sync skill), and no way to surface an interactive prompt back to the user — both of which have caused this skill to stop mid-archive in practice. See the Archive and Extract section for the full account.
 
 **NEVER run spec writing directly in this context when subagents are available** — always delegate, regardless of how small the batch is. This isn't about parallelizing large batches; it's about keeping raw `spec.md` contents out of the orchestrating context on every single run, the same discipline `accelint-qrspi-propose` and `accelint-qrspi-apply` apply unconditionally.
 
-**NEVER treat a mid-run branch in opsx:archive/opsx:bulk-archive (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
+**NEVER treat a mid-run branch in openspec-archive/openspec-bulk-archive (most commonly its own sync skill) as the end of the archive step** — resume the command's remaining steps once the branch completes. Concluding the branch itself was the whole task is exactly the failure mode that motivated running archive inline in the first place.
 
 ## Example Usage
 
@@ -512,12 +512,12 @@ Skill: Running preflight checks...
   <args>add-live-sync</args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("openspec-archive-change") and any args.
 
 Sync now? (y/n) → yes
-✓ Synced delta specs, resuming opsx:archive's remaining steps...
-✓ opsx:archive add-live-sync merged, archived to
+✓ Synced delta specs, resuming openspec-archive's remaining steps...
+✓ openspec-archive add-live-sync merged, archived to
   openspec/changes/archive/2026-03-02-add-live-sync/
 ✓ Extracted: specs_touched, decisions from design.md frontmatter
 
@@ -589,10 +589,10 @@ Skill: Confirmed. Writing this into design.md's frontmatter, then proceeding...
   <args>enhance-mock-consistency-rule</args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "openspec-archive-change" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("openspec-archive-change") and any args.
 
-✓ opsx:archive enhance-mock-consistency-rule merged, archived to
+✓ openspec-archive enhance-mock-consistency-rule merged, archived to
   openspec/changes/archive/2026-07-07-enhance-mock-consistency-rule/
 ...
 ```
@@ -609,8 +609,8 @@ Skill: Running preflight checks across 2 pending changes...
   <skill>openspec-bulk-archive-change</skill>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "openspec-bulk-archive-change" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("openspec-bulk-archive-change").
 
 Sync now? (y/n) → yes
 ⚠ add-dark-mode and update-footer both touch specs/ui/ — archive both,
@@ -626,4 +626,4 @@ Skill: ✓ Archived add-dark-mode, then update-footer, specs/ui/ merged in that 
 ...
 ```
 
-This is the scenario archive running inline actually unlocks: a subagent handed instructions to run opsx:bulk-archive has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.
+This is the scenario archive running inline actually unlocks: a subagent handed instructions to run openspec-bulk-archive has no way to relay that ordering question to the user and get a real answer back, so it either stalls or has to guess. Running archive in this context means the question reaches the person who can actually answer it.

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## [1.9.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.8.1] - 2026-08-21

--- a/skills/accelint-qrspi-propose/CHANGELOG.md
+++ b/skills/accelint-qrspi-propose/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.9.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
 ## [1.8.1] - 2026-08-21
 
 ### Fixed

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -15,7 +15,7 @@ Automate the QRSPI + OpenSpec planning workflow. This skill applies the methodol
 
 **Automates**: The planning phase of spec-driven development using QRSPI
 **Scope**: Questions → Research → Design → Structure/Plan (stops before implementation)
-**Output**: A complete OpenSpec change ready for the opsx:apply skill
+**Output**: A complete OpenSpec change ready for the accelint-qrspi-apply skill
 
 **Does NOT**: Implement code, run tests, create PRs, or archive changes
 
@@ -131,11 +131,11 @@ Execute these steps in order without stopping between them:
 
    ```
    <skill_invocation>
-     <skill>opsx:explore</skill>
+     <skill>openspec-explore</skill>
    </skill_invocation>
 
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.
 
    I have this ticket:
 
@@ -155,11 +155,11 @@ Execute these steps in order without stopping between them:
 
    ```
    <skill_invocation>
-     <skill>opsx:explore</skill>
+     <skill>openspec-explore</skill>
    </skill_invocation>
 
    IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.
+   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.
 
    [paste ONLY the research questions from step 12]
 
@@ -207,45 +207,45 @@ Execute these steps in order without stopping between them:
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   CRITICAL: You MUST use opsx commands to create and generate artifacts.
-   DO NOT create files or write artifact content yourself. The opsx commands
+   CRITICAL: You MUST invoke OpenSpec skills to create and generate artifacts.
+   DO NOT create files or write artifact content yourself. The OpenSpec skills
    will handle artifact generation following OpenSpec's configured rules.
 
    Now create the OpenSpec change with proposal and design artifacts:
 
-   1. Run the opsx:new skill to create the change (OpenSpec will prompt for a slug):
+   1. Invoke the openspec-new-change skill to create the change (OpenSpec will prompt for a slug):
       <skill_invocation>
-        <skill>opsx:new</skill>
+        <skill>openspec-new-change</skill>
       </skill_invocation>
 
       IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "opsx:new" — do not attempt to run this as a terminal command.
+      Execute the internal skill "openspec-new-change" — do not attempt to run this as a terminal command.
 
    2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
 
-   3. Run the opsx:continue skill ONCE with the change name to generate proposal.md ONLY:
+   3. Run the openspec-continue-change skill ONCE with the change name to generate proposal.md ONLY:
       <skill_invocation>
-        <skill>opsx:continue</skill>
+        <skill>openspec-continue-change</skill>
         <args><change-name></args>
       </skill_invocation>
 
       IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
 
-   4. Run the opsx:continue skill ONCE with the change name to generate design.md ONLY:
+   4. Run the openspec-continue-change skill ONCE with the change name to generate design.md ONLY:
       <skill_invocation>
-        <skill>opsx:continue</skill>
+        <skill>openspec-continue-change</skill>
         <args><change-name></args>
       </skill_invocation>
 
       IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
 
    5. STOP after design.md - do NOT generate specs or tasks yet
 
-   IMPORTANT: Let opsx:continue generate proposal.md and design.md using the
-   OpenSpec workflow. DO NOT write these files yourself. The opsx:continue
-   command handles artifact generation based on config.yaml rules.
+   IMPORTANT: Let openspec-continue-change generate proposal.md and design.md using the
+   OpenSpec workflow. DO NOT write these files yourself. The openspec-continue-change
+   skill handles artifact generation based on config.yaml rules.
 
    After design.md is generated (and ONLY proposal.md and design.md exist),
    report completion, the CHANGE NAME, and the path to the design file.
@@ -389,7 +389,7 @@ Execute these steps in order without stopping between them:
    f. **Handle missing data gracefully:**
       - If `specs_touched` or a clear decisions list can't be confidently read out of the approved design.md/proposal.md, don't guess at either — tell the user what's missing and ask them to add it to design.md directly. A design doc without a clear decisions trail is worth flagging on its own terms, and `accelint-qrspi-archive` needs this frontmatter later to do its cross-capability linking.
    
-   **Why this matters:** This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content the opsx:continue skill generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
+   **Why this matters:** This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content the openspec-continue-change skill generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
 
 32. REQUIRED: If the user does not explicitly approve (says "looks good", "approve", "continue", etc.), DO NOT move forward. This checkpoint is mandatory. Skipping it bypasses the core value of QRSPI methodology.
 
@@ -428,32 +428,32 @@ Execute these steps in order without stopping between them:
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   CRITICAL: You MUST use opsx:continue commands to generate artifacts.
-   DO NOT generate specs or tasks.md content yourself. The opsx:continue command
+   CRITICAL: You MUST invoke the openspec-continue-change skill to generate artifacts.
+   DO NOT generate specs or tasks.md content yourself. The openspec-continue-change skill
    will handle artifact generation following OpenSpec's configured rules.
 
    Now generate the remaining OpenSpec artifacts:
 
-   1. Run the opsx:continue skill with the change name to generate specs/* (delta specs):
+   1. Run the openspec-continue-change skill with the change name to generate specs/* (delta specs):
       <skill_invocation>
-        <skill>opsx:continue</skill>
+        <skill>openspec-continue-change</skill>
         <args><change-name></args>
       </skill_invocation>
 
       IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
 
-   2. Run the opsx:continue skill with the change name to generate tasks.md:
+   2. Run the openspec-continue-change skill with the change name to generate tasks.md:
       <skill_invocation>
-        <skill>opsx:continue</skill>
+        <skill>openspec-continue-change</skill>
         <args><change-name></args>
       </skill_invocation>
 
       IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
 
-   IMPORTANT: Let opsx:continue generate tasks.md using the OpenSpec workflow.
-   DO NOT write tasks.md yourself. The opsx:continue command handles this.
+   IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
+   DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
 
    After tasks.md is generated, the parent agent will validate vertical slicing
    and add a "## Parallelization Strategy" section if needed.
@@ -512,7 +512,7 @@ Execute these steps in order without stopping between them:
 
 42. If horizontal or mixed slicing is detected, **automatically convert to vertical slices**:
 
-   REQUIRED: The `qrspi-apply` skill requires vertical slicing. If the opsx:continue skill generated horizontal slices, you MUST restructure them before presenting them to the user.
+   REQUIRED: The `qrspi-apply` skill requires vertical slicing. If the openspec-continue-change skill generated horizontal slices, you MUST restructure them before presenting them to the user.
 
    **Conversion process**:
 
@@ -708,9 +708,9 @@ If any of these are missing, guide the user to set them up before running this s
 
 ## NEVER Do This
 
-**NEVER generate artifacts yourself** — Always use the opsx skills (`opsx:new`, `opsx:continue`) to create `proposal.md`, `design.md`, `specs/*`, and `tasks.md`. The opsx workflow handles artifact generation under OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design, spec, and task rules and create inconsistent outputs. The one narrow exception is step 30's `specs_touched`/`decisions` frontmatter block. That block is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content opsx:continue already generated and already approved by the user — not new design content. Even there, only the YAML frontmatter block is written; the `design.md` body is never touched by this step.
+**NEVER generate artifacts yourself** — Always invoke the OpenSpec skills (`openspec-new-change`, `openspec-continue-change`) to create `proposal.md`, `design.md`, `specs/*`, and `tasks.md`. The OpenSpec workflow handles artifact generation under OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design, spec, and task rules and create inconsistent outputs. The one narrow exception is step 30's `specs_touched`/`decisions` frontmatter block. That block is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content openspec-continue-change already generated and already approved by the user — not new design content. Even there, only the YAML frontmatter block is written; the `design.md` body is never touched by this step.
 
-**NEVER generate `tasks.md` from scratch** — Always use the opsx:continue skill to create the initial `tasks.md`. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) by following the validation guidance in step 42. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert it to numbered lists or plain bullets.
+**NEVER generate `tasks.md` from scratch** — Always invoke the openspec-continue-change skill to create the initial `tasks.md`. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If openspec-continue-change generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) by following the validation guidance in step 42. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert it to numbered lists or plain bullets.
 
 **NEVER use numbered lists or plain bullets in `tasks.md`** — All subtasks MUST use markdown checklist format: `- [ ] instruction`. The `qrspi-apply` skill tracks completion by checking and unchecking these boxes. If you see numbered lists (`1. 2. 3.`) or plain bullets (`-` without `[ ]`), convert them to `- [ ] ...` format.
 

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -235,11 +235,11 @@ Execute these steps in order without stopping between them.
 
 21. Wait for the sub-agent to complete
 
-22. Extract the change name/slug from the sub-agent output silently (look for "Change name:" or parse from the file path)
+22. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
 
 23. Store the change name — it will be passed to later steps
 
-24. Verify the design.md file exists at the reported path.
+24. Verify the design.md file exists at the reported path
 
 25. **If `--verbose` flag was set in step 1**: Create a `trace.md` audit trail file in the change folder before proceeding to the checkpoint.
 

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -123,17 +123,17 @@ Execute these steps in order without stopping between them.
 
 7. If validation passes and all workflows are present, continue to step 8
 
----
-**SILENT EXECUTION BLOCK: STEPS 8-24**
+8. **Generate research questions** (Context isolation: the agent sees ONLY the ticket, not prior codebase knowledge or research. This prevents solution-first thinking)
 
-The following steps execute INTERNALLY without user-facing output:
-- Use the Agent tool to spawn sub-agents with prompts containing
+9. Accept the ticket description from the user (passed as the skill argument or prompted if missing)
+
+10. Use the Agent tool to spawn sub-agent with this exact prompt
   ```text
   Invoke the openspec-explore skill.
 
   I have this ticket:
 
-  [paste full ticket description here]
+  <paste full ticket description here>
 
   Generate a list of research questions that will tell us everything we need
   to know before building this. Do not propose any solutions. Questions only.
@@ -141,7 +141,7 @@ The following steps execute INTERNALLY without user-facing output:
 
 11. Wait for the sub-agent (spawned via Agent tool) to complete and return the questions (INTERNAL STEP: Do NOT display the questions to the user)
 
-12. Extract and store the questions silently — they will be passed to the next step. Continue immediately to step 13 without stopping or reporting to the user.
+12. Extract and store the questions — they will be passed to the next step.
 
 13. **Answer research questions** (Context isolation: the agent answering questions should see ONLY the questions, not the original ticket. This is the core QRSPI insight — research is objective and ticket-agnostic)
 
@@ -150,15 +150,15 @@ The following steps execute INTERNALLY without user-facing output:
   ```text
   Invoke the openspec-explore skill.
 
-  [paste ONLY the research questions from step 12]
+  <paste ONLY the research questions from step 12>
 
-  Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/[capability]/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
+  Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
 
   **Use `sem impact` for dependency analysis**
 
   If research questions mention specific code entities (functions, classes, types, constants), check whether the `sem` CLI tool is available by running `which sem`.
 
-  If available, use `sem impact [token]` (baseline format, not JSON) to gather deterministic dependency data:
+  If available, use `sem impact <token>` (baseline format, not JSON) to gather deterministic dependency data:
   - Where the entity is defined (file:line)
   - What it depends on (all dependencies)
   - What depends on it (all call sites and references)
@@ -169,7 +169,7 @@ The following steps execute INTERNALLY without user-facing output:
 
 15. Wait for the sub-agent to complete and return the research document (INTERNAL STEP: Do NOT display the research findings to the user)
 
-16. Store the research answers silently — they will inform the design step. Continue immediately to step 17 without stopping or reporting to the user.
+16. Store the research answers — they will inform the design step.
 
 17. **Generate design scaffolding** (Context isolation: the ticket MUST NOT be in context during artifact generation. Use Agent tool to spawn a sub-agent with only questions + research to prevent "completion bleed".)
 
@@ -185,16 +185,16 @@ The following steps execute INTERNALLY without user-facing output:
   prevents solution bias.
 
   Research Questions and Answers:
-  [paste questions from step 12]
+  <paste questions from step 12>
 
   Research Findings:
-  [paste research doc from step 16]
+  <paste research doc from step 16>
 
   OpenSpec Design Rules (from config.yaml):
-  [paste the rules.design section verbatim]
+  <paste the rules.design section verbatim>
 
   Agent Behavior Context:
-  [paste relevant sections from CLAUDE.md/AGENTS.md]
+  <paste relevant sections from CLAUDE.md/AGENTS.md>
 
   CRITICAL: You MUST invoke OpenSpec skills to create and generate artifacts.
   DO NOT create files or write artifact content yourself. The OpenSpec skills
@@ -202,20 +202,19 @@ The following steps execute INTERNALLY without user-facing output:
 
   Now create the OpenSpec change with proposal and design artifacts:
 
-  1. Invoke the openspec-new-change skill to create the change (OpenSpec will prompt for a slug):
-     Invoke the openspec-new-change skill.
+  1. Invoke the openspec-new-change skill to create the change (OpenSpec will prompt for a slug)
 
   2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
 
   3. Run the openspec-continue-change skill ONCE with the change name to generate proposal.md ONLY:
      Invoke the openspec-continue-change skill.
 
-     [change-name]
+     <change-name>
 
   4. Run the openspec-continue-change skill ONCE with the change name to generate design.md ONLY:
      Invoke the openspec-continue-change skill.
 
-     [change-name]
+     <change-name>
 
   5. STOP after design.md - do NOT generate specs or tasks yet
 
@@ -227,31 +226,31 @@ The following steps execute INTERNALLY without user-facing output:
   report completion, the CHANGE NAME, and the path to the design file.
 
   IMPORTANT: You MUST report the change name explicitly at the end like:
-  "Change name: [slug]"
+  "Change name: <slug>"
 
   CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
   Your job ends here. The parent agent will handle the checkpoint and further steps.
   If you generate specs/* or tasks.md, you will bypass the mandatory design review.
   ```
 
-21. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
+21. Wait for the sub-agent to complete
 
 22. Extract the change name/slug from the sub-agent output silently (look for "Change name:" or parse from the file path)
 
 23. Store the change name — it will be passed to later steps
 
-24. Verify the design.md file exists at the reported path. Continue immediately to step 25 without stopping or reporting to the user.
+24. Verify the design.md file exists at the reported path.
 
 25. **If `--verbose` flag was set in step 1**: Create a `trace.md` audit trail file in the change folder before proceeding to the checkpoint.
 
    **Purpose**: Provides traceability by capturing the initial input, raw questions, and research answers that informed the design artifacts. This closes the loop from "what was entered → what was asked → what was answered".
 
-   **File location**: `openspec/changes/[change-name]/trace.md`
+   **File location**: `openspec/changes/<change-name>/trace.md`
 
    **Requirements**:
 
    - You MUST use the Write tool to create this file
-   - The file MUST be written to `openspec/changes/[change-name]/trace.md` (where `[change-name]` is the slug from step 23)
+   - The file MUST be written to `openspec/changes/<change-name>/trace.md` (where `<change-name>` is the slug from step 23)
    - The content MUST include an ISO 8601 timestamp indicating when the document was generated
    - The content MUST include the original ticket/feature/idea text that the user provided (from step 1, after flag removal)
    - The content MUST include the complete research questions from step 12
@@ -263,7 +262,7 @@ The following steps execute INTERNALLY without user-facing output:
    ```markdown
    # QRSPI Trace Audit Trail
 
-   Generated: <ISO 8601 timestamp>
+   Generated: [paste current ISO 8601 timestamp]
 
    This document captures the complete QRSPI flow: the initial input, the questions generated, and the research answers that informed the design artifacts. It provides an audit trail for understanding the context and decision-making process.
 
@@ -330,7 +329,7 @@ The following steps execute INTERNALLY without user-facing output:
       ```
 
    b. **Extract the data you need to write:**
-      - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/[slug]/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
+      - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
       - **`decisions`**: design.md's own decision content — the choices, rationale, and alternatives the design phase already worked through — restructured into a list of `{id, choice, rationale, alternatives}` entries. This is structuring content that's already there, not writing new design content.
       - **`created_at`**: ISO 8601 timestamp marking when this change was created (now, at the moment the user approves the design). Generate this using the current timestamp in ISO 8601 format (e.g., "2026-08-17T15:23:45.123Z"). This is the first of three timestamps used to measure time spent in the QRSPI flow (created_at → started_at → completed_at).
 
@@ -341,12 +340,12 @@ The following steps execute INTERNALLY without user-facing output:
         ---
         change: <change-name-from-step-23>
         created_at: "2026-08-17T15:23:45.123Z"
-        specs_touched: [capability-a, capability-b]
+        specs_touched: [<capability-a>, <capability-b>]
         decisions:
           - id: D1
             choice: <short decision summary>
             rationale: <why this over the alternatives>
-            alternatives: [[option], [option]]
+            alternatives: [<option>, <option>]
         ---
         ```
 
@@ -369,33 +368,62 @@ The following steps execute INTERNALLY without user-facing output:
 
 32. REQUIRED: If the user does not explicitly approve (says "looks good", "approve", "continue", etc.), DO NOT move forward. This checkpoint is mandatory. Skipping it bypasses the core value of QRSPI methodology.
 
----
-**SILENT EXECUTION BLOCK: STEPS 33-43**
+33. **Generate specs and tasks** (Context isolation: continue to keep the ticket out of context. Spawn a sub-agent with questions + research + approved design.md)
 
-The following steps execute INTERNALLY without user-facing output:
-- Use the Agent tool to spawn sub-agents with prompts containing
-  ```text
-  Invoke the openspec-continue-change skill.
+34. Read the (possibly user-edited) design.md file from step 31
 
-  [change-name]
+35. Read `openspec/config.yaml` to extract the `rules.spec` and `rules.tasks` sections
 
-  2. Run the openspec-continue-change skill with the change name to generate tasks.md:
-     Invoke the openspec-continue-change skill.
+36. Read `CLAUDE.md` or `AGENTS.md` for agent behavior context
 
-     [change-name]
+37. Use the Agent tool to spawn a sub-agent with this exact prompt:
 
-  IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
-  DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
+   ```text
+   You are generating OpenSpec specs and tasks based on QRSPI research and an
+   approved design. You have access to research and design, but NOT the original
+   ticket text.
 
-  After tasks.md is generated, the parent agent will validate vertical slicing
-  and add a "## Parallelization Strategy" section if needed.
+   CHANGE NAME: <change-name-from-step-23>
 
-  After tasks.md is generated, report completion and the path to the tasks file.
-  ```
+   Research Questions and Answers:
+   <paste questions from step 12>
+
+   Research Findings:
+   <paste research doc from step 16>
+
+   Approved Design:
+   <paste design.md content>
+
+   OpenSpec Spec Rules (from config.yaml):
+   <paste the rules.spec section verbatim>
+
+   OpenSpec Tasks Rules (from config.yaml):
+   <paste the rules.tasks section verbatim>
+
+   Agent Behavior Context:
+   <paste relevant sections from CLAUDE.md/AGENTS.md>
+
+   CRITICAL: You MUST use the openspec-continue-change skill to generate artifacts.
+   DO NOT generate specs or tasks.md content yourself. The openspec-continue-change skill
+   will handle artifact generation following OpenSpec's configured rules.
+
+   Now generate the remaining OpenSpec artifacts:
+
+   1. Invoke openspec-continue-change <change-name> to generate specs/* (delta specs)
+   2. Invoke openspec-continue-change <change-name> to generate tasks.md
+
+   IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
+   DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
+
+   After tasks.md is generated, the parent agent will validate vertical slicing
+   and add a "## Parallelization Strategy" section if needed.
+
+   After tasks.md is generated, report completion and the path to the tasks file.
+   ```
 
 38. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
 
-39. Verify specs/* and tasks.md exist at the reported paths silently. Continue immediately to step 40 without stopping or reporting to the user.
+39. Verify specs/* and tasks.md exist at the reported paths
 
 40. Read the generated `tasks.md` file
 
@@ -548,17 +576,17 @@ The following steps execute INTERNALLY without user-facing output:
    Change name: <change-name-from-step-23>
 
    Generated artifacts:
-   - openspec/changes/[change-slug]/proposal.md
-   - openspec/changes/[change-slug]/design.md
-   - openspec/changes/[change-slug]/specs/*
-   - openspec/changes/[change-slug]/tasks.md
+   - openspec/changes/<change-slug>/proposal.md
+   - openspec/changes/<change-slug>/design.md
+   - openspec/changes/<change-slug>/specs/*
+   - openspec/changes/<change-slug>/tasks.md
    [If --verbose was used:]
-   - openspec/changes/[change-slug]/trace.md (audit trail)
+   - openspec/changes/<change-slug>/trace.md (audit trail)
 
    Next steps:
    1. Review the artifacts one more time if needed
    2. Run `/clear` to start fresh context for implementation
-   3. Invoke the accelint-qrspi-apply skill with [change-name] to begin implementation.
+   3. Invoke the accelint-qrspi-apply skill with <change-name> to begin implementation.
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -185,16 +185,16 @@ Execute these steps in order without stopping between them.
   prevents solution bias.
 
   Research Questions and Answers:
-  <paste questions from step 12>
+  <paste the research questions from step 12>
 
   Research Findings:
   <paste research doc from step 16>
 
   OpenSpec Design Rules (from config.yaml):
-  <paste the rules.design section verbatim>
+  <paste the rules.design section verbatim from step 18>
 
   Agent Behavior Context:
-  <paste relevant sections from CLAUDE.md/AGENTS.md>
+  <paste relevant sections from CLAUDE.md/AGENTS.md from step 19>
 
   CRITICAL: You MUST invoke OpenSpec skills to create and generate artifacts.
   DO NOT create files or write artifact content yourself. The OpenSpec skills

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -83,7 +83,7 @@ Execute these steps in order without stopping between them.
 
    **Validation:**
    If the prompt is empty or contains only the skill invocation with no actual content (after removing flags):
-   ```
+   ```text
    I need a ticket or feature description to plan. Please provide:
 
    - A ticket ID and description (e.g., "ATI-123: Add user authentication...")
@@ -104,7 +104,7 @@ Execute these steps in order without stopping between them.
 4. Check if the `workflows:` section contains all three required workflows: `explore`, `new`, and `continue`
 
 5. If any are missing:
-   ```
+   ```text
    This skill requires the expanded OpenSpec workflows (explore, new, continue).
 
    Your current workflows: [list what's enabled]
@@ -127,38 +127,17 @@ Execute these steps in order without stopping between them.
 **SILENT EXECUTION BLOCK: STEPS 8-24**
 
 The following steps execute INTERNALLY without user-facing output:
-- Use the Agent tool to spawn sub-agents with prompts containing `<skill_invocation>` directives
-- The sub-agents will interpret those directives and use the Skill tool internally
-- Store results silently in memory
-- Show only brief one-sentence progress updates ("Generating questions...", "Researching codebase...")
-- Do NOT display questions, research findings, or artifact generation details
+- Use the Agent tool to spawn sub-agents with prompts containing
+  ```text
+  Invoke the openspec-explore skill.
 
-The FIRST user-facing output is at step 27 (design review checkpoint).
----
+  I have this ticket:
 
-8. **Generate research questions** (Context isolation: the agent sees ONLY the ticket, not prior codebase knowledge or research. This prevents solution-first thinking)
+  [paste full ticket description here]
 
-9. Accept the ticket description from the user (passed as the skill argument or prompted if missing)
-
-10. Use the Agent tool to spawn a sub-agent with this exact prompt:
-
-   ```
-   <skill_invocation>
-     <skill>openspec-explore</skill>
-     <args>
-   I have this ticket:
-
-   [paste full ticket description here]
-
-   Generate a list of research questions that will tell us everything we need
-   to know before building this. Do not propose any solutions. Questions only.
-     </args>
-   </skill_invocation>
-
-   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
-   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
-   internally to pass the skill name ("openspec-explore") and any args.
-   ```
+  Generate a list of research questions that will tell us everything we need
+  to know before building this. Do not propose any solutions. Questions only.
+  ```
 
 11. Wait for the sub-agent (spawned via Agent tool) to complete and return the questions (INTERNAL STEP: Do NOT display the questions to the user)
 
@@ -168,32 +147,25 @@ The FIRST user-facing output is at step 27 (design review checkpoint).
 
 14. Use the Agent tool to spawn a NEW sub-agent (fresh context) with this exact prompt:
 
-   ```
-   <skill_invocation>
-     <skill>openspec-explore</skill>
-     <args>
-   [paste ONLY the research questions from step 12]
+  ```text
+  Invoke the openspec-explore skill.
 
-   Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/[capability]/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
+  [paste ONLY the research questions from step 12]
 
-   **Use `sem impact` for dependency analysis**
+  Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/[capability]/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
 
-   If research questions mention specific code entities (functions, classes, types, constants), check whether the `sem` CLI tool is available by running `which sem`.
+  **Use `sem impact` for dependency analysis**
 
-   If available, use `sem impact [token]` (baseline format, not JSON) to gather deterministic dependency data:
-   - Where the entity is defined (file:line)
-   - What it depends on (all dependencies)
-   - What depends on it (all call sites and references)
-   - Transitive impact (how many entities are affected)
+  If research questions mention specific code entities (functions, classes, types, constants), check whether the `sem` CLI tool is available by running `which sem`.
 
-   Include this impact analysis in your research findings. This ensures the design phase has complete dependency information and won't miss references or call sites.
-     </args>
-   </skill_invocation>
+  If available, use `sem impact [token]` (baseline format, not JSON) to gather deterministic dependency data:
+  - Where the entity is defined (file:line)
+  - What it depends on (all dependencies)
+  - What depends on it (all call sites and references)
+  - Transitive impact (how many entities are affected)
 
-   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
-   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
-   internally to pass the skill name ("openspec-explore") and any args.
-   ```
+  Include this impact analysis in your research findings. This ensures the design phase has complete dependency information and won't miss references or call sites.
+  ```
 
 15. Wait for the sub-agent to complete and return the research document (INTERNAL STEP: Do NOT display the research findings to the user)
 
@@ -207,73 +179,60 @@ The FIRST user-facing output is at step 27 (design review checkpoint).
 
 20. Use the Agent tool to spawn a sub-agent with this exact prompt:
 
-   ```
-   You are generating OpenSpec artifacts based on QRSPI research. You have access
-   to the research questions and answers, but NOT the original ticket text. This
-   prevents solution bias.
+  ```text
+  You are generating OpenSpec artifacts based on QRSPI research. You have access
+  to the research questions and answers, but NOT the original ticket text. This
+  prevents solution bias.
 
-   Research Questions and Answers:
-   [paste questions from step 12]
+  Research Questions and Answers:
+  [paste questions from step 12]
 
-   Research Findings:
-   [paste research doc from step 16]
+  Research Findings:
+  [paste research doc from step 16]
 
-   OpenSpec Design Rules (from config.yaml):
-   [paste the rules.design section verbatim]
+  OpenSpec Design Rules (from config.yaml):
+  [paste the rules.design section verbatim]
 
-   Agent Behavior Context:
-   [paste relevant sections from CLAUDE.md/AGENTS.md]
+  Agent Behavior Context:
+  [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   CRITICAL: You MUST invoke OpenSpec skills to create and generate artifacts.
-   DO NOT create files or write artifact content yourself. The OpenSpec skills
-   will handle artifact generation following OpenSpec's configured rules.
+  CRITICAL: You MUST invoke OpenSpec skills to create and generate artifacts.
+  DO NOT create files or write artifact content yourself. The OpenSpec skills
+  will handle artifact generation following OpenSpec's configured rules.
 
-   Now create the OpenSpec change with proposal and design artifacts:
+  Now create the OpenSpec change with proposal and design artifacts:
 
-   1. Invoke the openspec-new-change skill to create the change (OpenSpec will prompt for a slug):
-      <skill_invocation>
-        <skill>openspec-new-change</skill>
-      </skill_invocation>
+  1. Invoke the openspec-new-change skill to create the change (OpenSpec will prompt for a slug):
+     Invoke the openspec-new-change skill.
 
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "openspec-new-change" and any args.
+  2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
 
-   2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
+  3. Run the openspec-continue-change skill ONCE with the change name to generate proposal.md ONLY:
+     Invoke the openspec-continue-change skill.
 
-   3. Run the openspec-continue-change skill ONCE with the change name to generate proposal.md ONLY:
-      <skill_invocation>
-        <skill>openspec-continue-change</skill>
-        <args>[change-name]</args>
-      </skill_invocation>
+     [change-name]
 
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "openspec-continue-change" and any args.
+  4. Run the openspec-continue-change skill ONCE with the change name to generate design.md ONLY:
+     Invoke the openspec-continue-change skill.
 
-   4. Run the openspec-continue-change skill ONCE with the change name to generate design.md ONLY:
-      <skill_invocation>
-        <skill>openspec-continue-change</skill>
-        <args>[change-name]</args>
-      </skill_invocation>
+     [change-name]
 
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "openspec-continue-change" and any args.
+  5. STOP after design.md - do NOT generate specs or tasks yet
 
-   5. STOP after design.md - do NOT generate specs or tasks yet
+  IMPORTANT: Let openspec-continue-change generate proposal.md and design.md using the
+  OpenSpec workflow. DO NOT write these files yourself. The openspec-continue-change
+  skill handles artifact generation based on config.yaml rules.
 
-   IMPORTANT: Let openspec-continue-change generate proposal.md and design.md using the
-   OpenSpec workflow. DO NOT write these files yourself. The openspec-continue-change
-   skill handles artifact generation based on config.yaml rules.
+  After design.md is generated (and ONLY proposal.md and design.md exist),
+  report completion, the CHANGE NAME, and the path to the design file.
 
-   After design.md is generated (and ONLY proposal.md and design.md exist),
-   report completion, the CHANGE NAME, and the path to the design file.
+  IMPORTANT: You MUST report the change name explicitly at the end like:
+  "Change name: [slug]"
 
-   IMPORTANT: You MUST report the change name explicitly at the end like:
-   "Change name: [slug]"
-
-   CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
-   Your job ends here. The parent agent will handle the checkpoint and further steps.
-   If you generate specs/* or tasks.md, you will bypass the mandatory design review.
-   ```
+  CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
+  Your job ends here. The parent agent will handle the checkpoint and further steps.
+  If you generate specs/* or tasks.md, you will bypass the mandatory design review.
+  ```
 
 21. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
 
@@ -335,7 +294,7 @@ The FIRST user-facing output is at step 27 (design review checkpoint).
 
 29. Present it to the user with this framing:
 
-   ```
+   ```text
    Design artifact generated. Please review for:
 
    - Wrong pattern references (did I find the legacy way instead of the current way?)
@@ -414,82 +373,25 @@ The FIRST user-facing output is at step 27 (design review checkpoint).
 **SILENT EXECUTION BLOCK: STEPS 33-43**
 
 The following steps execute INTERNALLY without user-facing output:
-- Use the Agent tool to spawn sub-agents with prompts containing `<skill_invocation>` directives
-- The sub-agents will interpret those directives and use the Skill tool internally
-- Store results silently
-- Show only brief one-sentence progress updates ("Generating specs and tasks...")
-- Do NOT display spec/task generation details
+- Use the Agent tool to spawn sub-agents with prompts containing
+  ```text
+  Invoke the openspec-continue-change skill.
 
-The FIRST user-facing output is at step 44 (tasks review checkpoint).
----
+  [change-name]
 
-33. **Generate specs and tasks** (Context isolation: continue to keep the ticket out of context. Use Agent tool to spawn a sub-agent with questions + research + approved design.md)
+  2. Run the openspec-continue-change skill with the change name to generate tasks.md:
+     Invoke the openspec-continue-change skill.
 
-34. Read the (possibly user-edited) design.md file from step 31
+     [change-name]
 
-35. Read `openspec/config.yaml` to extract the `rules.spec` and `rules.tasks` sections
+  IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
+  DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
 
-36. Read `CLAUDE.md` or `AGENTS.md` for agent behavior context
+  After tasks.md is generated, the parent agent will validate vertical slicing
+  and add a "## Parallelization Strategy" section if needed.
 
-37. Use the Agent tool to spawn a sub-agent with this exact prompt:
-
-   ```
-   You are generating OpenSpec specs and tasks based on QRSPI research and an
-   approved design. You have access to research and design, but NOT the original
-   ticket text.
-
-   CHANGE NAME: <change-name-from-step-23>
-
-   Research Questions and Answers:
-   [paste questions from step 12]
-
-   Research Findings:
-   [paste research doc from step 16]
-
-   Approved Design:
-   [paste design.md content]
-
-   OpenSpec Spec Rules (from config.yaml):
-   [paste the rules.spec section verbatim]
-
-   OpenSpec Tasks Rules (from config.yaml):
-   [paste the rules.tasks section verbatim]
-
-   Agent Behavior Context:
-   [paste relevant sections from CLAUDE.md/AGENTS.md]
-
-   CRITICAL: You MUST invoke the openspec-continue-change skill to generate artifacts.
-   DO NOT generate specs or tasks.md content yourself. The openspec-continue-change skill
-   will handle artifact generation following OpenSpec's configured rules.
-
-   Now generate the remaining OpenSpec artifacts:
-
-   1. Run the openspec-continue-change skill with the change name to generate specs/* (delta specs):
-      <skill_invocation>
-        <skill>openspec-continue-change</skill>
-        <args>[change-name]</args>
-      </skill_invocation>
-
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "openspec-continue-change" and any args.
-
-   2. Run the openspec-continue-change skill with the change name to generate tasks.md:
-      <skill_invocation>
-        <skill>openspec-continue-change</skill>
-        <args>[change-name]</args>
-      </skill_invocation>
-
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "openspec-continue-change" and any args.
-
-   IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
-   DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
-
-   After tasks.md is generated, the parent agent will validate vertical slicing
-   and add a "## Parallelization Strategy" section if needed.
-
-   After tasks.md is generated, report completion and the path to the tasks file.
-   ```
+  After tasks.md is generated, report completion and the path to the tasks file.
+  ```
 
 38. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
 
@@ -618,7 +520,7 @@ The FIRST user-facing output is at step 44 (tasks review checkpoint).
 
 44. ⚠️ **REQUIRED CHECKPOINT: Tasks Review** - Present `tasks.md` to the user for final approval:
 
-   ```
+   ```text
    Specs and tasks generated.
 
    [If auto-converted:]
@@ -640,7 +542,7 @@ The FIRST user-facing output is at step 44 (tasks review checkpoint).
 
 47. **Completion** - After tasks.md is approved, announce completion:
 
-   ```
+   ```text
    ✅ QRSPI planning phase complete.
 
    Change name: <change-name-from-step-23>
@@ -656,14 +558,7 @@ The FIRST user-facing output is at step 44 (tasks review checkpoint).
    Next steps:
    1. Review the artifacts one more time if needed
    2. Run `/clear` to start fresh context for implementation
-   3. Invoke the accelint-qrspi-apply skill to begin implementation:
-      <skill_invocation>
-        <skill>accelint-qrspi-apply</skill>
-        <args>[change-name]</args>
-      </skill_invocation>
-
-      IMPORTANT: Use the Skill tool to invoke this skill directly.
-      Pass the skill name "accelint-qrspi-apply" and any args.
+   3. Invoke the accelint-qrspi-apply skill with [change-name] to begin implementation.
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.
@@ -760,8 +655,9 @@ If any of these are missing, guide the user to set them up before running this s
 
 ## Example Usage
 
-```
+```text
 User: I want to plan this ticket using QRSPI:
 
 ## ATI-12: smart-ls CLI tool
 Create a CLI tool that returns structured directory listings as JSON...
+```

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -71,7 +71,7 @@ Capture frontmatter at step 31 after Checkpoint 1 approval, not before. `design.
 
 ## Implementation Steps
 
-Execute these steps in order without stopping between them:
+Execute these steps in order without stopping between them.
 
 1. **Validate user input and parse flags**: Check if the user provided a ticket, feature request, or idea in their prompt (either as skill arguments or in their message). Also check for the `--verbose` flag.
 
@@ -123,72 +123,89 @@ Execute these steps in order without stopping between them:
 
 7. If validation passes and all workflows are present, continue to step 8
 
+---
+**SILENT EXECUTION BLOCK: STEPS 8-24**
+
+The following steps execute INTERNALLY without user-facing output:
+- Use the Agent tool to spawn sub-agents with prompts containing `<skill_invocation>` directives
+- The sub-agents will interpret those directives and use the Skill tool internally
+- Store results silently in memory
+- Show only brief one-sentence progress updates ("Generating questions...", "Researching codebase...")
+- Do NOT display questions, research findings, or artifact generation details
+
+The FIRST user-facing output is at step 27 (design review checkpoint).
+---
+
 8. **Generate research questions** (Context isolation: the agent sees ONLY the ticket, not prior codebase knowledge or research. This prevents solution-first thinking)
 
 9. Accept the ticket description from the user (passed as the skill argument or prompted if missing)
 
-10. Spawn a sub-agent with this exact prompt:
+10. Use the Agent tool to spawn a sub-agent with this exact prompt:
 
    ```
    <skill_invocation>
      <skill>openspec-explore</skill>
-   </skill_invocation>
-
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.
-
+     <args>
    I have this ticket:
 
    [paste full ticket description here]
 
    Generate a list of research questions that will tell us everything we need
    to know before building this. Do not propose any solutions. Questions only.
+     </args>
+   </skill_invocation>
+
+   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
+   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
+   internally to pass the skill name ("openspec-explore") and any args.
    ```
 
-11. Wait for the sub-agent to complete and return the questions
+11. Wait for the sub-agent (spawned via Agent tool) to complete and return the questions (INTERNAL STEP: Do NOT display the questions to the user)
 
-12. Extract and store the questions — they will be passed to the next step
+12. Extract and store the questions silently — they will be passed to the next step. Continue immediately to step 13 without stopping or reporting to the user.
 
 13. **Answer research questions** (Context isolation: the agent answering questions should see ONLY the questions, not the original ticket. This is the core QRSPI insight — research is objective and ticket-agnostic)
 
-14. Spawn a NEW sub-agent (fresh context) with this exact prompt:
+14. Use the Agent tool to spawn a NEW sub-agent (fresh context) with this exact prompt:
 
    ```
    <skill_invocation>
      <skill>openspec-explore</skill>
-   </skill_invocation>
-
-   IMPORTANT: This is a skill invocation directive, NOT a shell command.
-   Execute the internal skill "openspec-explore" — do not attempt to run this as a terminal command.
-
+     <args>
    [paste ONLY the research questions from step 12]
 
-   Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/<capability>/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
+   Answer each question with facts only. Observe what the codebase does today AND what the current specs of record say (scan openspec/specs/INDEX.md for capabilities whose name or Purpose line plausibly relates to these questions; for any that match, read the full specs/[capability]/spec.md file and include its current requirements and scenarios directly in your findings, not just a reference to the file). Do not suggest changes or implementation approaches.
 
    **Use `sem impact` for dependency analysis**
 
    If research questions mention specific code entities (functions, classes, types, constants), check whether the `sem` CLI tool is available by running `which sem`.
 
-   If available, use `sem impact <token>` (baseline format, not JSON) to gather deterministic dependency data:
+   If available, use `sem impact [token]` (baseline format, not JSON) to gather deterministic dependency data:
    - Where the entity is defined (file:line)
    - What it depends on (all dependencies)
    - What depends on it (all call sites and references)
    - Transitive impact (how many entities are affected)
 
    Include this impact analysis in your research findings. This ensures the design phase has complete dependency information and won't miss references or call sites.
+     </args>
+   </skill_invocation>
+
+   IMPORTANT: Pass this entire block (including the <skill_invocation> XML tags) as literal text
+   in the sub-agent's prompt. The sub-agent will interpret the XML directive and use the Skill tool
+   internally to pass the skill name ("openspec-explore") and any args.
    ```
 
-15. Wait for the sub-agent to complete and return the research document
+15. Wait for the sub-agent to complete and return the research document (INTERNAL STEP: Do NOT display the research findings to the user)
 
-16. Store the research answers — they will inform the design step
+16. Store the research answers silently — they will inform the design step. Continue immediately to step 17 without stopping or reporting to the user.
 
-17. **Generate design scaffolding** (Context isolation: the ticket MUST NOT be in context during artifact generation. Spawn a sub-agent with only questions + research to prevent "completion bleed".)
+17. **Generate design scaffolding** (Context isolation: the ticket MUST NOT be in context during artifact generation. Use Agent tool to spawn a sub-agent with only questions + research to prevent "completion bleed".)
 
 18. Read `openspec/config.yaml` to extract the `rules.design` section
 
 19. Read `CLAUDE.md` or `AGENTS.md` to extract agent behavior context
 
-20. Spawn a sub-agent with this exact prompt:
+20. Use the Agent tool to spawn a sub-agent with this exact prompt:
 
    ```
    You are generating OpenSpec artifacts based on QRSPI research. You have access
@@ -218,28 +235,28 @@ Execute these steps in order without stopping between them:
         <skill>openspec-new-change</skill>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "openspec-new-change" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "openspec-new-change" and any args.
 
    2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
 
    3. Run the openspec-continue-change skill ONCE with the change name to generate proposal.md ONLY:
       <skill_invocation>
         <skill>openspec-continue-change</skill>
-        <args><change-name></args>
+        <args>[change-name]</args>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "openspec-continue-change" and any args.
 
    4. Run the openspec-continue-change skill ONCE with the change name to generate design.md ONLY:
       <skill_invocation>
         <skill>openspec-continue-change</skill>
-        <args><change-name></args>
+        <args>[change-name]</args>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "openspec-continue-change" and any args.
 
    5. STOP after design.md - do NOT generate specs or tasks yet
 
@@ -251,31 +268,31 @@ Execute these steps in order without stopping between them:
    report completion, the CHANGE NAME, and the path to the design file.
 
    IMPORTANT: You MUST report the change name explicitly at the end like:
-   "Change name: <slug>"
+   "Change name: [slug]"
 
    CRITICAL: STOP AFTER GENERATING DESIGN.MD. DO NOT CONTINUE TO SPECS OR TASKS.
    Your job ends here. The parent agent will handle the checkpoint and further steps.
    If you generate specs/* or tasks.md, you will bypass the mandatory design review.
    ```
 
-21. Wait for the sub-agent to complete
+21. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
 
-22. Extract the change name/slug from the sub-agent output (look for "Change name:" or parse from the file path)
+22. Extract the change name/slug from the sub-agent output silently (look for "Change name:" or parse from the file path)
 
 23. Store the change name — it will be passed to later steps
 
-24. Verify the design.md file exists at the reported path
+24. Verify the design.md file exists at the reported path. Continue immediately to step 25 without stopping or reporting to the user.
 
 25. **If `--verbose` flag was set in step 1**: Create a `trace.md` audit trail file in the change folder before proceeding to the checkpoint.
 
    **Purpose**: Provides traceability by capturing the initial input, raw questions, and research answers that informed the design artifacts. This closes the loop from "what was entered → what was asked → what was answered".
 
-   **File location**: `openspec/changes/<change-name>/trace.md`
+   **File location**: `openspec/changes/[change-name]/trace.md`
 
    **Requirements**:
 
    - You MUST use the Write tool to create this file
-   - The file MUST be written to `openspec/changes/<change-name>/trace.md` (where `<change-name>` is the slug from step 23)
+   - The file MUST be written to `openspec/changes/[change-name]/trace.md` (where `[change-name]` is the slug from step 23)
    - The content MUST include an ISO 8601 timestamp indicating when the document was generated
    - The content MUST include the original ticket/feature/idea text that the user provided (from step 1, after flag removal)
    - The content MUST include the complete research questions from step 12
@@ -352,14 +369,14 @@ Execute these steps in order without stopping between them:
       ```bash
       Read openspec/changes/<change-name-from-step-23>/design.md
       ```
-   
+
    b. **Extract the data you need to write:**
-      - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
+      - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/[slug]/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
       - **`decisions`**: design.md's own decision content — the choices, rationale, and alternatives the design phase already worked through — restructured into a list of `{id, choice, rationale, alternatives}` entries. This is structuring content that's already there, not writing new design content.
       - **`created_at`**: ISO 8601 timestamp marking when this change was created (now, at the moment the user approves the design). Generate this using the current timestamp in ISO 8601 format (e.g., "2026-08-17T15:23:45.123Z"). This is the first of three timestamps used to measure time spent in the QRSPI flow (created_at → started_at → completed_at).
 
    c. **Write the frontmatter using the Edit tool:**
-   
+
       - If design.md has NO frontmatter yet, add a complete frontmatter block at the top:
         ```yaml
         ---
@@ -370,30 +387,43 @@ Execute these steps in order without stopping between them:
           - id: D1
             choice: <short decision summary>
             rationale: <why this over the alternatives>
-            alternatives: [<option>, <option>]
+            alternatives: [[option], [option]]
         ---
         ```
-      
+
       - If design.md already has frontmatter (e.g., OpenSpec's own metadata), merge the new fields into the existing block using the Edit tool. Do NOT create a second frontmatter block.
-   
+
    d. **CRITICAL formatting requirements:**
       - **Use inline array syntax for specs_touched**: Write `specs_touched: [cap-a, cap-b]` NOT multi-line YAML with hyphens. This keeps frontmatter format consistent.
       - **Preserve existing frontmatter fields**: If there are other fields already present, keep them unchanged.
       - **Decisions use block syntax**: The `decisions` list uses multi-line YAML with hyphens for each entry (see example above).
-   
+
    e. **Verify the write succeeded:**
       - After using the Edit tool, check that the operation completed without errors
       - If the Edit tool reports an error, try reading the file again and re-attempting the write
       - If the write fails repeatedly, inform the user and ask them to add the frontmatter manually
-   
+
    f. **Handle missing data gracefully:**
       - If `specs_touched` or a clear decisions list can't be confidently read out of the approved design.md/proposal.md, don't guess at either — tell the user what's missing and ask them to add it to design.md directly. A design doc without a clear decisions trail is worth flagging on its own terms, and `accelint-qrspi-archive` needs this frontmatter later to do its cross-capability linking.
-   
+
    **Why this matters:** This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content the openspec-continue-change skill generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
 
 32. REQUIRED: If the user does not explicitly approve (says "looks good", "approve", "continue", etc.), DO NOT move forward. This checkpoint is mandatory. Skipping it bypasses the core value of QRSPI methodology.
 
-33. **Generate specs and tasks** (Context isolation: continue to keep the ticket out of context. Spawn a sub-agent with questions + research + approved design.md)
+---
+**SILENT EXECUTION BLOCK: STEPS 33-43**
+
+The following steps execute INTERNALLY without user-facing output:
+- Use the Agent tool to spawn sub-agents with prompts containing `<skill_invocation>` directives
+- The sub-agents will interpret those directives and use the Skill tool internally
+- Store results silently
+- Show only brief one-sentence progress updates ("Generating specs and tasks...")
+- Do NOT display spec/task generation details
+
+The FIRST user-facing output is at step 44 (tasks review checkpoint).
+---
+
+33. **Generate specs and tasks** (Context isolation: continue to keep the ticket out of context. Use Agent tool to spawn a sub-agent with questions + research + approved design.md)
 
 34. Read the (possibly user-edited) design.md file from step 31
 
@@ -401,7 +431,7 @@ Execute these steps in order without stopping between them:
 
 36. Read `CLAUDE.md` or `AGENTS.md` for agent behavior context
 
-37. Spawn a sub-agent with this exact prompt:
+37. Use the Agent tool to spawn a sub-agent with this exact prompt:
 
    ```
    You are generating OpenSpec specs and tasks based on QRSPI research and an
@@ -437,20 +467,20 @@ Execute these steps in order without stopping between them:
    1. Run the openspec-continue-change skill with the change name to generate specs/* (delta specs):
       <skill_invocation>
         <skill>openspec-continue-change</skill>
-        <args><change-name></args>
+        <args>[change-name]</args>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "openspec-continue-change" and any args.
 
    2. Run the openspec-continue-change skill with the change name to generate tasks.md:
       <skill_invocation>
         <skill>openspec-continue-change</skill>
-        <args><change-name></args>
+        <args>[change-name]</args>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "openspec-continue-change" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "openspec-continue-change" and any args.
 
    IMPORTANT: Let openspec-continue-change generate tasks.md using the OpenSpec workflow.
    DO NOT write tasks.md yourself. The openspec-continue-change skill handles this.
@@ -461,9 +491,9 @@ Execute these steps in order without stopping between them:
    After tasks.md is generated, report completion and the path to the tasks file.
    ```
 
-38. Wait for the sub-agent to complete
+38. Wait for the sub-agent to complete (INTERNAL STEP: Do NOT display artifact generation details to the user)
 
-39. Verify specs/* and tasks.md exist at the reported paths
+39. Verify specs/* and tasks.md exist at the reported paths silently. Continue immediately to step 40 without stopping or reporting to the user.
 
 40. Read the generated `tasks.md` file
 
@@ -616,12 +646,12 @@ Execute these steps in order without stopping between them:
    Change name: <change-name-from-step-23>
 
    Generated artifacts:
-   - openspec/changes/<change-slug>/proposal.md
-   - openspec/changes/<change-slug>/design.md
-   - openspec/changes/<change-slug>/specs/*
-   - openspec/changes/<change-slug>/tasks.md
+   - openspec/changes/[change-slug]/proposal.md
+   - openspec/changes/[change-slug]/design.md
+   - openspec/changes/[change-slug]/specs/*
+   - openspec/changes/[change-slug]/tasks.md
    [If --verbose was used:]
-   - openspec/changes/<change-slug>/trace.md (audit trail)
+   - openspec/changes/[change-slug]/trace.md (audit trail)
 
    Next steps:
    1. Review the artifacts one more time if needed
@@ -629,11 +659,11 @@ Execute these steps in order without stopping between them:
    3. Invoke the accelint-qrspi-apply skill to begin implementation:
       <skill_invocation>
         <skill>accelint-qrspi-apply</skill>
-        <args><change-name></args>
+        <args>[change-name]</args>
       </skill_invocation>
 
-      IMPORTANT: This is a skill invocation directive, NOT a shell command.
-      Execute the internal skill "accelint-qrspi-apply" — do not attempt to run this as a terminal command.
+      IMPORTANT: Use the Skill tool to invoke this skill directly.
+      Pass the skill name "accelint-qrspi-apply" and any args.
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -262,7 +262,7 @@ Execute these steps in order without stopping between them.
    ```markdown
    # QRSPI Trace Audit Trail
 
-   Generated: [paste current ISO 8601 timestamp]
+   Generated: [paste current ISO 8601 timestamp with Z suffix, generated using: python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z'))"]
 
    This document captures the complete QRSPI flow: the initial input, the questions generated, and the research answers that informed the design artifacts. It provides an audit trail for understanding the context and decision-making process.
 
@@ -331,7 +331,11 @@ Execute these steps in order without stopping between them.
    b. **Extract the data you need to write:**
       - **`specs_touched`**: the capability names design.md and proposal.md already declare as affected or introduced by this change. This is the change's own stated scope, read back out of what was just approved — not computed some other way. The delta spec files under `openspec/changes/<slug>/specs/` don't exist yet at this point (specs/tasks generation happens in steps 32-42), so there's nothing else to derive it from.
       - **`decisions`**: design.md's own decision content — the choices, rationale, and alternatives the design phase already worked through — restructured into a list of `{id, choice, rationale, alternatives}` entries. This is structuring content that's already there, not writing new design content.
-      - **`created_at`**: ISO 8601 timestamp marking when this change was created (now, at the moment the user approves the design). Generate this using the current timestamp in ISO 8601 format (e.g., "2026-08-17T15:23:45.123Z"). This is the first of three timestamps used to measure time spent in the QRSPI flow (created_at → started_at → completed_at).
+      - **`created_at`**: ISO 8601 timestamp with Z suffix marking when this change was created (now, at the moment the user approves the design). Generate this deterministically using:
+        ```bash
+        python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z'))"
+        ```
+        This is the first of three timestamps used to measure time spent in the QRSPI flow (created_at → started_at → completed_at).
 
    c. **Write the frontmatter using the Edit tool:**
 
@@ -470,6 +474,51 @@ Execute these steps in order without stopping between them.
    - Size: Prefer 3-5 major slices; more than 5 suggests scope is too large
    - Duration: Max 2 hours per subtask; break larger work into smaller subtasks
 
+   **CRITICAL: Testing Throughout (not just at the end)**:
+
+   EVERY vertical slice must include testing steps. If testing only appears in the
+   final slice, the structure is actually horizontal slices masquerading as vertical.
+
+   ✓ CORRECT - Testing in every slice:
+   ```
+   Slice 1: Mock API + working frontend
+   - [ ] Build mock API endpoint
+   - [ ] Create frontend component
+   - [ ] Test: Verify UI renders and responds to mock data
+
+   Slice 2: Wire real service layer
+   - [ ] Add service layer implementation
+   - [ ] Connect frontend to service
+   - [ ] Test: Verify real data flows from service to UI
+
+   Slice 3: Add database integration
+   - [ ] Add database queries
+   - [ ] Update service to use database
+   - [ ] Test: Verify data persists and loads correctly
+   ```
+
+   ✗ WRONG - All testing deferred to the end:
+   ```
+   Slice 1: Mock API + working frontend
+   - [ ] Build mock API endpoint
+   - [ ] Create frontend component
+
+   Slice 2: Wire real service layer
+   - [ ] Add service layer implementation
+   - [ ] Connect frontend to service
+
+   Slice 3: Add database integration
+   - [ ] Add database queries
+   - [ ] Update service to use database
+   - [ ] Test everything end-to-end  ← RED FLAG: Only testing appears here
+   ```
+
+   **When validating tasks.md**, check that:
+   - EACH slice has explicit test steps within that slice
+   - Test steps verify the slice's specific deliverable (not just "run tests")
+   - No slice consists purely of building without testing
+   - The final slice is NOT just "test everything" — that's a sign of horizontal work
+
 42. If horizontal or mixed slicing is detected, **automatically convert to vertical slices**:
 
    REQUIRED: The `qrspi-apply` skill requires vertical slicing. If the openspec-continue-change skill generated horizontal slices, you MUST restructure them before presenting them to the user.
@@ -491,19 +540,26 @@ Execute these steps in order without stopping between them.
       Do NOT use numbered lists (1. 2. 3.) or plain bullets (- without [ ]).
       The qrspi-apply skill depends on this format to track task completion.
 
-   c) **Preserve parallelization opportunities**: Structure slices to be independent
+   c) **Ensure EVERY slice includes testing steps**: Check that each slice has explicit
+      test subtasks within that slice, not just at the end. If testing only appears
+      in the final slice, add test steps to each earlier slice:
+      - Each slice should have one or more `- [ ] Test: <what to verify>` subtasks
+      - Test steps should verify the slice's specific deliverable
+      - Don't create a final "test everything" slice — testing belongs throughout
+
+   d) **Preserve parallelization opportunities**: Structure slices to be independent
       - Good: "Slice 1: auth flow" and "Slice 2: data export flow" are independent
       - Bad: "Slice 1: database schema" must complete before "Slice 2: service layer"
 
-   d) **Update Parallelization Strategy (if it exists)**: If the tasks.md already has
+   e) **Update Parallelization Strategy (if it exists)**: If the tasks.md already has
       a "## Parallelization Strategy" section, revise it to reflect the new slice
       structure (which slices can run in parallel, which have dependencies).
       Note: If the section doesn't exist, it will be added in step 43.
 
-   e) **Write changes to tasks.md**: Edit the file in place using the Edit tool
+   f) **Write changes to tasks.md**: Edit the file in place using the Edit tool
 
-   f) **Show diff to user**: Display what changed and explain why (e.g., "Converted
-      from layer-based to feature-based slices for better parallelization")
+   g) **Show diff to user**: Display what changed and explain why (e.g., "Converted
+      from layer-based to feature-based slices and added testing steps to each slice")
 
 43. **REQUIRED: Check for and add Parallelization Strategy section**:
 

--- a/skills/accelint-qrspi-propose/SKILL.md
+++ b/skills/accelint-qrspi-propose/SKILL.md
@@ -4,7 +4,7 @@ description: Use this skill when the user wants to start the formal QRSPI/OpenSp
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.8.1"
+  version: "1.9.0"
 ---
 
 # Accelint QRSPI
@@ -15,7 +15,7 @@ Automate the QRSPI + OpenSpec planning workflow. This skill applies the methodol
 
 **Automates**: The planning phase of spec-driven development using QRSPI
 **Scope**: Questions → Research → Design → Structure/Plan (stops before implementation)
-**Output**: A complete OpenSpec change ready for `/opsx:apply`
+**Output**: A complete OpenSpec change ready for the opsx:apply skill
 
 **Does NOT**: Implement code, run tests, create PRs, or archive changes
 
@@ -130,7 +130,12 @@ Execute these steps in order without stopping between them:
 10. Spawn a sub-agent with this exact prompt:
 
    ```
-   /opsx:explore
+   <skill_invocation>
+     <skill>opsx:explore</skill>
+   </skill_invocation>
+
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.
 
    I have this ticket:
 
@@ -149,7 +154,12 @@ Execute these steps in order without stopping between them:
 14. Spawn a NEW sub-agent (fresh context) with this exact prompt:
 
    ```
-   /opsx:explore
+   <skill_invocation>
+     <skill>opsx:explore</skill>
+   </skill_invocation>
+
+   IMPORTANT: This is a skill invocation directive, NOT a shell command.
+   Execute the internal skill "opsx:explore" — do not attempt to run this as a terminal command.
 
    [paste ONLY the research questions from step 12]
 
@@ -197,20 +207,44 @@ Execute these steps in order without stopping between them:
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   CRITICAL: You MUST use /opsx commands to create and generate artifacts.
-   DO NOT create files or write artifact content yourself. The /opsx commands
+   CRITICAL: You MUST use opsx commands to create and generate artifacts.
+   DO NOT create files or write artifact content yourself. The opsx commands
    will handle artifact generation following OpenSpec's configured rules.
 
    Now create the OpenSpec change with proposal and design artifacts:
 
-   1. Run /opsx:new to create the change (OpenSpec will prompt for a slug)
+   1. Run the opsx:new skill to create the change (OpenSpec will prompt for a slug):
+      <skill_invocation>
+        <skill>opsx:new</skill>
+      </skill_invocation>
+
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "opsx:new" — do not attempt to run this as a terminal command.
+
    2. CRITICAL: Capture the change name/slug from the output and use it in all subsequent commands
-   3. Run /opsx:continue <change-name> ONCE to generate proposal.md ONLY
-   4. Run /opsx:continue <change-name> ONCE to generate design.md ONLY
+
+   3. Run the opsx:continue skill ONCE with the change name to generate proposal.md ONLY:
+      <skill_invocation>
+        <skill>opsx:continue</skill>
+        <args><change-name></args>
+      </skill_invocation>
+
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+
+   4. Run the opsx:continue skill ONCE with the change name to generate design.md ONLY:
+      <skill_invocation>
+        <skill>opsx:continue</skill>
+        <args><change-name></args>
+      </skill_invocation>
+
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+
    5. STOP after design.md - do NOT generate specs or tasks yet
 
-   IMPORTANT: Let /opsx:continue generate proposal.md and design.md using the
-   OpenSpec workflow. DO NOT write these files yourself. The /opsx:continue
+   IMPORTANT: Let opsx:continue generate proposal.md and design.md using the
+   OpenSpec workflow. DO NOT write these files yourself. The opsx:continue
    command handles artifact generation based on config.yaml rules.
 
    After design.md is generated (and ONLY proposal.md and design.md exist),
@@ -355,7 +389,7 @@ Execute these steps in order without stopping between them:
    f. **Handle missing data gracefully:**
       - If `specs_touched` or a clear decisions list can't be confidently read out of the approved design.md/proposal.md, don't guess at either — tell the user what's missing and ask them to add it to design.md directly. A design doc without a clear decisions trail is worth flagging on its own terms, and `accelint-qrspi-archive` needs this frontmatter later to do its cross-capability linking.
    
-   **Why this matters:** This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content `/opsx:continue` generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
+   **Why this matters:** This frontmatter is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, not part of the design content the opsx:continue skill generates — writing it here doesn't fall under the "never generate artifacts yourself" rule (see NEVER Do This). Nothing in proposal.md's or design.md's actual content gets created or altered by this step; only the frontmatter block does.
 
 32. REQUIRED: If the user does not explicitly approve (says "looks good", "approve", "continue", etc.), DO NOT move forward. This checkpoint is mandatory. Skipping it bypasses the core value of QRSPI methodology.
 
@@ -394,17 +428,32 @@ Execute these steps in order without stopping between them:
    Agent Behavior Context:
    [paste relevant sections from CLAUDE.md/AGENTS.md]
 
-   CRITICAL: You MUST use /opsx:continue commands to generate artifacts.
-   DO NOT generate specs or tasks.md content yourself. The /opsx:continue command
+   CRITICAL: You MUST use opsx:continue commands to generate artifacts.
+   DO NOT generate specs or tasks.md content yourself. The opsx:continue command
    will handle artifact generation following OpenSpec's configured rules.
 
    Now generate the remaining OpenSpec artifacts:
 
-   1. Run /opsx:continue <change-name> to generate specs/* (delta specs)
-   2. Run /opsx:continue <change-name> to generate tasks.md
+   1. Run the opsx:continue skill with the change name to generate specs/* (delta specs):
+      <skill_invocation>
+        <skill>opsx:continue</skill>
+        <args><change-name></args>
+      </skill_invocation>
 
-   IMPORTANT: Let /opsx:continue generate tasks.md using the OpenSpec workflow.
-   DO NOT write tasks.md yourself. The /opsx:continue command handles this.
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+
+   2. Run the opsx:continue skill with the change name to generate tasks.md:
+      <skill_invocation>
+        <skill>opsx:continue</skill>
+        <args><change-name></args>
+      </skill_invocation>
+
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "opsx:continue" — do not attempt to run this as a terminal command.
+
+   IMPORTANT: Let opsx:continue generate tasks.md using the OpenSpec workflow.
+   DO NOT write tasks.md yourself. The opsx:continue command handles this.
 
    After tasks.md is generated, the parent agent will validate vertical slicing
    and add a "## Parallelization Strategy" section if needed.
@@ -463,7 +512,7 @@ Execute these steps in order without stopping between them:
 
 42. If horizontal or mixed slicing is detected, **automatically convert to vertical slices**:
 
-   REQUIRED: The `qrspi-apply` skill requires vertical slicing. If `/opsx:continue` generated horizontal slices, you MUST restructure them before presenting them to the user.
+   REQUIRED: The `qrspi-apply` skill requires vertical slicing. If the opsx:continue skill generated horizontal slices, you MUST restructure them before presenting them to the user.
 
    **Conversion process**:
 
@@ -577,13 +626,20 @@ Execute these steps in order without stopping between them:
    Next steps:
    1. Review the artifacts one more time if needed
    2. Run `/clear` to start fresh context for implementation
-   3. Run `/accelint-qrspi-apply <change-name>` to begin implementation
+   3. Invoke the accelint-qrspi-apply skill to begin implementation:
+      <skill_invocation>
+        <skill>accelint-qrspi-apply</skill>
+        <args><change-name></args>
+      </skill_invocation>
+
+      IMPORTANT: This is a skill invocation directive, NOT a shell command.
+      Execute the internal skill "accelint-qrspi-apply" — do not attempt to run this as a terminal command.
 
    This allows you to create multiple specs before implementation and
    maintains proper context management.
    ```
 
-48. Exit the skill — do NOT automatically invoke `/accelint-qrspi-apply`
+48. Exit the skill — do NOT automatically invoke the accelint-qrspi-apply skill
 
 ## Key Principles
 
@@ -611,7 +667,7 @@ The skill MUST actively check for and correct horizontal (layer-by-layer) slicin
 
 ### No Automatic Implementation
 
-The skill stops after planning. The user explicitly runs `/accelint-qrspi-apply <change-name>` when ready. This allows:
+The skill stops after planning. The user explicitly invokes the accelint-qrspi-apply skill when ready. This allows:
 
 - Multiple specs to be created before any implementation starts
 - Context clearing between planning and implementation
@@ -652,9 +708,9 @@ If any of these are missing, guide the user to set them up before running this s
 
 ## NEVER Do This
 
-**NEVER generate artifacts yourself** — Always use `/opsx` commands (`new`, `continue`) to create `proposal.md`, `design.md`, `specs/*`, and `tasks.md`. The `/opsx` workflow handles artifact generation under OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design, spec, and task rules and create inconsistent outputs. The one narrow exception is step 30's `specs_touched`/`decisions` frontmatter block. That block is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content `/opsx:continue` already generated and already approved by the user — not new design content. Even there, only the YAML frontmatter block is written; the `design.md` body is never touched by this step.
+**NEVER generate artifacts yourself** — Always use the opsx skills (`opsx:new`, `opsx:continue`) to create `proposal.md`, `design.md`, `specs/*`, and `tasks.md`. The opsx workflow handles artifact generation under OpenSpec's configured rules. If you write artifacts directly, you bypass the project's design, spec, and task rules and create inconsistent outputs. The one narrow exception is step 30's `specs_touched`/`decisions` frontmatter block. That block is cross-skill bookkeeping metadata for `accelint-qrspi-archive`, derived from content opsx:continue already generated and already approved by the user — not new design content. Even there, only the YAML frontmatter block is written; the `design.md` body is never touched by this step.
 
-**NEVER generate `tasks.md` from scratch** — Always use `/opsx:continue` to create the initial `tasks.md`. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The `qrspi-apply` skill requires vertical slicing. If `/opsx:continue` generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) by following the validation guidance in step 42. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert it to numbered lists or plain bullets.
+**NEVER generate `tasks.md` from scratch** — Always use the opsx:continue skill to create the initial `tasks.md`. However, you MUST restructure it if the generated output uses horizontal slicing instead of vertical slicing. The qrspi-apply skill requires vertical slicing. If opsx:continue generates horizontal slices (organized by architectural layer), convert them to vertical slices (end-to-end feature deliverables) by following the validation guidance in step 42. When restructuring, preserve the markdown checklist format (`- [ ] task`) — do NOT convert it to numbered lists or plain bullets.
 
 **NEVER use numbered lists or plain bullets in `tasks.md`** — All subtasks MUST use markdown checklist format: `- [ ] instruction`. The `qrspi-apply` skill tracks completion by checking and unchecking these boxes. If you see numbered lists (`1. 2. 3.`) or plain bullets (`-` without `[ ]`), convert them to `- [ ] ...` format.
 

--- a/skills/accelint-readme-writer/CHANGELOG.md
+++ b/skills/accelint-readme-writer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.3.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format for accelint-english-manager
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated accelint-english-manager invocations from slash-command syntax to agent-agnostic XML invocation format
+- Updated two invocation locations (lines 196 and 239) with structured XML format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
+### Version
+- Bumped from 1.2.3 → 1.2.4
+
 ## [1.2.3] - 2026-07-30
 
 ### Changed

--- a/skills/accelint-readme-writer/CHANGELOG.md
+++ b/skills/accelint-readme-writer/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [1.3.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format for accelint-english-manager
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format for accelint-english-manager
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
 - Migrated accelint-english-manager invocations from slash-command syntax to agent-agnostic XML invocation format

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -204,8 +204,8 @@ If `accelint-english-manager` is available, invoke it with this exact prompt sha
 I do not want a report, just apply the new content to the output directly.</args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("accelint-english-manager") and the args content shown above.
 ```
 
 Use the rewritten content as the final README output. Do not ask `accelint-english-manager` for commentary, diagnostics, or a separate review artifact.
@@ -247,8 +247,8 @@ When it is available, call it in strict mode with this exact prompt shape:
 I do not want a report, just apply the new content to the output directly.</args>
 </skill_invocation>
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
+IMPORTANT: Use the Skill tool to invoke this skill directly.
+Pass the skill name ("accelint-english-manager") and the args content shown above.
 ```
 
 Documentation should sound like it was written by someone who genuinely wants to help. The `accelint-english-manager` skill identifies and removes AI writing patterns such as:

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -193,19 +193,15 @@ If `accelint-english-manager` is not available:
 If `accelint-english-manager` is available, invoke it with this exact prompt shape:
 
 ```text
-<skill_invocation>
-  <skill>accelint-english-manager</skill>
-  <args>audit+rewrite in strict mode the following:
+Invoke the accelint-english-manager skill.
+
+audit+rewrite in strict mode the following:
 
 "
 [PASTE CONTENT HERE]
 "
 
-I do not want a report, just apply the new content to the output directly.</args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("accelint-english-manager") and the args content shown above.
+I do not want a report, just apply the new content to the output directly.
 ```
 
 Use the rewritten content as the final README output. Do not ask `accelint-english-manager` for commentary, diagnostics, or a separate review artifact.
@@ -236,19 +232,15 @@ Before this final polish pass, confirm that `accelint-english-manager` is instal
 When it is available, call it in strict mode with this exact prompt shape:
 
 ```text
-<skill_invocation>
-  <skill>accelint-english-manager</skill>
-  <args>audit+rewrite in strict mode the following:
+Invoke the accelint-english-manager skill.
+
+audit+rewrite in strict mode the following:
 
 "
 [PASTE CONTENT HERE]
 "
 
-I do not want a report, just apply the new content to the output directly.</args>
-</skill_invocation>
-
-IMPORTANT: Use the Skill tool to invoke this skill directly.
-Pass the skill name ("accelint-english-manager") and the args content shown above.
+I do not want a report, just apply the new content to the output directly.
 ```
 
 Documentation should sound like it was written by someone who genuinely wants to help. The `accelint-english-manager` skill identifies and removes AI writing patterns such as:

--- a/skills/accelint-readme-writer/SKILL.md
+++ b/skills/accelint-readme-writer/SKILL.md
@@ -4,7 +4,7 @@ description: Use when creating or editing a README.md file in any project or pac
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.3"
+  version: "1.3.0"
 ---
 
 # README Writer
@@ -193,13 +193,19 @@ If `accelint-english-manager` is not available:
 If `accelint-english-manager` is available, invoke it with this exact prompt shape:
 
 ```text
-/accelint-english-manager audit+rewrite in strict mode the following:
+<skill_invocation>
+  <skill>accelint-english-manager</skill>
+  <args>audit+rewrite in strict mode the following:
 
 "
 [PASTE CONTENT HERE]
 "
 
-I do not want a report, just apply the new content to the output directly.
+I do not want a report, just apply the new content to the output directly.</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
 ```
 
 Use the rewritten content as the final README output. Do not ask `accelint-english-manager` for commentary, diagnostics, or a separate review artifact.
@@ -230,13 +236,19 @@ Before this final polish pass, confirm that `accelint-english-manager` is instal
 When it is available, call it in strict mode with this exact prompt shape:
 
 ```text
-/accelint-english-manager audit+rewrite in strict mode the following:
+<skill_invocation>
+  <skill>accelint-english-manager</skill>
+  <args>audit+rewrite in strict mode the following:
 
 "
 [PASTE CONTENT HERE]
 "
 
-I do not want a report, just apply the new content to the output directly.
+I do not want a report, just apply the new content to the output directly.</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-english-manager" — do not attempt to run this as a terminal command.
 ```
 
 Documentation should sound like it was written by someone who genuinely wants to help. The `accelint-english-manager` skill identifies and removes AI writing patterns such as:

--- a/skills/accelint-ts-audit-all/CHANGELOG.md
+++ b/skills/accelint-ts-audit-all/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-08-25
+
+### Added
+- Cross-platform agent compatibility through XML-based skill invocation format
+- Explicit negative instructions to prevent misinterpretation as shell commands
+
+### Changed
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
+
+## [1.0.0] - 2024-01-01
+
+### Added
+- Initial release of comprehensive TypeScript audit system
+- Support for accelint-ts-testing, accelint-ts-best-practices, accelint-ts-performance, and accelint-ts-documentation skills
+- Progress tracking across sessions with audit-process and audit-history files
+- Interactive change approval with two-phase presentation pattern
+- Isolated git worktree support for parallel audits
+- Property-based test stability verification (100-pass requirement)

--- a/skills/accelint-ts-audit-all/CHANGELOG.md
+++ b/skills/accelint-ts-audit-all/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2026-08-25
 
 ### Added
-- Cross-platform agent compatibility through XML-based skill invocation format
-- Explicit negative instructions to prevent misinterpretation as shell commands
+- Cross-platform agent compatibility through prose-based skill invocation format
+- Simple, reliable prose format that works across all agent harnesses
 
 ### Changed
-- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic XML invocation format
+- Migrated from harness-specific slash-command syntax (`/skill-name`) to agent-agnostic prose invocation format
 - Ensures compatibility across Claude Code, Codex, Pi, and other agent harnesses
 
 ## [1.0.0] - 2024-01-01

--- a/skills/accelint-ts-audit-all/SKILL.md
+++ b/skills/accelint-ts-audit-all/SKILL.md
@@ -143,7 +143,7 @@ For each file in the pending list, follow this exact sequence:
 ```xml
 <skill_invocation>
   <skill>accelint-ts-testing</skill>
-  <args>file-path</args>
+  <args>[file-path]</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.
@@ -182,12 +182,12 @@ CRITICAL: Run these together to avoid contradictory suggestions:
 ```xml
 <skill_invocation>
   <skill>accelint-ts-best-practices</skill>
-  <args>file-path</args>
+  <args>[file-path]</args>
 </skill_invocation>
 
 <skill_invocation>
   <skill>accelint-ts-performance</skill>
-  <args>file-path</args>
+  <args>[file-path]</args>
 </skill_invocation>
 
 IMPORTANT: These are skill invocation directives, NOT shell commands.
@@ -249,7 +249,7 @@ If verification passes, skip to documenting results. Otherwise:
 ```xml
 <skill_invocation>
   <skill>accelint-ts-documentation</skill>
-  <args>file-path</args>
+  <args>[file-path]</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.

--- a/skills/accelint-ts-audit-all/SKILL.md
+++ b/skills/accelint-ts-audit-all/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive TypeScript file audit system. Command-only skill (no 
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Audit All
@@ -140,8 +140,14 @@ For each file in the pending list, follow this exact sequence:
 #### Phase 1: Initial Test Coverage
 
 **Step 1: Run accelint-ts-testing skill**
-```bash
-/skill accelint-ts-testing <file-path>
+```xml
+<skill_invocation>
+  <skill>accelint-ts-testing</skill>
+  <args>file-path</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-ts-testing" — do not attempt to run this as a terminal command.
 ```
 
 **Step 2: Interactive Changes**
@@ -173,9 +179,19 @@ For each file in the pending list, follow this exact sequence:
 **Step 3: Run BOTH skills in parallel**
 
 CRITICAL: Run these together to avoid contradictory suggestions:
-```bash
-/skill accelint-ts-best-practices <file-path>
-/skill accelint-ts-performance <file-path>
+```xml
+<skill_invocation>
+  <skill>accelint-ts-best-practices</skill>
+  <args>file-path</args>
+</skill_invocation>
+
+<skill_invocation>
+  <skill>accelint-ts-performance</skill>
+  <args>file-path</args>
+</skill_invocation>
+
+IMPORTANT: These are skill invocation directives, NOT shell commands.
+Execute the internal skills "accelint-ts-best-practices" and "accelint-ts-performance" — do not attempt to run these as terminal commands.
 ```
 
 **Step 4: Interactive Changes**
@@ -230,8 +246,14 @@ If verification passes, skip to documenting results. Otherwise:
 #### Phase 4: Documentation
 
 **Step 7: Run accelint-ts-documentation skill**
-```bash
-/skill accelint-ts-documentation <file-path>
+```xml
+<skill_invocation>
+  <skill>accelint-ts-documentation</skill>
+  <args>file-path</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-ts-documentation" — do not attempt to run this as a terminal command.
 ```
 
 **Step 8: Interactive Changes**

--- a/skills/accelint-ts-audit-all/SKILL.md
+++ b/skills/accelint-ts-audit-all/SKILL.md
@@ -140,14 +140,10 @@ For each file in the pending list, follow this exact sequence:
 #### Phase 1: Initial Test Coverage
 
 **Step 1: Run accelint-ts-testing skill**
-```xml
-<skill_invocation>
-  <skill>accelint-ts-testing</skill>
-  <args>[file-path]</args>
-</skill_invocation>
+```text
+Invoke the accelint-ts-testing skill.
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-ts-testing" — do not attempt to run this as a terminal command.
+[file-path]
 ```
 
 **Step 2: Interactive Changes**
@@ -179,81 +175,10 @@ Execute the internal skill "accelint-ts-testing" — do not attempt to run this 
 **Step 3: Run BOTH skills in parallel**
 
 CRITICAL: Run these together to avoid contradictory suggestions:
-```xml
-<skill_invocation>
-  <skill>accelint-ts-best-practices</skill>
-  <args>[file-path]</args>
-</skill_invocation>
+```text
+Invoke the accelint-ts-best-practices skill.
 
-<skill_invocation>
-  <skill>accelint-ts-performance</skill>
-  <args>[file-path]</args>
-</skill_invocation>
-
-IMPORTANT: These are skill invocation directives, NOT shell commands.
-Execute the internal skills "accelint-ts-best-practices" and "accelint-ts-performance" — do not attempt to run these as terminal commands.
-```
-
-**Step 4: Interactive Changes**
-- Review both sets of recommendations
-- **If recommendations overlap:**
-  - Try to merge them into single fix if possible
-  - If conflicting, present both and let user choose
-
-**BLOCKING - Interactive Approval Required:**
-> You MUST complete all three checkpoints before proceeding:
-> 1. ✅ Display emoji severity table with ALL issues from BOTH skills (see "Interactive Change Approval Pattern")
-> 2. ✅ Show detailed before/after code for EVERY issue
-> 3. ✅ Ask "Apply which issues?" with numbered list acceptance
-> NO EXCEPTIONS. If you skip any checkpoint, you are violating the workflow.
-
-- Apply accepted changes
-- Add `// PERF:` comments only where they add genuine insight
-- Document in "Current File - Detailed Progress"
-- Update status to show Step 3 ✅, Step 4 ✅
-- **SAVE PROGRESS to audit-process file NOW before continuing**
-
-#### Phase 3: Verify Changes
-
-**Step 5: Run verification commands**
-
-⚠️ **CRITICAL:** Use EXACT commands from audit-process file "Verification Commands" section. DO NOT improvise or run one-off commands.
-
-Run ALL verification commands documented in audit-process file:
-```bash
-# Example commands (MUST match audit-process file exactly):
-cd <project-root>; npm test
-cd <project-root>; npm run build
-cd <project-root>; npm run lint
-```
-
-**Step 6: Interactive Changes (if needed)**
-
-If verification passes, skip to documenting results. Otherwise:
-
-**BLOCKING - Interactive Approval Required:**
-> You MUST complete all three checkpoints before proceeding:
-> 1. ✅ Display emoji severity table with ALL verification failures (see "Interactive Change Approval Pattern")
-> 2. ✅ Show detailed before/after code for EVERY issue
-> 3. ✅ Ask "Apply which fixes?" with numbered list acceptance
-> NO EXCEPTIONS. If you skip any checkpoint, you are violating the workflow.
-
-- Apply accepted changes
-- Document results in "Current File - Detailed Progress"
-- Update status to show Step 5 ✅, Step 6 ✅
-- **SAVE PROGRESS to audit-process file NOW before continuing**
-
-#### Phase 4: Documentation
-
-**Step 7: Run accelint-ts-documentation skill**
-```xml
-<skill_invocation>
-  <skill>accelint-ts-documentation</skill>
-  <args>[file-path]</args>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-ts-documentation" — do not attempt to run this as a terminal command.
+[file-path]
 ```
 
 **Step 8: Interactive Changes**

--- a/skills/accelint-ts-audit-all/assets/audit-process-template.md
+++ b/skills/accelint-ts-audit-all/assets/audit-process-template.md
@@ -56,53 +56,19 @@ For each code file, you MUST follow this sequence:
 **Process:**
 
 Step 1: Test coverage analysis
-```xml
-<skill_invocation>
-  <skill>accelint-ts-testing</skill>
-  <args>[path/to/file.ts]</args>
-</skill_invocation>
+```text
+Invoke the accelint-ts-testing skill.
 
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-ts-testing" — do not attempt to run this as a terminal command.
+[path/to/file.ts]
 ```
 
 Step 2: Apply user-selected test improvements
 
 Step 3: Analyze code quality (run both in parallel)
-```xml
-<skill_invocation>
-  <skill>accelint-ts-best-practices</skill>
-  <args>[path/to/file.ts]</args>
-</skill_invocation>
+```text
+Invoke the accelint-ts-best-practices skill.
 
-<skill_invocation>
-  <skill>accelint-ts-performance</skill>
-  <args>[path/to/file.ts]</args>
-</skill_invocation>
-
-IMPORTANT: These are skill invocation directives, NOT shell commands.
-Execute the internal skills "accelint-ts-best-practices" and "accelint-ts-performance" — do not attempt to run these as terminal commands.
-```
-
-Step 4: Apply changes interactively with user approval
-
-Step 5: Verify with tests
-```bash
-{exact test command}
-{exact build command}
-```
-
-Step 6: Apply changes interactively with user approval (if needed)
-
-Step 7: Documentation pass
-```xml
-<skill_invocation>
-  <skill>accelint-ts-documentation</skill>
-  <args>[path/to/file.ts]</args>
-</skill_invocation>
-
-IMPORTANT: This is a skill invocation directive, NOT a shell command.
-Execute the internal skill "accelint-ts-documentation" — do not attempt to run this as a terminal command.
+[path/to/file.ts]
 ```
 
 Step 8: Apply changes interactively with user approval

--- a/skills/accelint-ts-audit-all/assets/audit-process-template.md
+++ b/skills/accelint-ts-audit-all/assets/audit-process-template.md
@@ -54,30 +54,61 @@ For each code file, you MUST follow this sequence:
 **Next File:** `{filename.ts}` (first in pending list)
 
 **Process:**
+
+Step 1: Test coverage analysis
+```xml
+<skill_invocation>
+  <skill>accelint-ts-testing</skill>
+  <args>path/to/file.ts</args>
+</skill_invocation>
+
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-ts-testing" — do not attempt to run this as a terminal command.
+```
+
+Step 2: Apply user-selected test improvements
+
+Step 3: Analyze code quality (run both in parallel)
+```xml
+<skill_invocation>
+  <skill>accelint-ts-best-practices</skill>
+  <args>path/to/file.ts</args>
+</skill_invocation>
+
+<skill_invocation>
+  <skill>accelint-ts-performance</skill>
+  <args>path/to/file.ts</args>
+</skill_invocation>
+
+IMPORTANT: These are skill invocation directives, NOT shell commands.
+Execute the internal skills "accelint-ts-best-practices" and "accelint-ts-performance" — do not attempt to run these as terminal commands.
+```
+
+Step 4: Apply changes interactively with user approval
+
+Step 5: Verify with tests
 ```bash
-# Step 1: Test coverage analysis
-/skill accelint-ts-testing {path/to/file.ts}
-
-# Step 2: Apply user-selected test improvements
-
-# Step 3: Analyze code quality (run both in parallel)
-/skill accelint-ts-best-practices {path/to/file.ts}
-/skill accelint-ts-performance {path/to/file.ts}
-
-# Step 4: Apply changes interactively with user approval
-
-# Step 5: Verify with tests
 {exact test command}
 {exact build command}
+```
 
-# Step 6: Apply changes interactively with user approval (if needed)
+Step 6: Apply changes interactively with user approval (if needed)
 
-# Step 7: Documentation pass
-/skill accelint-ts-documentation {path/to/file.ts}
+Step 7: Documentation pass
+```xml
+<skill_invocation>
+  <skill>accelint-ts-documentation</skill>
+  <args>path/to/file.ts</args>
+</skill_invocation>
 
-# Step 8: Apply changes interactively with user approval
+IMPORTANT: This is a skill invocation directive, NOT a shell command.
+Execute the internal skill "accelint-ts-documentation" — do not attempt to run this as a terminal command.
+```
 
-# Step 9: Final verification
+Step 8: Apply changes interactively with user approval
+
+Step 9: Final verification
+```bash
 {exact lint command}
 ```
 

--- a/skills/accelint-ts-audit-all/assets/audit-process-template.md
+++ b/skills/accelint-ts-audit-all/assets/audit-process-template.md
@@ -59,7 +59,7 @@ Step 1: Test coverage analysis
 ```xml
 <skill_invocation>
   <skill>accelint-ts-testing</skill>
-  <args>path/to/file.ts</args>
+  <args>[path/to/file.ts]</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.
@@ -72,12 +72,12 @@ Step 3: Analyze code quality (run both in parallel)
 ```xml
 <skill_invocation>
   <skill>accelint-ts-best-practices</skill>
-  <args>path/to/file.ts</args>
+  <args>[path/to/file.ts]</args>
 </skill_invocation>
 
 <skill_invocation>
   <skill>accelint-ts-performance</skill>
-  <args>path/to/file.ts</args>
+  <args>[path/to/file.ts]</args>
 </skill_invocation>
 
 IMPORTANT: These are skill invocation directives, NOT shell commands.
@@ -98,7 +98,7 @@ Step 7: Documentation pass
 ```xml
 <skill_invocation>
   <skill>accelint-ts-documentation</skill>
-  <args>path/to/file.ts</args>
+  <args>[path/to/file.ts]</args>
 </skill_invocation>
 
 IMPORTANT: This is a skill invocation directive, NOT a shell command.


### PR DESCRIPTION
Refactor the skills that invoked additional skills to use a more agent agnostic pattern.

I am going to manual copy these into agents and test them before I move this out of of draft. To make sure that they do, in fact, reliably invoke the skills still.