### PR TITLE
docs(architecture-doc): pilot a shorter discovery description

### DIFF
--- a/skills/accelint-architecture-doc/CHANGELOG.md
+++ b/skills/accelint-architecture-doc/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this skill will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-09-11
+
+### Changed
+- Shortened the architecture-document discovery description while retaining file-producing scope, requests without a filename, and the exception for advice, planning, or diagrams that support document updates.
+  - Rationale: Reduce metadata loaded during skill selection for Claude and Astra. Workflow instructions and approval gates remain unchanged.
+
+### Added
+- Added discovery cases for positive triggers, excluded requests, and document-update exceptions so both model families can evaluate selection before adopting the shorter description.
+
+### Version
+- Bumped from 1.2.2 to 1.3.0.
+
 ## [1.2.2] - 2026-08-21
 
 ### Changed

--- a/skills/accelint-architecture-doc/README.md
+++ b/skills/accelint-architecture-doc/README.md
@@ -160,9 +160,11 @@ Refresh ARCHITECTURE.md. Findings: - Auth migrated from sessions to JWT. - Worke
 
 The skill includes 11 eval scenarios in `evals/evals.json` covering create, refresh, restructure, monorepo, OpenSpec-aware, and agent-doc integration workflows.
 
+The description-selection pilot adds 17 cases in `evals/discovery.json`. See [the pilot procedure and results](evals/discovery.md) for the comparison method and remaining Claude validation.
+
 ## Version
 
-Current version: 1.2.2
+Current version: 1.3.0
 
 See `CHANGELOG.md` for release history.
 

--- a/skills/accelint-architecture-doc/SKILL.md
+++ b/skills/accelint-architecture-doc/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: accelint-architecture-doc
-description: Create or update a living ARCHITECTURE.md for a codebase. Use when the user wants to write, refresh, restructure, or maintain an architecture document; document how the system is organized across tech stack, deployment model, services, components, and data stores; or turn codebase findings into durable architecture docs for engineers or agents. Trigger on requests such as write an architecture doc, document this system, create or update ARCHITECTURE.md, give me a technical overview of this repo, or map out how this app is put together, even when the file is not named. Prefer this skill for file-producing architecture documentation, not for generic architecture advice, implementation planning, or diagram-only brainstorming unless that work is clearly part of updating the document.
+description: Use when the user wants to write, refresh, restructure, or maintain architecture documentation, including ARCHITECTURE.md, a technical overview, or a map of the system. Applies to file-producing documentation even when no filename is given. Do not use for generic architecture advice, implementation planning, or diagram-only brainstorming unless that work is part of updating the document.
 license: Apache-2.0
 metadata:
   author: accelint
-  version: "1.2.2"
+  version: "1.3.0"
 ---
 
 # Architecture Doc

--- a/skills/accelint-architecture-doc/evals/discovery-results.json
+++ b/skills/accelint-architecture-doc/evals/discovery-results.json
@@ -1,0 +1,49 @@
+{
+  "date": "2026-09-11",
+  "baseline_commit": "8d979e68783cd8fa45a8c7aa34e708be9221f484",
+  "model": "gpt-6-astra",
+  "reasoning_effort": "low",
+  "method": "One fresh-context subagent per description; all 17 prompts classified in a batch, with expected labels withheld. Responses transcribed from evaluator output.",
+  "baseline": {
+    "create": true,
+    "refresh": true,
+    "restructure": true,
+    "unnamed_doc": true,
+    "map_doc": true,
+    "findings": true,
+    "advice": false,
+    "implementation": false,
+    "diagram": false,
+    "doc_diagram": true,
+    "doc_planning": true,
+    "doc_advice": true,
+    "fix": false,
+    "typo": false,
+    "original_document": true,
+    "original_overview": true,
+    "original_map": true
+  },
+  "candidate": {
+    "create": true,
+    "refresh": true,
+    "restructure": true,
+    "unnamed_doc": true,
+    "map_doc": true,
+    "findings": true,
+    "advice": false,
+    "implementation": false,
+    "diagram": false,
+    "doc_diagram": true,
+    "doc_planning": true,
+    "doc_advice": true,
+    "fix": false,
+    "typo": false,
+    "original_document": true,
+    "original_overview": true,
+    "original_map": true
+  },
+  "claude": {
+    "status": "not_run",
+    "reason": "Claude Code authentication unavailable; attempted execution returned Not logged in."
+  }
+}

--- a/skills/accelint-architecture-doc/evals/discovery.json
+++ b/skills/accelint-architecture-doc/evals/discovery.json
@@ -1,0 +1,91 @@
+{
+  "skill_name": "accelint-architecture-doc",
+  "evaluation_type": "description-selection",
+  "cases": [
+    {
+      "id": "create",
+      "prompt": "Please create an ARCHITECTURE.md for this Express and Postgres app.",
+      "should_select": true
+    },
+    {
+      "id": "refresh",
+      "prompt": "Refresh ARCHITECTURE.md to reflect our Redis migration.",
+      "should_select": true
+    },
+    {
+      "id": "restructure",
+      "prompt": "Restructure our architecture document without losing its existing content.",
+      "should_select": true
+    },
+    {
+      "id": "unnamed_doc",
+      "prompt": "Document how this system is organized so engineers have a durable technical overview.",
+      "should_select": true
+    },
+    {
+      "id": "map_doc",
+      "prompt": "Map out how this app is put together and save it as onboarding documentation.",
+      "should_select": true
+    },
+    {
+      "id": "findings",
+      "prompt": "Turn these codebase findings into architecture documentation for agents.",
+      "should_select": true
+    },
+    {
+      "id": "advice",
+      "prompt": "Should our next service use a monolith or microservices? I only want advice.",
+      "should_select": false
+    },
+    {
+      "id": "implementation",
+      "prompt": "Plan the implementation of Redis caching. Do not write architecture documentation.",
+      "should_select": false
+    },
+    {
+      "id": "diagram",
+      "prompt": "Brainstorm a system diagram in chat. Do not update or create a document.",
+      "should_select": false
+    },
+    {
+      "id": "doc_diagram",
+      "prompt": "Update ARCHITECTURE.md, including brainstorming a clearer system diagram for that document.",
+      "should_select": true
+    },
+    {
+      "id": "doc_planning",
+      "prompt": "Update our architecture document with the implementation plan for the service split.",
+      "should_select": true
+    },
+    {
+      "id": "doc_advice",
+      "prompt": "Review our service-boundary options and incorporate your recommendation into ARCHITECTURE.md.",
+      "should_select": true
+    },
+    {
+      "id": "fix",
+      "prompt": "Fix the Redis connection retry bug in the API.",
+      "should_select": false
+    },
+    {
+      "id": "typo",
+      "prompt": "Fix the spelling in the README installation command description.",
+      "should_select": false
+    },
+    {
+      "id": "original_document",
+      "prompt": "Document this system.",
+      "should_select": true
+    },
+    {
+      "id": "original_overview",
+      "prompt": "Give me a technical overview of this repo.",
+      "should_select": true
+    },
+    {
+      "id": "original_map",
+      "prompt": "Map out how this app is put together.",
+      "should_select": true
+    }
+  ]
+}

--- a/skills/accelint-architecture-doc/evals/discovery.md
+++ b/skills/accelint-architecture-doc/evals/discovery.md
@@ -1,0 +1,27 @@
+# Description-selection pilot
+
+This checks whether a model selects `accelint-architecture-doc` from its description. It does not execute the skill or measure automatic selection among competing skills.
+
+## Inputs and procedure
+
+`discovery.json` records 17 prompts and expected selections. The cases cover document creation and maintenance, requests without a filename, standalone exclusions, and the exception for advice, planning, and diagrams used in document updates. Three cases repeat the original description's unqualified trigger phrases.
+
+Compare the description in `SKILL.md` with the description at baseline commit `8d979e68783cd8fa45a8c7aa34e708be9221f484`. Give each version to a separate fresh model context with the same prompts and settings. Do not expose `should_select` labels to the evaluator. Use this instruction with the skill name, description, and an array of request IDs and prompts:
+
+```text
+Evaluate skill selection only. For each request, decide whether the provided skill description applies. Do not execute requests. Return only a JSON array with id and select boolean for every request.
+```
+
+Record the returned selections, model, settings, and any failed runs. Compare each result with `should_select`. Keep the descriptions separate so one evaluation cannot borrow wording from the other.
+
+## Observed results
+
+On 2026-09-11, separate fresh-context GPT-6 Astra subagents at low reasoning matched all 17 expected selections for both descriptions. Each agent classified all prompts in one batch. `discovery-results.json` contains the transcribed selections.
+
+The description decreased from 790 to 390 characters, a 50.6% reduction in characters. This is not a token, latency, or cost measurement. The workflow body after frontmatter is byte-for-byte unchanged from the baseline.
+
+A Claude Code run was attempted, but authentication was unavailable. No Claude result is claimed. The 17-case set includes three original trigger phrases added after an independent review of the initial 14-case set; both Astra runs reported here used the final set.
+
+## Remaining validation
+
+Run the same comparison on the Claude models the team supports. Test automatic discovery with competing installed skills and execute a representative workflow through its preview approval gate on Claude and Astra. Use the existing `evals.json` workflow scenarios for that follow-up. The single-pass selection results here do not establish general cross-model compatibility or completion quality.


### PR DESCRIPTION
Related issue: https://github.com/gohypergiant/agent-skills/issues/161

`accelint-architecture-doc` loads a 790-character description during skill discovery. This pilot reduces it to 390 characters while retaining file-producing scope, unnamed-document requests, and the exception for advice, planning, or diagrams used in document updates.

The workflow body is byte-for-byte unchanged. The patch adds 17 description-selection cases and updates the skill version and changelog to 1.3.0. It is the first bounded experiment proposed in the linked issue; it does not complete the broader cross-model evaluation.

## Validation

- Independent GPT-6 Astra runs at low reasoning matched all 17 expected selections for both the original and candidate descriptions.
- Confirmed identical workflow bodies, valid discovery JSON and YAML frontmatter, matching version declarations, and `git diff --check`.
- The bundled quick validator could not run because PyYAML is absent. Ruby YAML parsing and direct metadata checks passed instead.
- A fresh-context skill-manager audit found no confirmed description regression and requested three original unqualified trigger cases. Those cases were added before the final Astra runs.
- Claude execution was attempted but the local Claude Code session is not logged in. No Claude result is claimed.
- These are single-pass description-selection checks, not an end-to-end agent benchmark. They do not measure latency, cost, competition among skills, or actual approval behavior.

## Requested team review

Review trigger coverage and run the same cases on the Claude models the team supports. Before adopting the change, exercise automatic discovery and a workflow that reaches the existing preview approval gate in both agent environments. Keep any future changes to workflow requirements separate from this pilot.
