### PR TITLE
refactor: archive sync check in archive

### DIFF
--- a/skills/accelint-qrspi-archive/CHANGELOG.md
+++ b/skills/accelint-qrspi-archive/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.5.0] - 2026-08-31
+
+### Added
+- **Strengthened synthesis suggestion mechanism** — Upgraded from passive informational prose to RFC 2119-style actionable directives
+  - Replaced weak "ℹ Consider running accelint-archive-synthesis" with directive format: "⚠️ You SHOULD run accelint-archive-synthesis now"
+  - Rationale: Agents trained on RFC 2119 keywords (MUST/SHOULD) reliably recognize these as actionable directives, while passive prose like "Consider" is often ignored
+- **Dual-trigger synthesis threshold system** — Now fires when either 50 changes accumulate OR 30 working days elapse since last synthesis run, whichever comes first
+  - Change threshold: 50 archived changes since last synthesis checkpoint
+  - Time threshold: 30 working days (6 weeks × 5 working days/week)
+  - Rationale: High-velocity projects need periodic linting before decision drift accumulates too deeply; lower-velocity projects need time-based nudges to ensure review happens even when change volume is low
+- **SYNTHESIS-LOG.md checkpoint tracking** — Reads last synthesis run date and row count from `openspec/changes/archive/SYNTHESIS-LOG.md`
+  - Parses most recent checkpoint under "## Run History" section
+  - First-run handling: treats missing log as (epoch, 0 rows) baseline
+  - Working days calculation: total calendar days minus weekend days (Saturdays/Sundays)
+- **Subagent-based calculation** — Delegates all threshold calculation to subagent, keeping parent context clean
+  - Subagent returns structured JSON with trigger status and metrics
+  - Parent uses response for output formatting only
+  - Follows same pattern as spec writing (step 22) and other isolated operations
+
+### Changed
+- **New step 36** — Added synthesis trigger check as dedicated step after archive reporting (step 34-35)
+  - Three distinct output formats: threshold exceeded, threshold not exceeded, first-run case
+  - Clear metrics shown: change delta, time delta, checkpoint info, current state
+  - Includes rationale for dual-trigger approach in output
+- **Hard-coded thresholds** — 50 changes and 30 working days are now explicit constants for clear tuning
+  - Not "reasoned defaults" subject to adjustment — these are the defined thresholds
+  - Can be changed directly in skill instructions if project cadence requires different values
+
+### Version
+- Bumped from 1.4.0 → 1.5.0
+
 ## [1.4.0] - 2026-08-25
 
 ### Added

--- a/skills/accelint-qrspi-archive/SKILL.md
+++ b/skills/accelint-qrspi-archive/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires the OpenSpec CLI. Per-capability spec writes require sub-agent support — see the skill body for the degraded fallback if unavailable. Native archive always runs directly in the invoking agent's own context, never as a subagent, regardless of sub-agent availability. Each change's design.md should carry specs_touched and decisions frontmatter — ideally written by accelint-qrspi-propose at design time — but preflight Task A can derive and confirm it when a change didn't go through that flow. Each touched spec must already have a ## Purpose or ### Purpose heading in its body.
 metadata:
   author: accelint
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Accelint QRSPI Archive
@@ -407,6 +407,101 @@ A patched `specs/INDEX.md` can still drift from reality for reasons outside this
 35. If any capability was left with a placeholder purpose or skipped entirely because preflight Task B never resolved, call that out explicitly here rather than letting it disappear into the diff.
 
 **Output**: a human-readable summary of every file this skill touched.
+
+36. **Check synthesis trigger thresholds** — spawn a subagent to determine whether the archive corpus has grown or aged enough to warrant running `accelint-archive-synthesis`, using a dual-trigger system that fires when either 50 changes have accumulated OR 30 working days have elapsed since the last synthesis run, whichever comes first.
+
+   This check runs after every archive operation (both single-change and bulk) to ensure synthesis suggestions surface at the right cadence. The dual-trigger approach addresses two distinct synthesis needs: high-velocity projects that archive many changes quickly need periodic linting before decision drift accumulates too deeply, while lower-velocity projects need time-based nudges to ensure the archive corpus gets reviewed periodically even when change volume is low.
+
+   Spawn a subagent with this prompt:
+
+   ```text
+   Check whether accelint-archive-synthesis should run based on dual-trigger thresholds.
+
+   Current date: <YYYY-MM-DD from system context>
+
+   Thresholds (hard-coded):
+   - Change threshold: 50 archived changes since last synthesis run
+   - Time threshold: 30 working days since last synthesis run
+
+   Trigger condition: (change_delta >= 50) OR (time_delta >= 30 working days)
+
+   Steps:
+
+   1. Read openspec/changes/archive/SYNTHESIS-LOG.md if it exists.
+      - Parse the last line under "## Run History" section
+      - Extract: checkpoint date (YYYY-MM-DD) and row count (after "checked through row")
+      - If file doesn't exist or section is empty, this is first-run: no baseline
+
+   2. Count current archive size:
+      - Use: grep -c "^|" openspec/changes/archive/INDEX.md
+      - Subtract 2 (header and separator rows) = current archived change count
+
+   3. Calculate deltas:
+      - Change delta = current row count - checkpoint row count
+      - Time delta (working days):
+        * Calculate calendar days between checkpoint date and current date
+        * Subtract weekend days (Saturdays and Sundays) in that period
+        * Result = working days elapsed
+
+   4. Apply trigger logic:
+      - trigger_exceeded = (change_delta >= 50) OR (time_delta >= 30)
+
+   Return ONLY this structured response (no explanation):
+
+   {
+     "trigger_exceeded": true/false,
+     "first_run": true/false,
+     "change_delta": N,
+     "time_delta": X,
+     "last_checkpoint_date": "YYYY-MM-DD" or null,
+     "last_checkpoint_row": N or 0,
+     "current_row": N
+   }
+   ```
+
+   Once the subagent returns, use its response to construct the appropriate output:
+
+   **When trigger_exceeded = true AND first_run = false:**
+
+   ```
+   ⚠️  SYNTHESIS CHECKPOINT THRESHOLD EXCEEDED
+
+   You SHOULD run accelint-archive-synthesis now:
+   - Changes since last synthesis: <change_delta> (threshold: 50)
+   - Working days since last synthesis: <time_delta> (threshold: 30)
+   - Last checkpoint: <last_checkpoint_date> at row <last_checkpoint_row>
+   - Current state: row <current_row>
+
+   High-velocity projects need periodic linting before decision drift accumulates
+   too deeply. Lower-velocity projects need time-based nudges to ensure the
+   archive corpus gets reviewed periodically even when change volume is low.
+
+   Invoke the accelint-archive-synthesis skill to run the synthesis check.
+   ```
+
+   **When trigger_exceeded = false:**
+
+   ```
+   ✓ Synthesis check: <change_delta> changes since last run (<last_checkpoint_date>), <time_delta> working days elapsed
+     Thresholds: 50 changes OR 30 working days, whichever first
+   ```
+
+   **When first_run = true:**
+
+   ```
+   ⚠️  SYNTHESIS CHECKPOINT NOTICE
+
+   This project has <current_row> archived changes but no synthesis checkpoint exists yet
+   (openspec/changes/archive/SYNTHESIS-LOG.md not found).
+
+   You SHOULD run accelint-archive-synthesis to establish the first baseline.
+   The synthesis skill will check for decision drift, index reconciliation issues,
+   and structural coupling across the full archive corpus.
+
+   Invoke the accelint-archive-synthesis skill to run the initial synthesis check.
+   ```
+
+   The RFC 2119 SHOULD language (not passive "Consider" prose) ensures agents reliably recognize this as an actionable directive rather than informational commentary. The subagent handles all calculation complexity, returning only the minimal data needed for output formatting.
 
 ## Key Principles
 


### PR DESCRIPTION
Add a check to the archive skill that will determine the state of the current completed specs and suggest running archive-synthesis so that we don't run into one that has to drift detect 100s of specs (like I had to).